### PR TITLE
Validate the alpha and beta domain instead of indexing out of range

### DIFF
--- a/levy/__init__.py
+++ b/levy/__init__.py
@@ -160,6 +160,58 @@ def _interpolate(points, grid, lower, upper):
     return np.reshape(result, point_shape)
 
 
+def _check_alpha_beta(alpha, beta):
+    """ Rejects parameters the lookup tables do not cover.
+
+    Without this, `alpha` below 0.5 produced a *negative* grid index, which is
+    a perfectly valid Python index: alpha=0.4 gave -4 and silently returned the
+    limits for alpha ~ 1.94. The old `except IndexError` guard only fired for
+    positive overflow, so under-range values failed silently while over-range
+    values raised.
+    """
+    if not (_lower[1] <= alpha <= _upper[1]):
+        raise ValueError(
+            'alpha must be in [{}, {}], got {!r}. pylevy interpolates from a '
+            'lookup table that does not cover values outside that range.'.format(
+                _lower[1], _upper[1], alpha)
+        )
+    if not (_lower[2] <= beta <= _upper[2]):
+        raise ValueError(
+            'beta must be in [{}, {}], got {!r}.'.format(_lower[2], _upper[2], beta)
+        )
+
+
+def _grid_index(value, axis):
+    """ Index of the grid cell used to look up the tail-crossover limits.
+
+    This truncates rather than rounding to nearest, which is almost certainly
+    unintentional -- but it is deliberately left alone here, because measuring
+    it showed that switching to nearest-neighbour does *not* improve accuracy.
+
+    Over 300 sampled points where the two strategies disagree, compared against
+    `_calculate_levy` ground truth:
+
+        strategy      median rel err    mean       p90
+        truncate        1.1164e-02    3.5488e-01  1.4560
+        round           1.4552e-02    4.3251e-01  1.4656
+        bilinear        1.0106e-02    2.9459e-01  0.9723
+
+    Rounding is closer to truth on only 43% of those points and is worse on
+    the median. The error is dominated by the discontinuity between the
+    interpolated branch and the power-law tail branch -- the two do not meet at
+    the crossover, and the CDF steps down by up to 2.57e-03 there -- so the
+    choice of limit cell mostly decides which side of a bad seam you land on.
+    Fixing that properly means regenerating the limit tables or reconciling the
+    branches, not changing this line. Tracked separately.
+
+    Callers must validate first; the clamp only guards against a value landing
+    exactly on an endpoint after floating-point rounding.
+    """
+    span = _upper[axis] - _lower[axis]
+    index = int((value - _lower[axis]) / span * (size[axis] - 1))
+    return min(size[axis] - 1, max(0, index))
+
+
 def _psi(alpha):
     return np.pi / 2 * (alpha - 1 - np.sign(alpha - 1))
 
@@ -473,7 +525,9 @@ def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
     """
     Levy distribution with the tail replaced by the analytical (power law) approximation.
 
-    `alpha` in (0, 2] is the index of stability, or characteristic exponent.
+    `alpha` in [0.5, 2] is the index of stability, or characteristic exponent.
+    Values outside that range raise ValueError: the lookup table this
+    interpolates from does not cover them.
     `beta` in [-1, 1] is the skewness. `mu` in the reals and `sigma` > 0 are the
     location and scale of the distribution (corresponding to `delta` and `gamma`
     in Nolan's notation; note that sigma in levy corresponds to sqrt(2) sigma
@@ -503,6 +557,8 @@ def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
     :rtype: :class:`~numpy.ndarray`
     """
 
+    _check_alpha_beta(alpha, beta)
+
     loc = mu
 
     what = _read_from_cache('cdf') if cdf else _read_from_cache('pdf')
@@ -510,18 +566,10 @@ def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
     upper_limit = _read_from_cache('upper_limit')
 
     xr = (np.asarray(x, 'd') - loc) / sigma
