### PR TITLE
Changed in the naming of the package for the building of docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@
 #
 import os
 import sys
-from unittest.mock import MagicMock
 sys.path.insert(0, os.path.abspath('../../../'))
 
 # -- Project information -----------------------------------------------------
@@ -44,15 +43,6 @@ extensions = [
     'sphinx.ext.intersphinx',
 ]
 
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return MagicMock()
-
-
-MOCK_MODULES = ['numpy', 'scipy']
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/levy.rst
+++ b/docs/source/levy.rst
@@ -1,12 +1,12 @@
 Module Levy
-==========
+===========
 
-.. automodule:: pylevy.levy
+.. automodule:: levy
 
-.. autofunction:: pylevy.levy.change_par
+.. autofunction:: levy.change_par
 
-.. autofunction:: pylevy.levy.random
+.. autofunction:: levy.random
 
-.. autofunction:: pylevy.levy.levy
+.. autofunction:: levy.levy
 
-.. autofunction:: pylevy.levy.fit_levy
+.. autofunction:: levy.fit_levy


### PR DESCRIPTION
Since the package is being installed as levy and not as pylevy.levy, had to rename the references for the autodoc of the module. 