-    alpha_index = int((alpha - _lower[1]) / (_upper[1] - _lower[1]) * (size[1] - 1))
-    beta_index = int((beta - _lower[2]) / (_upper[2] - _lower[2]) * (size[2] - 1))
-    try:
-        low_lims = lower_limit[alpha_index, beta_index]
-        up_lims = upper_limit[alpha_index, beta_index]
-    except IndexError:
-        logger.error(
-            'Grid index out of range: alpha=%s -> index %s, beta=%s -> index %s. '
-            'Please open an issue at https://github.com/josemiotto/pylevy/issues',
-            alpha, alpha_index, beta, beta_index,
-        )
-        raise
+    alpha_index = _grid_index(alpha, 1)
+    beta_index = _grid_index(beta, 2)
+    low_lims = lower_limit[alpha_index, beta_index]
+    up_lims = upper_limit[alpha_index, beta_index]
     mask = (low_lims <= xr) & (xr <= up_lims)
     z = xr[mask]
 

--- a/levy/__init__.py
+++ b/levy/__init__.py
@@ -160,6 +160,58 @@ def _interpolate(points, grid, lower, upper):
     return np.reshape(result, point_shape)
 
 
+def _check_alpha_beta(alpha, beta):
+    """ Rejects parameters the lookup tables do not cover.
+
+    Without this, `alpha` below 0.5 produced a *negative* grid index, which is
+    a perfectly valid Python index: alpha=0.4 gave -4 and silently returned the
+    limits for alpha ~ 1.94. The old `except IndexError` guard only fired for
+    positive overflow, so under-range values failed silently while over-range
+    values raised.
+    """
+    if not (_lower[1] <= alpha <= _upper[1]):
+        raise ValueError(
+            'alpha must be in [{}, {}], got {!r}. pylevy interpolates from a '
+            'lookup table that does not cover values outside that range.'.format(
+                _lower[1], _upper[1], alpha)
+        )
+    if not (_lower[2] <= beta <= _upper[2]):
+        raise ValueError(
+            'beta must be in [{}, {}], got {!r}.'.format(_lower[2], _upper[2], beta)
+        )
+
+
+def _grid_index(value, axis):
+    """ Index of the grid cell used to look up the tail-crossover limits.
+
+    This truncates rather than rounding to nearest, which is almost certainly
+    unintentional -- but it is deliberately left alone here, because measuring
+    it showed that switching to nearest-neighbour does *not* improve accuracy.
+
+    Over 300 sampled points where the two strategies disagree, compared against
+    `_calculate_levy` ground truth:
+
+        strategy      median rel err    mean       p90
+        truncate        1.1164e-02    3.5488e-01  1.4560
+        round           1.4552e-02    4.3251e-01  1.4656
+        bilinear        1.0106e-02    2.9459e-01  0.9723
+
+    Rounding is closer to truth on only 43% of those points and is worse on
+    the median. The error is dominated by the discontinuity between the
+    interpolated branch and the power-law tail branch -- the two do not meet at
+    the crossover, and the CDF steps down by up to 2.57e-03 there -- so the
+    choice of limit cell mostly decides which side of a bad seam you land on.
+    Fixing that properly means regenerating the limit tables or reconciling the
+    branches, not changing this line. Tracked separately.
+
+    Callers must validate first; the clamp only guards against a value landing
+    exactly on an endpoint after floating-point rounding.
+    """
+    span = _upper[axis] - _lower[axis]
+    index = int((value - _lower[axis]) / span * (size[axis] - 1))
+    return min(size[axis] - 1, max(0, index))
+
+
 def _psi(alpha):
     return np.pi / 2 * (alpha - 1 - np.sign(alpha - 1))
 
@@ -483,7 +535,9 @@ def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
     """
     Levy distribution with the tail replaced by the analytical (power law) approximation.
 
-    `alpha` in (0, 2] is the index of stability, or characteristic exponent.
+    `alpha` in [0.5, 2] is the index of stability, or characteristic exponent.
+    Values outside that range raise ValueError: the lookup table this
+    interpolates from does not cover them.
     `beta` in [-1, 1] is the skewness. `mu` in the reals and `sigma` > 0 are the
     location and scale of the distribution (corresponding to `delta` and `gamma`
     in Nolan's notation; note that sigma in levy corresponds to sqrt(2) sigma
@@ -513,6 +567,8 @@ def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
     :rtype: :class:`~numpy.ndarray`
     """
 
+    _check_alpha_beta(alpha, beta)
+
     loc = mu
 
     what = _read_from_cache('cdf') if cdf else _read_from_cache('pdf')
@@ -520,18 +576,10 @@ def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
     upper_limit = _read_from_cache('upper_limit')
 
     xr = (np.asarray(x, 'd') - loc) / sigma
-    alpha_index = int((alpha - _lower[1]) / (_upper[1] - _lower[1]) * (size[1] - 1))
-    beta_index = int((beta - _lower[2]) / (_upper[2] - _lower[2]) * (size[2] - 1))
-    try:
-        low_lims = lower_limit[alpha_index, beta_index]
-        up_lims = upper_limit[alpha_index, beta_index]
-    except IndexError:
-        logger.error(
-            'Grid index out of range: alpha=%s -> index %s, beta=%s -> index %s. '
-            'Please open an issue at https://github.com/josemiotto/pylevy/issues',
-            alpha, alpha_index, beta, beta_index,
-        )
-        raise
+    alpha_index = _grid_index(alpha, 1)
+    beta_index = _grid_index(beta, 2)
+    low_lims = lower_limit[alpha_index, beta_index]
+    up_lims = upper_limit[alpha_index, beta_index]
     mask = (low_lims <= xr) & (xr <= up_lims)
     z = xr[mask]
 

--- a/tests/test_known_bugs.py
+++ b/tests/test_known_bugs.py
@@ -55,73 +55,53 @@ def test_random_at_alpha_2_respects_location_and_scale():
 
 
 # --------------------------------------------------------------------------
-# (b) alpha below the supported floor indexes the table from the wrong end
-# --------------------------------------------------------------------------
-
-
-@xfail
-def test_alpha_below_supported_range_is_rejected():
-    """The module docstring (line 43) says alpha < 0.5 is unsupported, but
-    levy/__init__.py:469 computes ``int((alpha - 0.5) / 1.5 * 75)`` with no
-    lower bound, so alpha=0.4 gives index -4 -- a *valid* negative index that
-    silently reads the limits for alpha ~ 1.94. The ``except IndexError`` guard
-    at line 471 only catches positive overflow.
-
-    Observed: ``levy(x, 0.4, 0)`` returns the same values as ``levy(x, 0.5, 0)``
-    instead of raising.
-    """
-    with pytest.raises(ValueError):
-        levy.levy(np.array([1.0, 2.0]), 0.4, 0.0)
-
-
-@xfail
-def test_beta_outside_range_is_rejected():
-    """Same missing validation on the beta axis (line 470)."""
-    with pytest.raises(ValueError):
-        levy.levy(np.array([1.0, 2.0]), 1.5, 1.5)
-
-
-@xfail
-def test_alpha_below_range_does_not_alias_to_the_boundary():
-    """Distinct unsupported alphas must not silently produce identical output."""
-    assert not np.allclose(
-        levy.levy(np.array([1.0, 2.0]), 0.4, 0.0),
-        levy.levy(np.array([1.0, 2.0]), 0.5, 0.0),
-    )
-
-
-# --------------------------------------------------------------------------
 # (c) the tail-crossover cell is truncated instead of rounded
 # --------------------------------------------------------------------------
 
 
 @xfail
-def test_tail_crossover_uses_the_nearest_grid_cell():
-    """levy/__init__.py:469-470 truncate with ``int()`` where they should round.
+def test_tail_crossover_is_accurate_off_the_grid():
+    """The tail crossover is inaccurate for alpha/beta between grid points.
 
-    The consequence is observable, not cosmetic. At alpha=1.410182, beta=-0.5
-    the truncated cell has an upper crossover of 71.30 while the nearest cell
-    has 499.80. At x=285.55 the two branches disagree by 64%:
+    ``_grid_index`` snaps (alpha, beta) to one cell of the 76x101 limit tables
+    and uses that cell's crossover for every value in between. The consequence
+    is large: at alpha=1.410182, beta=-0.5 the selected cell has an upper
+    crossover of 71.30 while the neighbouring cell has 499.80, so at x=285.55
+    the two disagree by 64% -- one takes the power-law branch, the other the
+    interpolated branch.
 
-        levy() returns        1.919040e-07   (power-law tail branch)
-        interpolated value    5.382755e-07   (what the nearest cell gives)
+    Note that simply rounding to the nearest cell does **not** fix this. Over
+    300 sampled disagreement points, measured against ``_calculate_levy``:
 
-    ``sigma`` is unaffected; this is purely the choice of limit cell.
+        truncate  median 1.1164e-02   mean 3.5488e-01   p90 1.4560
+        round     median 1.4552e-02   mean 4.3251e-01   p90 1.4656
+        bilinear  median 1.0106e-02   mean 2.9459e-01   p90 0.9723
+
+    Rounding is *worse* on the median and better on only 43% of points. The
+    error is dominated by the seam itself: the interpolated branch and the
+    power-law branch do not meet at the crossover (see
+    ``test_cdf_is_monotone_across_the_tail_crossover``). A real fix means
+    interpolating the limits and reconciling the two branches so they agree
+    where they join, which is a numerical change worth its own PR and its own
+    evidence -- not a one-line int()/round() swap.
+
+    This test asserts the accuracy target, so it stays red until that lands.
     """
-    alpha, beta, x = 1.410182, -0.5, 285.55
-    probe = np.array([x])
+    rng = np.random.RandomState(0)
+    errors = []
+    for _ in range(40):
+        alpha = rng.uniform(0.55, 1.95)
+        beta = rng.uniform(-0.95, 0.95)
+        x = rng.uniform(15.0, 700.0) * rng.choice([-1.0, 1.0])
+        truth = levy._calculate_levy(float(x), alpha, beta, False)
+        if not np.isfinite(truth) or abs(truth) < 1e-300:
+            continue
+        got = levy.levy(np.array([float(x)]), alpha, beta)[0]
+        errors.append(abs(got - truth) / abs(truth))
 
-    # The nearest cell puts x inside the interpolated region.
-    upper_limit = _table("upper_limit")
-    k = (alpha - 0.5) / 1.5 * 75
-    beta_index = int(round((beta + 1.0) / 2.0 * 100))
-    assert int(k) != int(round(k)), "probe no longer straddles two cells"
-    assert x < upper_limit[int(round(k)), beta_index]
-
-    np.testing.assert_allclose(
-        levy.levy(probe, alpha, beta),
-        levy._int_levy(probe, alpha, beta),
-        rtol=1e-9,
+    assert np.median(errors) < 1e-4, (
+        "median relative error near the tail crossover is "
+        f"{np.median(errors):.3e}"
     )
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -183,3 +183,47 @@ def test_evaluating_levy_emits_no_output(capsys):
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
+
+
+# --------------------------------------------------------------------------
+# alpha/beta domain validation (was: out-of-range values silently indexed the
+# lookup tables from the wrong end)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("alpha", [0.4, 0.0, -1.0, 2.5, 3.0, np.nan])
+def test_alpha_outside_the_supported_range_raises(alpha):
+    """alpha=0.4 used to give grid index -4 -- a valid *negative* index -- so
+    it silently returned the limits for alpha ~ 1.94 and produced
+    plausible-looking numbers identical to alpha=0.5. Only positive overflow
+    raised, and then as an IndexError from deep inside the lookup.
+    """
+    with pytest.raises(ValueError, match="alpha"):
+        levy.levy(np.array([1.0, 2.0]), alpha, 0.0)
+
+
+@pytest.mark.parametrize("beta", [-1.5, 1.5, 2.0, np.nan])
+def test_beta_outside_the_supported_range_raises(beta):
+    with pytest.raises(ValueError, match="beta"):
+        levy.levy(np.array([1.0, 2.0]), 1.5, beta)
+
+
+@pytest.mark.parametrize("alpha", [0.5, 0.7, 1.0, 1.5, 1.9, 2.0])
+@pytest.mark.parametrize("beta", [-1.0, 0.0, 1.0])
+def test_endpoints_of_the_supported_range_are_accepted(alpha, beta):
+    """The bounds are inclusive; validation must not reject the corners."""
+    result = levy.levy(np.array([0.5, 1.0]), alpha, beta)
+    assert np.all(np.isfinite(result))
+
+
+def test_validation_message_names_the_offending_parameter():
+    with pytest.raises(ValueError) as info:
+        levy.levy(np.array([1.0]), 0.3, 0.0)
+    message = str(info.value)
+    assert "alpha" in message and "0.3" in message
+
+
+def test_neglog_levy_also_validates():
+    """The fit path goes through neglog_levy, so it must reject too."""
+    with pytest.raises(ValueError):
+        levy.neglog_levy(np.array([1.0]), 0.4, 0.0, 0.0, 1.0)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -194,3 +194,47 @@ def test_evaluating_levy_emits_no_output(capsys):
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
+
+
+# --------------------------------------------------------------------------
+# alpha/beta domain validation (was: out-of-range values silently indexed the
+# lookup tables from the wrong end)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("alpha", [0.4, 0.0, -1.0, 2.5, 3.0, np.nan])
+def test_alpha_outside_the_supported_range_raises(alpha):
+    """alpha=0.4 used to give grid index -4 -- a valid *negative* index -- so
+    it silently returned the limits for alpha ~ 1.94 and produced
+    plausible-looking numbers identical to alpha=0.5. Only positive overflow
+    raised, and then as an IndexError from deep inside the lookup.
+    """
+    with pytest.raises(ValueError, match="alpha"):
+        levy.levy(np.array([1.0, 2.0]), alpha, 0.0)
+
+
+@pytest.mark.parametrize("beta", [-1.5, 1.5, 2.0, np.nan])
+def test_beta_outside_the_supported_range_raises(beta):
+    with pytest.raises(ValueError, match="beta"):
+        levy.levy(np.array([1.0, 2.0]), 1.5, beta)
+
+
+@pytest.mark.parametrize("alpha", [0.5, 0.7, 1.0, 1.5, 1.9, 2.0])
+@pytest.mark.parametrize("beta", [-1.0, 0.0, 1.0])
+def test_endpoints_of_the_supported_range_are_accepted(alpha, beta):
+    """The bounds are inclusive; validation must not reject the corners."""
+    result = levy.levy(np.array([0.5, 1.0]), alpha, beta)
+    assert np.all(np.isfinite(result))
+
+
+def test_validation_message_names_the_offending_parameter():
+    with pytest.raises(ValueError) as info:
+        levy.levy(np.array([1.0]), 0.3, 0.0)
+    message = str(info.value)
+    assert "alpha" in message and "0.3" in message
+
+
+def test_neglog_levy_also_validates():
+    """The fit path goes through neglog_levy, so it must reject too."""
+    with pytest.raises(ValueError):
+        levy.neglog_levy(np.array([1.0]), 0.4, 0.0, 0.0, 1.0)


### PR DESCRIPTION
> Part 4 of a 20-commit stack. Stacked on #24 — review that first; the diff here against its base is a single commit.

levy() computed its lookup index with a bare int() and no lower bound:

    alpha_index = int((alpha - 0.5) / 1.5 * 75)

For alpha below the supported floor of 0.5 this goes negative -- alpha=0.4
gives -4 -- which is a perfectly valid Python index. The call then silently
read the tail-crossover limits for alpha ~ 1.94 and returned
plausible-looking numbers: levy(x, 0.4, 0) produced exactly the same values
as levy(x, 0.5, 0). The `except IndexError` guard only caught positive
overflow, so over-range alpha raised while under-range alpha failed
silently. The module docstring already said alpha < 0.5 is unsupported;
nothing enforced it, and levy()'s own docstring contradicted it by claiming
alpha in (0, 2].

alpha and beta are now checked at the top of levy(), raising ValueError
with the offending value in the message. The unreachable IndexError handler
is gone and levy()'s docstring is corrected to [0.5, 2].

This does not change any computed value: all 249 characterization goldens
regenerate byte-identically, and fitting still converges in all five
parametrizations.

Scope note -- what this PR deliberately does NOT do:

The same two lines truncate rather than rounding to nearest, which looks
like an obvious bug. I had intended to fix it here and measured it first,
against _calculate_levy ground truth over 300 sampled points where the two
strategies disagree:

    strategy    median rel err   mean         p90       max
    truncate      1.1164e-02   3.5488e-01   1.4560    2.454
    round         1.4552e-02   4.3251e-01   1.4656    2.367
    bilinear      1.0106e-02   2.9459e-01   0.9723    2.313

Rounding is closer to truth on only 43% of those points and is worse on the
median, so switching would move values by up to 245% with no accuracy
justification. The error is dominated by something else: the interpolated
branch and the power-law tail branch do not meet at the crossover -- the CDF
steps down by as much as 2.57e-03 there -- so the choice of limit cell
mostly decides which side of a bad seam you land on. Interpolating the
limits (the "bilinear" row) helps the mean and p90 but is still ~1e-2 on the
median.

Fixing that properly means regenerating the limit tables or reconciling the
two branches where they join. That is a real numerical change and deserves
its own PR and its own evidence, so the truncation is left exactly as it is
and documented in _grid_index, with the accuracy target kept red as
test_known_bugs.py::test_tail_crossover_is_accurate_off_the_grid.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

