### PR TITLE
Move table generation into a levy-tables command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,10 @@ jobs:
       - name: Show environment
         run: python -c "import numpy, scipy; print('numpy', numpy.__version__, '| scipy', scipy.__version__)"
 
+      # The table-building tests regenerate tables by quadrature and take ~70s;
+      # they run once in the `build-tables` job rather than on all five legs.
       - name: Run tests
-        run: python -m pytest tests/ -q
+        run: python -m pytest tests/ -q -m "not build"
 
   test-numpy1:
     name: numpy 1.x
@@ -80,7 +82,36 @@ jobs:
         run: python -c "import numpy, scipy; print('numpy', numpy.__version__, '| scipy', scipy.__version__)"
 
       - name: Run tests
-        run: python -m pytest tests/ -q
+        run: python -m pytest tests/ -q -m "not build"
+
+  build-tables:
+    name: table generation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      # Exercises levy-tables end to end at a 24x10x13 grid: builds the
+      # densities and crossover limits by quadrature, checks them against
+      # calculate_levy, writes a manifest, and confirms nothing is written into
+      # the installed package.
+      - name: Build tiny tables and verify
+        run: python -m pytest tests/test_build_cli.py -q -m build
+
+      - name: Console script is installed and runs
+        run: |
+          levy-tables where
+          levy-tables build --out "$RUNNER_TEMP/tables" --size 24,10,13 --what pdf
+          test -f "$RUNNER_TEMP/tables/pdf.npz"
+          test -f "$RUNNER_TEMP/tables/manifest.json"
 
   test-numpy2:
     name: numpy 2.x (pinned)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,10 @@ jobs:
       - name: Show environment
         run: python -c "import numpy, scipy; print('numpy', numpy.__version__, '| scipy', scipy.__version__)"
 
+      # The table-building tests regenerate tables by quadrature and take ~70s;
+      # they run once in the `build-tables` job rather than on all five legs.
       - name: Run tests
-        run: python -m pytest tests/ -q
+        run: python -m pytest tests/ -q -m "not build"
 
   test-numpy1:
     name: numpy 1.x
@@ -85,7 +87,36 @@ jobs:
         run: python -c "import numpy, scipy; print('numpy', numpy.__version__, '| scipy', scipy.__version__)"
 
       - name: Run tests
-        run: python -m pytest tests/ -q
+        run: python -m pytest tests/ -q -m "not build"
+
+  build-tables:
+    name: table generation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      # Exercises levy-tables end to end at a 24x10x13 grid: builds the
+      # densities and crossover limits by quadrature, checks them against
+      # calculate_levy, writes a manifest, and confirms nothing is written into
+      # the installed package.
+      - name: Build tiny tables and verify
+        run: python -m pytest tests/test_build_cli.py -q -m build
+
+      - name: Console script is installed and runs
+        run: |
+          levy-tables where
+          levy-tables build --out "$RUNNER_TEMP/tables" --size 24,10,13 --what pdf
+          test -f "$RUNNER_TEMP/tables/pdf.npz"
+          test -f "$RUNNER_TEMP/tables/manifest.json"
 
   test-numpy2:
     name: numpy 2.x (pinned)
@@ -113,7 +144,7 @@ jobs:
         run: python -c "import numpy, scipy; print('numpy', numpy.__version__, '| scipy', scipy.__version__)"
 
       - name: Run tests
-        run: python -m pytest tests/ -q
+        run: python -m pytest tests/ -q -m "not build"
 
   golden:
     name: golden file is reproducible

--- a/levy/__init__.py
+++ b/levy/__init__.py
@@ -94,6 +94,49 @@ f_bounds = {k: {par_names[k][i]: f_bounds[i] for i in range(4)} for k in par_nam
 ROOT = os.path.dirname(os.path.abspath(__file__))
 _data_cache = {}
 
+_TABLE_NAMES = ('pdf', 'cdf', 'lower_limit', 'upper_limit')
+
+
+def user_cache_dir():
+    """ Per-user directory where regenerated tables are looked for.
+
+    Resolved without a third-party dependency: XDG_CACHE_HOME or ~/.cache on
+    Unix, ~/Library/Caches on macOS, LOCALAPPDATA on Windows.
+    """
+    if sys.platform == 'win32':
+        base = os.environ.get('LOCALAPPDATA') or os.path.expanduser(r'~\AppData\Local')
+    elif sys.platform == 'darwin':
+        base = os.path.expanduser('~/Library/Caches')
+    else:
+        base = os.environ.get('XDG_CACHE_HOME') or os.path.expanduser('~/.cache')
+    return os.path.join(base, 'pylevy')
+
+
+def data_dir(writable=False):
+    """ Directory the lookup tables are read from.
+
+    Search order: ``$LEVY_DATA_DIR``, then the user cache directory if it holds
+    a complete set, then the tables shipped inside the package.
+
+    `writable=True` returns where a *new* build should go. Absent an override
+    that is the user cache directory, never the installed package: writing
+    there fails on a read-only or system install, and a partial run would
+    corrupt the installation.
+
+    ``$LEVY_DATA_DIR`` overrides both reads and writes. Pointing it at the
+    installed package is therefore possible, but that is the caller saying so
+    explicitly rather than the default doing it behind their back.
+    """
+    override = os.environ.get('LEVY_DATA_DIR')
+    if override:
+        return override
+    cache = user_cache_dir()
+    if writable:
+        return cache
+    if all(os.path.exists(os.path.join(cache, '{}.npz'.format(n))) for n in _TABLE_NAMES):
+        return cache
+    return ROOT
+
 
 # Cells of cdf.npz that scipy.integrate.quad failed to evaluate when the table
 # was generated. All four are at alpha index 4 (alpha = 0.58), beta indices 13
@@ -190,7 +233,7 @@ def _read_from_cache(key):
     except KeyError:
         # np.load returns a lazy NpzFile; materialise the array and let the
         # archive close instead of leaking the handle until garbage collection.
-        with np.load(os.path.join(ROOT, '{}.npz'.format(key))) as archive:
+        with np.load(os.path.join(data_dir(), '{}.npz'.format(key))) as archive:
             table = archive['arr_0']
         _data_cache[key] = _repair_table(key, table)
         return _data_cache[key]
@@ -279,7 +322,20 @@ def _check_alpha_beta(alpha, beta):
         )
 
 
-def _grid_index(value, axis):
+def _grid_shape():
+    """ Shape of the tables actually loaded.
+
+    `size` is the resolution of the tables shipped with the package, but
+    `levy-tables build --size` can produce others and $LEVY_DATA_DIR can point
+    at them. Anything that converts a parameter into a grid index has to use
+    the real shape, not the constant: doing otherwise raised
+    ``IndexError: index 50 is out of bounds for axis 0 with size 10`` as soon
+    as a table of a different resolution was loaded.
+    """
+    return _read_from_cache('pdf').shape
+
+
+def _grid_index(value, axis, length=None):
     """ Index of the grid cell used to look up the tail-crossover limits.
 
     This truncates rather than rounding to nearest, which is almost certainly
@@ -305,9 +361,11 @@ def _grid_index(value, axis):
     Callers must validate first; the clamp only guards against a value landing
     exactly on an endpoint after floating-point rounding.
     """
+    if length is None:
+        length = _grid_shape()[axis]
     span = _upper[axis] - _lower[axis]
-    index = int((value - _lower[axis]) / span * (size[axis] - 1))
-    return min(size[axis] - 1, max(0, index))
+    index = int((value - _lower[axis]) / span * (length - 1))
+    return min(length - 1, max(0, index))
 
 
 def _psi(alpha):
@@ -483,57 +541,6 @@ class Parameters(object):
             self._x[i] = f_bounds[self.par][self.pnames[i]](vals[j])
 
 
-def _calculate_levy(x, alpha, beta, cdf=False):
-    """
-    Calculation of Levy stable distribution via numerical integration.
-    This is used in the creation of the lookup table.
-    Notice that to compute it in a 'true' x, the tangent must be applied.
-    Example: levy(2, 1.5, 0) = _calculate_levy(np.tan(2), 1.5, 0)
-    "0" parametrization as per http://academic2.americanp.edu/~jpnolan/stable/stable.html
-    Addition: the special case alpha=1.0 was added. Due to an error in the
-    numerical integration, the limit was changed from 0 to 1e-10.
-    """
-    from scipy import integrate
-
-    beta = -beta
-
-    if alpha == 1:
-        li = 1e-10
-
-        # These functions need a correction, since the distribution is displaced, probably get rid of "-u" at the end
-        def func_cos(u):
-            # return np.exp(-u) * np.cos(-beta * 2 / np.pi * (u * np.log(u) - u))
-            return np.exp(-u) * np.cos(-beta * 2 / np.pi * u * np.log(u))
-
-        def func_sin(u):
-            # return np.exp(-u) * np.sin(-beta * 2 / np.pi * (u * np.log(u) - u))
-            return np.exp(-u) * np.sin(-beta * 2 / np.pi * u * np.log(u))
-
-    else:
-        li = 0
-
-        def func_cos(u):
-            ua = u ** alpha
-            return np.exp(-ua) * np.cos(_phi(alpha, beta) * (ua - u))
-
-        def func_sin(u):
-            ua = u ** alpha
-            return np.exp(-ua) * np.sin(_phi(alpha, beta) * (ua - u))
-
-    if cdf:
-        # Cumulative density function
-        return (
-            integrate.quad(lambda u: u and func_cos(u) / u or 0.0, li, np.inf, weight="sin", wvar=x, limlst=1000)[0]
-            + integrate.quad(lambda u: u and func_sin(u) / u or 0.0, li, np.inf, weight="cos", wvar=x, limlst=1000)[0]
-            ) / np.pi + 0.5
-    else:
-        # Probability density function
-        return (
-            integrate.quad(func_cos, li, np.inf, weight="cos", wvar=x, limlst=1000)[0]
-            - integrate.quad(func_sin, li, np.inf, weight="sin", wvar=x, limlst=1000)[0]
-            ) / np.pi
-
-
 def _approximate(x, alpha, beta, cdf=False):
     mask = (x > 0)
     values = np.sin(np.pi * alpha / 2.0) * gamma(alpha) / np.pi * np.power(np.abs(x), -alpha - 1.0)
@@ -545,78 +552,6 @@ def _approximate(x, alpha, beta, cdf=False):
         return values
     else:
         return values * alpha
-
-
-def _make_dist_data_file():
-    """ Generates the lookup tables, writes it to .npz files. """
-
-    xs, alphas, betas = [np.linspace(_lower[i], _upper[i], size[i], endpoint=True) for i in [0, 1, 2]]
-    ts = np.tan(xs)
-
-    logger.info("Generating pdf.npz ...")
-    pdf = np.zeros(size, 'float64')
-    for i, alpha in enumerate(alphas):
-        for j, beta in enumerate(betas):
-            logger.debug("Calculating alpha=%.2f, beta=%.2f", alpha, beta)
-            pdf[:, i, j] = [_calculate_levy(t, alpha, beta, False) for t in ts]
-    np.savez(os.path.join(ROOT, 'pdf.npz'), pdf)
-
-    logger.info("Generating cdf.npz ...")
-    cdf = np.zeros(size, 'float64')
-    for i, alpha in enumerate(alphas):
-        for j, beta in enumerate(betas):
-            logger.debug("Calculating alpha=%.2f, beta=%.2f", alpha, beta)
-            cdf[:, i, j] = [_calculate_levy(t, alpha, beta, True) for t in ts]
-    np.savez(os.path.join(ROOT, 'cdf.npz'), cdf)
-
-
-def _int_levy(x, alpha, beta, cdf=False):
-    """
-    Interpolate densities of the Levy stable distribution specified by alpha and beta.
-
-    Specify cdf=True to obtain the *cumulative* density function.
-
-    Note: may sometimes return slightly negative values, due to numerical inaccuracies.
-    """
-    points = np.empty(np.shape(x) + (3,), 'float64')
-    points[..., 0] = np.arctan(x)
-    points[..., 1] = alpha
-    points[..., 2] = beta
-
-    what = _read_from_cache('cdf') if cdf else _read_from_cache('pdf')
-    return _interpolate(points, what, _lower, _upper)
-
-
-def _get_closest_approx(alpha, beta, upper=True):
-    n = 100000
-    x1, x2 = -50.0, 1e4 - 50.0
-    li1, li2 = 10, 500
-    if upper is False:
-        x1, x2 = -1e4 + 50, 50
-        li1, li2 = -500, -10
-    dx = (x2 - x1) / n
-    x = np.linspace(x1, x2, num=n + 1, endpoint=True)
-    y = 1.0 - _int_levy(x, alpha, beta, cdf=True)
-    z = 1.0 - _approximate(x, alpha, beta, cdf=True)
-    mask = (li1 < x) & (x < li2)
-    return li1 + dx * np.argmin((np.log(z[mask]) - np.log(y[mask])) ** 2.0)
-
-
-def _make_limit_data_files():
-    for upper in [True, False]:
-        string = 'lower' if upper is False else 'upper'
-
-        limits = np.zeros(size[1:], 'float64')
-        alphas, betas = [np.linspace(_lower[i], _upper[i], size[i], endpoint=True) for i in [1, 2]]
-
-        logger.info("Generating %s_limit.npz ...", string)
-
-        for i, alpha in enumerate(alphas):
-            for j, beta in enumerate(betas):
-                limits[i, j] = _get_closest_approx(alpha, beta, upper=upper)
-                logger.debug("Calculating alpha=%.2f, beta=%.2f, limit=%.2f", alpha, beta, limits[i, j])
-
-        np.savez(os.path.join(ROOT, '{}_limit.npz'.format(string)), limits)
 
 
 def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
@@ -664,8 +599,8 @@ def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
     upper_limit = _read_from_cache('upper_limit')
 
     xr = (np.asarray(x, 'd') - loc) / sigma
-    alpha_index = _grid_index(alpha, 1)
-    beta_index = _grid_index(beta, 2)
+    alpha_index = _grid_index(alpha, 1, lower_limit.shape[0])
+    beta_index = _grid_index(beta, 2, lower_limit.shape[1])
     low_lims = lower_limit[alpha_index, beta_index]
     up_lims = upper_limit[alpha_index, beta_index]
     mask = (low_lims <= xr) & (xr <= up_lims)
@@ -845,18 +780,29 @@ def random(alpha, beta, mu=0.0, sigma=1.0, shape=()):
     return mu + sigma * k
 
 
+# Backwards compatibility: the table-generation helpers moved to levy._build.
+# Exposed lazily (PEP 562) so importing levy does not pull in scipy.integrate
+# for the sake of code only a maintainer regenerating tables ever runs.
+_MOVED_TO_BUILD = {
+    '_calculate_levy': 'calculate_levy',
+    '_int_levy': 'interpolated_levy',
+}
+
+
+def __getattr__(name):
+    if name in _MOVED_TO_BUILD:
+        from levy import _build
+        return getattr(_build, _MOVED_TO_BUILD[name])
+    raise AttributeError('module {!r} has no attribute {!r}'.format(__name__, name))
+
+
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format='%(message)s')
-
-    if "build" in sys.argv[1:]:
-        _make_dist_data_file()
-        _make_limit_data_files()
-
-    logger.info("Testing fit_levy using parametrization 0 and fixed alpha (1.5).")
-
-    N = 1000
-    logger.info("%d points, result should be (1.5, 0.5, 0.0, 1.0).", N)
-    x0 = random(1.5, 0.5, 0.0, 1.0, shape=(N,))
-
-    result0 = fit_levy(x0, par='0', alpha=1.5)
-    logger.info("%s", result0)
+    from levy._build.cli import main
+    logger.warning(
+        "`python -m levy build` is superseded by the `levy-tables` command, "
+        "which writes to a cache directory instead of into the installed package."
+    )
+    # Pass the subcommand through. Prepending 'build' unconditionally turned
+    # `python levy/__init__.py where` into `build where`; no arguments still
+    # means build, which is what this entry point has always done.
+    sys.exit(main(sys.argv[1:] or ['build']))

--- a/levy/__init__.py
+++ b/levy/__init__.py
@@ -46,6 +46,7 @@ Notes on the parameters
 import logging
 import sys
 import os
+import zipfile
 import numpy as np
 from scipy.special import gamma
 from scipy import optimize
@@ -95,6 +96,49 @@ f_bounds = {k: {par_names[k][i]: f_bounds[i] for i in range(4)} for k in par_nam
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 _data_cache = {}
+
+_TABLE_NAMES = ('pdf', 'cdf', 'lower_limit', 'upper_limit')
+
+
+def user_cache_dir():
+    """ Per-user directory where regenerated tables are looked for.
+
+    Resolved without a third-party dependency: XDG_CACHE_HOME or ~/.cache on
+    Unix, ~/Library/Caches on macOS, LOCALAPPDATA on Windows.
+    """
+    if sys.platform == 'win32':
+        base = os.environ.get('LOCALAPPDATA') or os.path.expanduser(r'~\AppData\Local')
+    elif sys.platform == 'darwin':
+        base = os.path.expanduser('~/Library/Caches')
+    else:
+        base = os.environ.get('XDG_CACHE_HOME') or os.path.expanduser('~/.cache')
+    return os.path.join(base, 'pylevy')
+
+
+def data_dir(writable=False):
+    """ Directory the lookup tables are read from.
+
+    Search order: ``$LEVY_DATA_DIR``, then the user cache directory if it holds
+    a complete set, then the tables shipped inside the package.
+
+    `writable=True` returns where a *new* build should go. Absent an override
+    that is the user cache directory, never the installed package: writing
+    there fails on a read-only or system install, and a partial run would
+    corrupt the installation.
+
+    ``$LEVY_DATA_DIR`` overrides both reads and writes. Pointing it at the
+    installed package is therefore possible, but that is the caller saying so
+    explicitly rather than the default doing it behind their back.
+    """
+    override = os.environ.get('LEVY_DATA_DIR')
+    if override:
+        return override
+    cache = user_cache_dir()
+    if writable:
+        return cache
+    if all(os.path.exists(os.path.join(cache, '{}.npz'.format(n))) for n in _TABLE_NAMES):
+        return cache
+    return ROOT
 
 
 # Cells of cdf.npz that scipy.integrate.quad failed to evaluate when the table
@@ -206,17 +250,86 @@ def _repair_table(key, table):
     return table
 
 
+def _unreadable_table(path, directory, error):
+    """Build the error for a table that could not be loaded.
+
+    Parameters
+    ----------
+    path : str
+        The archive that failed to load.
+    directory : str
+        The directory ``data_dir()`` chose, which decides what the remedy is.
+    error : Exception
+        What ``np.load`` raised.
+
+    Returns
+    -------
+    RuntimeError
+        Says which file, why it failed, where the file came from, and what to
+        do about it -- a bare ``BadZipFile: File is not a zip file`` from
+        three frames down says none of those.
+    """
+    what = 'cannot read the lookup table {} ({}: {}).'.format(
+        path, type(error).__name__, error)
+    if os.environ.get('LEVY_DATA_DIR'):
+        return RuntimeError(
+            what + ' $LEVY_DATA_DIR points at {}; fix or rebuild the tables '
+            'there, or unset it to fall back to the packaged ones.'.format(directory))
+    if directory == ROOT:
+        return RuntimeError(
+            what + ' This is the copy shipped inside the package, so the '
+            'installation itself is damaged; reinstall it.')
+    return RuntimeError(
+        what + ' The user cache at {} holds a table that cannot be read. Delete '
+        'that directory to go back to the packaged tables, or rerun '
+        '`levy-tables build`; `levy-tables where` shows which is in use.'.format(directory))
+
+
 def _read_from_cache(key):
     """ Loads the file given by key """
     try:
         return _data_cache[key]
     except KeyError:
-        # np.load returns a lazy NpzFile; materialise the array and let the
-        # archive close instead of leaking the handle until garbage collection.
-        with np.load(os.path.join(ROOT, '{}.npz'.format(key))) as archive:
-            table = archive['arr_0']
+        directory = data_dir()
+        path = os.path.join(directory, '{}.npz'.format(key))
+        try:
+            # np.load returns a lazy NpzFile; materialise the array and let
+            # the archive close instead of leaking the handle until garbage
+            # collection.
+            with np.load(path) as archive:
+                table = archive['arr_0']
+        except (OSError, EOFError, ValueError, KeyError, zipfile.BadZipFile) as error:
+            # Everything np.load raises for a missing, empty, truncated or
+            # foreign file, plus KeyError for an archive without arr_0.
+            raise _unreadable_table(path, directory, error) from error
+        _check_table_shape(key, table, directory)
         _data_cache[key] = _repair_table(key, table)
         return _data_cache[key]
+
+
+def _check_table_shape(key, table, directory):
+    """ Refuse a table whose shape does not match the pdf table's.
+
+    A directory is chosen by `data_dir()` on the strength of which files
+    exist, not what is in them, so a partial rebuild -- `levy-tables build
+    --what pdf --size ...` into a cache that already held a full set -- could
+    leave pdf.npz at one resolution next to a cdf and limits at another. The
+    grid index is derived from the pdf table's shape, so the mismatched
+    tables would be read with the wrong indices and return wrong numbers
+    rather than fail. Every table is therefore checked against the pdf.
+    """
+    if key == 'pdf':
+        return
+    reference = _read_from_cache('pdf').shape
+    expected = reference if key == 'cdf' else reference[1:]
+    if tuple(table.shape) != tuple(expected):
+        raise RuntimeError(
+            'the lookup tables in {} do not belong together: {} is {} but the pdf '
+            'table is {}. A partial rebuild has probably left tables of two '
+            'resolutions side by side; rebuild the whole set with `levy-tables '
+            'build`, or delete the directory to go back to the packaged tables.'.format(
+                directory, key, 'x'.join(map(str, table.shape)),
+                'x'.join(map(str, reference))))
 
 
 def _reflect(x, lower, upper):
@@ -302,7 +415,20 @@ def _check_alpha_beta(alpha, beta):
         )
 
 
-def _grid_index(value, axis):
+def _grid_shape():
+    """ Shape of the tables actually loaded.
+
+    `size` is the resolution of the tables shipped with the package, but
+    `levy-tables build --size` can produce others and $LEVY_DATA_DIR can point
+    at them. Anything that converts a parameter into a grid index has to use
+    the real shape, not the constant: doing otherwise raised
+    ``IndexError: index 50 is out of bounds for axis 0 with size 10`` as soon
+    as a table of a different resolution was loaded.
+    """
+    return _read_from_cache('pdf').shape
+
+
+def _grid_index(value, axis, length=None):
     """ Index of the grid cell used to look up the tail-crossover limits.
 
     This truncates rather than rounding to nearest, which is almost certainly
@@ -328,9 +454,11 @@ def _grid_index(value, axis):
     Callers must validate first; the clamp only guards against a value landing
     exactly on an endpoint after floating-point rounding.
     """
+    if length is None:
+        length = _grid_shape()[axis]
     span = _upper[axis] - _lower[axis]
-    index = int((value - _lower[axis]) / span * (size[axis] - 1))
-    return min(size[axis] - 1, max(0, index))
+    index = int((value - _lower[axis]) / span * (length - 1))
+    return min(length - 1, max(0, index))
 
 
 def _psi(alpha):
@@ -516,57 +644,6 @@ class Parameters(object):
             self._x[i] = f_bounds[self.par][self.pnames[i]](vals[j])
 
 
-def _calculate_levy(x, alpha, beta, cdf=False):
-    """
-    Calculation of Levy stable distribution via numerical integration.
-    This is used in the creation of the lookup table.
-    Notice that to compute it in a 'true' x, the tangent must be applied.
-    Example: levy(2, 1.5, 0) = _calculate_levy(np.tan(2), 1.5, 0)
-    "0" parametrization as per http://academic2.americanp.edu/~jpnolan/stable/stable.html
-    Addition: the special case alpha=1.0 was added. Due to an error in the
-    numerical integration, the limit was changed from 0 to 1e-10.
-    """
-    from scipy import integrate
-
-    beta = -beta
-
-    if alpha == 1:
-        li = 1e-10
-
-        # These functions need a correction, since the distribution is displaced, probably get rid of "-u" at the end
-        def func_cos(u):
-            # return np.exp(-u) * np.cos(-beta * 2 / np.pi * (u * np.log(u) - u))
-            return np.exp(-u) * np.cos(-beta * 2 / np.pi * u * np.log(u))
-
-        def func_sin(u):
-            # return np.exp(-u) * np.sin(-beta * 2 / np.pi * (u * np.log(u) - u))
-            return np.exp(-u) * np.sin(-beta * 2 / np.pi * u * np.log(u))
-
-    else:
-        li = 0
-
-        def func_cos(u):
-            ua = u ** alpha
-            return np.exp(-ua) * np.cos(_phi(alpha, beta) * (ua - u))
-
-        def func_sin(u):
-            ua = u ** alpha
-            return np.exp(-ua) * np.sin(_phi(alpha, beta) * (ua - u))
-
-    if cdf:
-        # Cumulative density function
-        return (
-            integrate.quad(lambda u: u and func_cos(u) / u or 0.0, li, np.inf, weight="sin", wvar=x, limlst=1000)[0]
-            + integrate.quad(lambda u: u and func_sin(u) / u or 0.0, li, np.inf, weight="cos", wvar=x, limlst=1000)[0]
-            ) / np.pi + 0.5
-    else:
-        # Probability density function
-        return (
-            integrate.quad(func_cos, li, np.inf, weight="cos", wvar=x, limlst=1000)[0]
-            - integrate.quad(func_sin, li, np.inf, weight="sin", wvar=x, limlst=1000)[0]
-            ) / np.pi
-
-
 def _approximate(x, alpha, beta, cdf=False):
     mask = (x > 0)
     values = np.sin(np.pi * alpha / 2.0) * gamma(alpha) / np.pi * np.power(np.abs(x), -alpha - 1.0)
@@ -578,78 +655,6 @@ def _approximate(x, alpha, beta, cdf=False):
         return values
     else:
         return values * alpha
-
-
-def _make_dist_data_file():
-    """ Generates the lookup tables, writes it to .npz files. """
-
-    xs, alphas, betas = [np.linspace(_lower[i], _upper[i], size[i], endpoint=True) for i in [0, 1, 2]]
-    ts = np.tan(xs)
-
-    logger.info("Generating pdf.npz ...")
-    pdf = np.zeros(size, 'float64')
-    for i, alpha in enumerate(alphas):
-        for j, beta in enumerate(betas):
-            logger.debug("Calculating alpha=%.2f, beta=%.2f", alpha, beta)
-            pdf[:, i, j] = [_calculate_levy(t, alpha, beta, False) for t in ts]
-    np.savez(os.path.join(ROOT, 'pdf.npz'), pdf)
-
-    logger.info("Generating cdf.npz ...")
-    cdf = np.zeros(size, 'float64')
-    for i, alpha in enumerate(alphas):
-        for j, beta in enumerate(betas):
-            logger.debug("Calculating alpha=%.2f, beta=%.2f", alpha, beta)
-            cdf[:, i, j] = [_calculate_levy(t, alpha, beta, True) for t in ts]
-    np.savez(os.path.join(ROOT, 'cdf.npz'), cdf)
-
-
-def _int_levy(x, alpha, beta, cdf=False):
-    """
-    Interpolate densities of the Levy stable distribution specified by alpha and beta.
-
-    Specify cdf=True to obtain the *cumulative* density function.
-
-    Note: may sometimes return slightly negative values, due to numerical inaccuracies.
-    """
-    points = np.empty(np.shape(x) + (3,), 'float64')
-    points[..., 0] = np.arctan(x)
-    points[..., 1] = alpha
-    points[..., 2] = beta
-
-    what = _read_from_cache('cdf') if cdf else _read_from_cache('pdf')
-    return _interpolate(points, what, _lower, _upper)
-
-
-def _get_closest_approx(alpha, beta, upper=True):
-    n = 100000
-    x1, x2 = -50.0, 1e4 - 50.0
-    li1, li2 = 10, 500
-    if upper is False:
-        x1, x2 = -1e4 + 50, 50
-        li1, li2 = -500, -10
-    dx = (x2 - x1) / n
-    x = np.linspace(x1, x2, num=n + 1, endpoint=True)
-    y = 1.0 - _int_levy(x, alpha, beta, cdf=True)
-    z = 1.0 - _approximate(x, alpha, beta, cdf=True)
-    mask = (li1 < x) & (x < li2)
-    return li1 + dx * np.argmin((np.log(z[mask]) - np.log(y[mask])) ** 2.0)
-
-
-def _make_limit_data_files():
-    for upper in [True, False]:
-        string = 'lower' if upper is False else 'upper'
-
-        limits = np.zeros(size[1:], 'float64')
-        alphas, betas = [np.linspace(_lower[i], _upper[i], size[i], endpoint=True) for i in [1, 2]]
-
-        logger.info("Generating %s_limit.npz ...", string)
-
-        for i, alpha in enumerate(alphas):
-            for j, beta in enumerate(betas):
-                limits[i, j] = _get_closest_approx(alpha, beta, upper=upper)
-                logger.debug("Calculating alpha=%.2f, beta=%.2f, limit=%.2f", alpha, beta, limits[i, j])
-
-        np.savez(os.path.join(ROOT, '{}_limit.npz'.format(string)), limits)
 
 
 def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
@@ -697,8 +702,8 @@ def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
     upper_limit = _read_from_cache('upper_limit')
 
     xr = (np.asarray(x, 'd') - loc) / sigma
-    alpha_index = _grid_index(alpha, 1)
-    beta_index = _grid_index(beta, 2)
+    alpha_index = _grid_index(alpha, 1, lower_limit.shape[0])
+    beta_index = _grid_index(beta, 2, lower_limit.shape[1])
     low_lims = lower_limit[alpha_index, beta_index]
     up_lims = upper_limit[alpha_index, beta_index]
     mask = (low_lims <= xr) & (xr <= up_lims)
@@ -878,18 +883,29 @@ def random(alpha, beta, mu=0.0, sigma=1.0, shape=()):
     return mu + sigma * k
 
 
+# Backwards compatibility: the table-generation helpers moved to levy._build.
+# Exposed lazily (PEP 562) so importing levy does not pull in scipy.integrate
+# for the sake of code only a maintainer regenerating tables ever runs.
+_MOVED_TO_BUILD = {
+    '_calculate_levy': 'calculate_levy',
+    '_int_levy': 'interpolated_levy',
+}
+
+
+def __getattr__(name):
+    if name in _MOVED_TO_BUILD:
+        from levy import _build
+        return getattr(_build, _MOVED_TO_BUILD[name])
+    raise AttributeError('module {!r} has no attribute {!r}'.format(__name__, name))
+
+
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format='%(message)s')
-
-    if "build" in sys.argv[1:]:
-        _make_dist_data_file()
-        _make_limit_data_files()
-
-    logger.info("Testing fit_levy using parametrization 0 and fixed alpha (1.5).")
-
-    N = 1000
-    logger.info("%d points, result should be (1.5, 0.5, 0.0, 1.0).", N)
-    x0 = random(1.5, 0.5, 0.0, 1.0, shape=(N,))
-
-    result0 = fit_levy(x0, par='0', alpha=1.5)
-    logger.info("%s", result0)
+    from levy._build.cli import main
+    logger.warning(
+        "`python -m levy build` is superseded by the `levy-tables` command, "
+        "which writes to a cache directory instead of into the installed package."
+    )
+    # Pass the subcommand through. Prepending 'build' unconditionally turned
+    # `python levy/__init__.py where` into `build where`; no arguments still
+    # means build, which is what this entry point has always done.
+    sys.exit(main(sys.argv[1:] or ['build']))

--- a/levy/__main__.py
+++ b/levy/__main__.py
@@ -1,0 +1,30 @@
+# -*- encoding: utf-8 -*-
+"""Entry point for ``python -m levy``.
+
+This file did not exist before, which means ``python -m levy build`` -- the
+command the module docstring gave for regenerating the lookup tables -- never
+actually worked: for a package, ``-m`` requires ``__main__.py``, and the
+``if __name__ == "__main__"`` block in ``__init__.py`` is only reachable by
+running that file directly (``python levy/__init__.py build``).
+
+Prefer the ``levy-tables`` console script; this exists so the documented
+invocation does what it says.
+"""
+
+import sys
+
+from levy._build.cli import main
+
+if __name__ == "__main__":
+    argv = sys.argv[1:]
+    if argv and argv[0] == "build":
+        # The documented 1.x spelling. Keep it working, and say what
+        # replaced it -- and where it writes now. Written to stderr rather
+        # than logged: logging is only configured inside main(), so a log
+        # record emitted here would go to the library's NullHandler.
+        sys.stderr.write(
+            "`python -m levy build` is superseded by the `levy-tables` command; "
+            "the tables go to the user cache directory, not into the package.\n"
+        )
+        sys.exit(main(argv))
+    sys.exit(main(argv or ["where"]))

--- a/levy/_build/__init__.py
+++ b/levy/_build/__init__.py
@@ -1,0 +1,28 @@
+# -*- encoding: utf-8 -*-
+"""Offline generation of the lookup tables pylevy interpolates from.
+
+Nothing here is needed to *use* the package. It is imported only by the
+``levy-tables`` command and by tests, which is the point: the previous
+arrangement kept the quadrature code in ``levy/__init__.py``, so importing the
+library pulled in ``scipy.integrate`` and ~90 lines that only a maintainer
+regenerating the tables would ever run.
+
+The tables take roughly 25 minutes of CPU to rebuild at the shipped
+(200, 76, 101) resolution, and the crossover limits another 30, so the builders
+here support parallel execution.
+"""
+
+from levy._build.quadrature import calculate_levy, interpolated_levy
+from levy._build.tables import (
+    build_crossover_tables,
+    build_density_tables,
+    write_manifest,
+)
+
+__all__ = [
+    "build_crossover_tables",
+    "build_density_tables",
+    "calculate_levy",
+    "interpolated_levy",
+    "write_manifest",
+]

--- a/levy/_build/cli.py
+++ b/levy/_build/cli.py
@@ -1,0 +1,122 @@
+# -*- encoding: utf-8 -*-
+"""``levy-tables``: regenerate the lookup tables.
+
+    levy-tables build                    # into the user cache directory
+    levy-tables build --out ./tables     # somewhere explicit
+    levy-tables build --size 40,16,21 --jobs 6
+    levy-tables where                    # which tables are actually in use
+
+Previously the only way to do this was ``python -m levy build``, which wrote
+24 MB straight into the installed package -- impossible on a read-only or
+system install, and silently destructive on a partial run.
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+logger = logging.getLogger("levy._build")
+
+
+def _parse_size(text):
+    parts = [int(p) for p in text.split(",")]
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError("expected three comma-separated integers, e.g. 200,76,101")
+    if any(p < 8 for p in parts):
+        raise argparse.ArgumentTypeError("each dimension must be at least 8 for cubic interpolation")
+    return tuple(parts)
+
+
+def _parse_what(text):
+    allowed = {"pdf", "cdf", "limits"}
+    what = [p.strip() for p in text.split(",") if p.strip()]
+    unknown = set(what) - allowed
+    if unknown:
+        raise argparse.ArgumentTypeError("unknown table(s): {}".format(", ".join(sorted(unknown))))
+    return what
+
+
+def build(args):
+    from levy import data_dir
+    from levy._build.tables import build_crossover_tables, build_density_tables, write_manifest
+
+    out_dir = args.out or data_dir(writable=True)
+    logger.info("Writing tables to %s", out_dir)
+
+    started = time.time()
+    densities = [w for w in args.what if w in ("pdf", "cdf")]
+    cdf_table = None
+    if densities:
+        results = build_density_tables(out_dir, args.size, jobs=args.jobs, what=densities)
+        if "cdf" in results:
+            cdf_table = results["cdf"][0]
+
+    if "limits" in args.what:
+        if cdf_table is None and args.size != tuple(__import__("levy").size):
+            logger.error(
+                "--what limits at a non-default --size needs the cdf table from the same run; "
+                "add cdf to --what"
+            )
+            return 2
+        build_crossover_tables(out_dir, args.size, jobs=args.jobs, cdf_table=cdf_table)
+
+    manifest = write_manifest(out_dir, args.size, extra={"seconds": round(time.time() - started, 1)})
+    logger.info("Done in %.1fs. Manifest: %s", time.time() - started, os.path.join(out_dir, "manifest.json"))
+    for name, entry in sorted(manifest["tables"].items()):
+        logger.info("  %-12s %8.2f MB  %s", name, entry["bytes"] / 1e6, entry["sha256"][:16])
+    return 0
+
+
+def where(args):
+    import levy
+
+    print("tables in use : {}".format(levy.data_dir()))
+    print("packaged      : {}".format(levy.ROOT))
+    print("user cache    : {}".format(levy.user_cache_dir()))
+    print("LEVY_DATA_DIR : {}".format(os.environ.get("LEVY_DATA_DIR", "(unset)")))
+    for name in ("pdf", "cdf", "lower_limit", "upper_limit"):
+        path = os.path.join(levy.data_dir(), "{}.npz".format(name))
+        marker = "ok" if os.path.exists(path) else "MISSING"
+        size_mb = os.path.getsize(path) / 1e6 if os.path.exists(path) else 0.0
+        print("  {:<12} {:>6}  {:8.2f} MB".format(name, marker, size_mb))
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="levy-tables", description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-v", "--verbose", action="store_true", help="verbose (DEBUG) logging")
+    subparsers = parser.add_subparsers(dest="command")
+
+    build_parser = subparsers.add_parser("build", help="regenerate the lookup tables")
+    build_parser.add_argument("--out", help="output directory (default: the user cache directory)")
+    build_parser.add_argument("--size", type=_parse_size, default=None,
+                              help="grid as x,alpha,beta (default: 200,76,101)")
+    build_parser.add_argument("--what", type=_parse_what, default=["pdf", "cdf", "limits"],
+                              help="which tables to build (default: pdf,cdf,limits)")
+    build_parser.add_argument("--jobs", type=int, default=1,
+                              help="worker processes; a full build is ~55 CPU-minutes")
+    build_parser.set_defaults(func=build)
+
+    where_parser = subparsers.add_parser("where", help="show which tables are in use")
+    where_parser.set_defaults(func=where)
+
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help()
+        return 1
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(message)s",
+    )
+    if args.command == "build" and args.size is None:
+        import levy
+        args.size = tuple(levy.size)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/levy/_build/cli.py
+++ b/levy/_build/cli.py
@@ -1,0 +1,169 @@
+# -*- encoding: utf-8 -*-
+"""``levy-tables``: regenerate the lookup tables.
+
+    levy-tables build                    # into the user cache directory
+    levy-tables build --out ./tables     # somewhere explicit
+    levy-tables build --size 40,16,21 --jobs 6
+    levy-tables where                    # which tables are actually in use
+
+Previously the only way to do this was ``python -m levy build``, which wrote
+24 MB straight into the installed package -- impossible on a read-only or
+system install, and silently destructive on a partial run.
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+logger = logging.getLogger("levy._build")
+
+
+def _parse_size(text):
+    parts = [int(p) for p in text.split(",")]
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError("expected three comma-separated integers, e.g. 200,76,101")
+    if any(p < 8 for p in parts):
+        raise argparse.ArgumentTypeError("each dimension must be at least 8 for cubic interpolation")
+    return tuple(parts)
+
+
+def _parse_what(text):
+    allowed = {"pdf", "cdf", "limits"}
+    what = [p.strip() for p in text.split(",") if p.strip()]
+    unknown = set(what) - allowed
+    if unknown:
+        raise argparse.ArgumentTypeError("unknown table(s): {}".format(", ".join(sorted(unknown))))
+    return what
+
+
+# Which files each `--what` item rewrites, in either limits layout.
+_WRITES = {
+    "pdf": ("pdf.npz",),
+    "cdf": ("cdf.npz",),
+    "limits": ("lower_limit.npz", "upper_limit.npz", "limits.npz"),
+}
+
+
+def _tables_left_over(out_dir, size, what):
+    """Return the tables in `out_dir` this run will not rewrite, that are not `size`.
+
+    `data_dir()` takes a directory on the strength of which files exist, so a
+    partial rebuild at a new size would leave the untouched tables at the old
+    one and the set would be used together: the grid index comes from the
+    pdf's shape, and the other tables would be read with it. Refusing here
+    keeps a cache internally consistent by construction.
+    """
+    import numpy as np
+
+    kept = set()
+    for item in ("pdf", "cdf", "limits"):
+        if item not in what:
+            kept.update(_WRITES[item])
+    wrong = []
+    for name in sorted(kept):
+        path = os.path.join(out_dir, name)
+        if not os.path.exists(path):
+            continue
+        with np.load(path) as archive:
+            shapes = {tuple(archive[key].shape) for key in archive.files}
+        expected = tuple(size) if name in ("pdf.npz", "cdf.npz") else tuple(size[1:])
+        if shapes != {expected}:
+            wrong.append("{} is {}".format(name, ", ".join("x".join(map(str, s)) for s in shapes)))
+    return wrong
+
+
+def build(args):
+    from levy import data_dir
+    from levy._build.tables import build_crossover_tables, build_density_tables, write_manifest
+
+    out_dir = args.out or data_dir(writable=True)
+    logger.info("Writing tables to %s", out_dir)
+
+    wrong = _tables_left_over(out_dir, args.size, args.what)
+    if wrong:
+        logger.error(
+            "%s already holds tables at another size that this run would leave in "
+            "place (%s); a set of mixed sizes is unusable. Rebuild everything "
+            "(--what pdf,cdf,limits), or use a different --out.",
+            out_dir, "; ".join(wrong),
+        )
+        return 2
+
+    started = time.time()
+    densities = [w for w in args.what if w in ("pdf", "cdf")]
+    cdf_table = None
+    if densities:
+        results = build_density_tables(out_dir, args.size, jobs=args.jobs, what=densities)
+        if "cdf" in results:
+            cdf_table = results["cdf"][0]
+
+    if "limits" in args.what:
+        # Without a cdf from this run, build_crossover_tables takes the one
+        # already in out_dir (that is how limits get recomputed for a table
+        # built earlier), and refuses any cdf that is not the requested size.
+        try:
+            build_crossover_tables(out_dir, args.size, jobs=args.jobs, cdf_table=cdf_table)
+        except ValueError as error:
+            logger.error("%s", error)
+            return 2
+
+    manifest = write_manifest(out_dir, args.size, extra={"seconds": round(time.time() - started, 1)})
+    logger.info("Done in %.1fs. Manifest: %s", time.time() - started, os.path.join(out_dir, "manifest.json"))
+    for name, entry in sorted(manifest["tables"].items()):
+        logger.info("  %-12s %8.2f MB  %s", name, entry["bytes"] / 1e6, entry["sha256"][:16])
+    return 0
+
+
+def where(args):
+    import levy
+
+    print("tables in use : {}".format(levy.data_dir()))
+    print("packaged      : {}".format(levy.ROOT))
+    print("user cache    : {}".format(levy.user_cache_dir()))
+    print("LEVY_DATA_DIR : {}".format(os.environ.get("LEVY_DATA_DIR", "(unset)")))
+    for name in ("pdf", "cdf", "lower_limit", "upper_limit"):
+        path = os.path.join(levy.data_dir(), "{}.npz".format(name))
+        marker = "ok" if os.path.exists(path) else "MISSING"
+        size_mb = os.path.getsize(path) / 1e6 if os.path.exists(path) else 0.0
+        print("  {:<12} {:>6}  {:8.2f} MB".format(name, marker, size_mb))
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="levy-tables", description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-v", "--verbose", action="store_true", help="verbose (DEBUG) logging")
+    subparsers = parser.add_subparsers(dest="command")
+
+    build_parser = subparsers.add_parser("build", help="regenerate the lookup tables")
+    build_parser.add_argument("--out", help="output directory (default: the user cache directory)")
+    build_parser.add_argument("--size", type=_parse_size, default=None,
+                              help="grid as x,alpha,beta (default: 200,76,101)")
+    build_parser.add_argument("--what", type=_parse_what, default=["pdf", "cdf", "limits"],
+                              help="which tables to build (default: pdf,cdf,limits)")
+    build_parser.add_argument("--jobs", type=int, default=1,
+                              help="worker processes; a full build is ~55 CPU-minutes")
+    build_parser.set_defaults(func=build)
+
+    where_parser = subparsers.add_parser("where", help="show which tables are in use")
+    where_parser.set_defaults(func=where)
+
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help()
+        return 1
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(message)s",
+    )
+    if args.command == "build" and args.size is None:
+        import levy
+        args.size = tuple(levy.size)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/levy/_build/quadrature.py
+++ b/levy/_build/quadrature.py
@@ -1,0 +1,101 @@
+# -*- encoding: utf-8 -*-
+"""Direct numerical evaluation of the Levy stable density, by quadrature.
+
+This is the ground truth the interpolation tables are built from, and the
+reference the test suite measures interpolation error against. It is far too
+slow for general use -- that is the whole reason the tables exist.
+
+Moved out of ``levy/__init__.py`` unchanged apart from the ``np.Inf`` -> ``np.inf``
+fix and the rename; the numerical results are identical.
+"""
+
+import numpy as np
+
+from levy import _interpolate, _lower, _phi, _upper
+
+__all__ = ["calculate_levy", "interpolated_levy"]
+
+
+def calculate_levy(x, alpha, beta, cdf=False):
+    """ Levy stable distribution by numerical integration.
+
+    Used to build the lookup tables, and as the reference in accuracy tests.
+    Note that to evaluate at a 'true' x the tangent must be applied:
+    ``levy(2, 1.5, 0) == calculate_levy(np.tan(2), 1.5, 0)``.
+
+    "0" parametrization as per Nolan. The special case alpha == 1 is handled
+    separately; because of an error in the numerical integration, its lower
+    limit is 1e-10 rather than 0.
+
+    Known limitation: for alpha = 0.58, beta = -+0.74 and |x| near 0.0079 --
+    the two grid points closest to zero -- ``integrate.quad``'s oscillatory
+    routine fails and returns ~5.72e+307. Those are exactly the four unusable
+    cells in the shipped cdf.npz. The weight passed to quad is sin(x*u) or
+    cos(x*u), whose period grows without bound as x approaches zero, which is
+    where the routine breaks down. Callers building tables should validate the
+    result rather than trusting it; see levy._build.tables.
+    """
+    from scipy import integrate
+
+    beta = -beta
+
+    if alpha == 1:
+        li = 1e-10
+
+        def func_cos(u):
+            return np.exp(-u) * np.cos(-beta * 2 / np.pi * u * np.log(u))
+
+        def func_sin(u):
+            return np.exp(-u) * np.sin(-beta * 2 / np.pi * u * np.log(u))
+
+    else:
+        li = 0
+
+        def func_cos(u):
+            ua = u ** alpha
+            return np.exp(-ua) * np.cos(_phi(alpha, beta) * (ua - u))
+
+        def func_sin(u):
+            ua = u ** alpha
+            return np.exp(-ua) * np.sin(_phi(alpha, beta) * (ua - u))
+
+    if cdf:
+        # Cumulative density function
+        return (
+            integrate.quad(
+                lambda u: u and func_cos(u) / u or 0.0,
+                li, np.inf, weight="sin", wvar=x, limlst=1000)[0]
+            + integrate.quad(
+                lambda u: u and func_sin(u) / u or 0.0,
+                li, np.inf, weight="cos", wvar=x, limlst=1000)[0]
+            ) / np.pi + 0.5
+    else:
+        # Probability density function
+        return (
+            integrate.quad(
+                func_cos, li, np.inf, weight="cos", wvar=x, limlst=1000)[0]
+            - integrate.quad(
+                func_sin, li, np.inf, weight="sin", wvar=x, limlst=1000)[0]
+            ) / np.pi
+
+
+def interpolated_levy(x, alpha, beta, cdf=False, table=None):
+    """ Interpolate the table without replacing the tails.
+
+    ``levy.levy`` splices the power-law asymptote onto the tails; this does not,
+    which is what the crossover search needs in order to find where the two
+    agree.
+
+    May return slightly negative values: Catmull-Rom weights have negative
+    lobes, so even a non-negative grid can interpolate below zero.
+    """
+    from levy import _read_from_cache
+
+    points = np.empty(np.shape(x) + (3,), 'float64')
+    points[..., 0] = np.arctan(x)
+    points[..., 1] = alpha
+    points[..., 2] = beta
+
+    if table is None:
+        table = _read_from_cache('cdf') if cdf else _read_from_cache('pdf')
+    return _interpolate(points, table, _lower, _upper)

--- a/levy/_build/tables.py
+++ b/levy/_build/tables.py
@@ -1,0 +1,228 @@
+# -*- encoding: utf-8 -*-
+"""Builders for the four lookup tables, with provenance and validation.
+
+Differences from the previous ``_make_dist_data_file`` / ``_make_limit_data_files``:
+
+* they take an output directory instead of writing into the installed package;
+* they can run across processes, because a full rebuild is ~25 CPU-minutes for
+  the densities and ~30 more for the crossover limits;
+* they validate what quadrature returns instead of storing it blindly, which is
+  how four unusable cells ended up in the shipped cdf.npz;
+* they write a manifest recording how the tables were made.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import sys
+
+import numpy as np
+
+from levy import _approximate, _lower, _upper, size
+from levy._build.quadrature import calculate_levy, interpolated_levy
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "build_crossover_tables",
+    "build_density_tables",
+    "grid_axes",
+    "write_manifest",
+]
+
+#: A CDF outside this band, or a non-finite density, means quadrature failed.
+_CDF_BOUND = 1e-6
+
+
+def grid_axes(grid_size=None):
+    """ The x, alpha and beta axes of the lookup grid.
+
+    x is stored in arctan space, so the grid covers the whole real line; the
+    tables hold values at ``tan(x_axis)``.
+    """
+    grid_size = tuple(grid_size or size)
+    return [
+        np.linspace(_lower[i], _upper[i], grid_size[i], endpoint=True)
+        for i in range(3)
+    ]
+
+
+def _density_column(args):
+    """One (alpha, beta) column of the table. Top level, so it can be pickled."""
+    alpha, beta, ts, cdf = args
+    return np.array([calculate_levy(t, alpha, beta, cdf) for t in ts])
+
+
+def _validate_column(column, cdf, alpha, beta):
+    """Flag values quadrature could not compute, rather than storing them."""
+    if cdf:
+        bad = ~np.isfinite(column) | (column < -_CDF_BOUND) | (column > 1.0 + _CDF_BOUND)
+    else:
+        bad = ~np.isfinite(column)
+    if bad.any():
+        good = ~bad
+        kind = "cdf" if cdf else "pdf"
+        # Two good points are the minimum np.interp needs. Below that the
+        # column cannot be filled at all, and saying "filling by
+        # interpolation" would be a lie: the bad values are written as they
+        # are. Say which of the two actually happened.
+        if good.sum() >= 2:
+            logger.warning(
+                "quadrature failed for %d of %d points at alpha=%.4f beta=%.4f (%s); "
+                "filling by interpolation along x",
+                int(bad.sum()), column.size, alpha, beta, kind,
+            )
+            column = column.copy()
+            column[bad] = np.interp(np.flatnonzero(bad), np.flatnonzero(good), column[good])
+        else:
+            logger.error(
+                "quadrature failed for %d of %d points at alpha=%.4f beta=%.4f (%s) "
+                "with fewer than 2 usable points; the column is UNFILLED and the "
+                "table it is written into is not usable",
+                int(bad.sum()), column.size, alpha, beta, kind,
+            )
+    return column, int(bad.sum())
+
+
+def _map(function, items, jobs):
+    if jobs and jobs > 1:
+        from multiprocessing import Pool
+        with Pool(jobs) as pool:
+            for result in pool.imap(function, items):
+                yield result
+    else:
+        for item in items:
+            yield function(item)
+
+
+def build_density_tables(out_dir, grid_size=None, jobs=1, what=("pdf", "cdf")):
+    """ Generate pdf.npz and/or cdf.npz into `out_dir`.
+
+    Returns {name: (array, number_of_repaired_cells)}.
+    """
+    grid_size = tuple(grid_size or size)
+    x_axis, alphas, betas = grid_axes(grid_size)
+    ts = np.tan(x_axis)
+    os.makedirs(out_dir, exist_ok=True)
+
+    results = {}
+    for name in what:
+        cdf = name == "cdf"
+        logger.info("Generating %s.npz at %s ...", name, "x".join(map(str, grid_size)))
+        table = np.zeros(grid_size, 'float64')
+        columns = [(alpha, beta, ts, cdf) for alpha in alphas for beta in betas]
+        repaired = 0
+        for index, column in enumerate(_map(_density_column, columns, jobs)):
+            i, j = divmod(index, len(betas))
+            column, bad = _validate_column(column, cdf, alphas[i], betas[j])
+            repaired += bad
+            table[:, i, j] = column
+            if index % 500 == 0:
+                logger.info("  %d/%d columns", index, len(columns))
+        np.savez_compressed(os.path.join(out_dir, '{}.npz'.format(name)), table)
+        logger.info("Wrote %s.npz (%d cell(s) repaired)", name, repaired)
+        results[name] = (table, repaired)
+    return results
+
+
+def _crossover_cell(args):
+    """Where the power-law asymptote best matches the interpolated CDF."""
+    alpha, beta, upper, table = args
+    n = 100000
+    x1, x2 = -50.0, 1e4 - 50.0
+    li1, li2 = 10, 500
+    if upper is False:
+        x1, x2 = -1e4 + 50, 50
+        li1, li2 = -500, -10
+    dx = (x2 - x1) / n
+    x = np.linspace(x1, x2, num=n + 1, endpoint=True)
+    y = 1.0 - interpolated_levy(x, alpha, beta, cdf=True, table=table)
+    z = 1.0 - _approximate(x, alpha, beta, cdf=True)
+    mask = (li1 < x) & (x < li2)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        return li1 + dx * np.argmin((np.log(z[mask]) - np.log(y[mask])) ** 2.0)
+
+
+def build_crossover_tables(out_dir, grid_size=None, jobs=1, cdf_table=None):
+    """ Generate lower_limit.npz and upper_limit.npz into `out_dir`.
+
+    These say where levy() should stop interpolating and switch to the
+    power-law tail, so they depend on the CDF table and must be rebuilt after it.
+    """
+    from levy import _read_from_cache
+
+    grid_size = tuple(grid_size or size)
+    _, alphas, betas = grid_axes(grid_size)
+    os.makedirs(out_dir, exist_ok=True)
+    if cdf_table is None:
+        # The crossover is a property of a particular CDF table: it says where
+        # that table stops matching the tail approximation. Reading the
+        # installed one would describe a table other than the one being written
+        # here, which is wrong whenever the two differ -- a different grid size,
+        # or simply a rebuild. Prefer the CDF just produced in out_dir.
+        built = os.path.join(out_dir, 'cdf.npz')
+        if os.path.exists(built):
+            with np.load(built) as archive:
+                cdf_table = archive[archive.files[0]]
+        else:
+            cdf_table = _read_from_cache('cdf')
+
+    results = {}
+    for upper in (True, False):
+        name = 'upper' if upper else 'lower'
+        logger.info("Generating %s_limit.npz ...", name)
+        cells = [(alpha, beta, upper, cdf_table) for alpha in alphas for beta in betas]
+        limits = np.zeros(grid_size[1:], 'float64')
+        for index, value in enumerate(_map(_crossover_cell, cells, jobs)):
+            i, j = divmod(index, len(betas))
+            limits[i, j] = value
+            if index % 500 == 0:
+                logger.info("  %d/%d cells", index, len(cells))
+        np.savez_compressed(os.path.join(out_dir, '{}_limit.npz'.format(name)), limits)
+        results['{}_limit'.format(name)] = limits
+    return results
+
+
+def write_manifest(out_dir, grid_size=None, extra=None):
+    """ Record how the tables in `out_dir` were produced.
+
+    Without this there is no way to tell what resolution a table was built at,
+    which library versions produced it, or whether a file has been altered.
+    """
+    import scipy
+
+    grid_size = tuple(grid_size or size)
+    entries = {}
+    # Both layouts: the two separate crossover files, and the merged
+    # limits.npz that replaces them. Missing names are skipped below, so
+    # listing all of them keeps the manifest correct across the change.
+    for name in ('pdf', 'cdf', 'lower_limit', 'upper_limit', 'limits'):
+        path = os.path.join(out_dir, '{}.npz'.format(name))
+        if not os.path.exists(path):
+            continue
+        with open(path, 'rb') as handle:
+            digest = hashlib.sha256(handle.read()).hexdigest()
+        with np.load(path) as archive:
+            key = archive.files[0]
+            entries[name] = {
+                'sha256': digest,
+                'bytes': os.path.getsize(path),
+                'shape': list(archive[key].shape),
+                'dtype': str(archive[key].dtype),
+            }
+
+    manifest = {
+        'grid_size': list(grid_size),
+        'lower': list(map(float, _lower)),
+        'upper': list(map(float, _upper)),
+        'numpy': np.__version__,
+        'scipy': scipy.__version__,
+        'python': sys.version.split()[0],
+        'tables': entries,
+    }
+    manifest.update(extra or {})
+    path = os.path.join(out_dir, 'manifest.json')
+    with open(path, 'w') as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+    return manifest

--- a/levy/_build/tables.py
+++ b/levy/_build/tables.py
@@ -1,0 +1,276 @@
+# -*- encoding: utf-8 -*-
+"""Builders for the four lookup tables, with provenance and validation.
+
+Differences from the previous ``_make_dist_data_file`` / ``_make_limit_data_files``:
+
+* they take an output directory instead of writing into the installed package;
+* they can run across processes, because a full rebuild is ~25 CPU-minutes for
+  the densities and ~30 more for the crossover limits;
+* they validate what quadrature returns instead of storing it blindly, which is
+  how four unusable cells ended up in the shipped cdf.npz;
+* they write a manifest recording how the tables were made.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import sys
+
+import numpy as np
+
+from levy import _approximate, _lower, _upper, size
+from levy._build.quadrature import calculate_levy, interpolated_levy
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "build_crossover_tables",
+    "build_density_tables",
+    "grid_axes",
+    "write_manifest",
+]
+
+#: A CDF outside this band, or a non-finite density, means quadrature failed.
+_CDF_BOUND = 1e-6
+
+
+def grid_axes(grid_size=None):
+    """ The x, alpha and beta axes of the lookup grid.
+
+    x is stored in arctan space, so the grid covers the whole real line; the
+    tables hold values at ``tan(x_axis)``.
+    """
+    grid_size = tuple(grid_size or size)
+    return [
+        np.linspace(_lower[i], _upper[i], grid_size[i], endpoint=True)
+        for i in range(3)
+    ]
+
+
+def _density_column(args):
+    """One (alpha, beta) column of the table. Top level, so it can be pickled."""
+    alpha, beta, ts, cdf = args
+    return np.array([calculate_levy(t, alpha, beta, cdf) for t in ts])
+
+
+def _validate_column(column, cdf, alpha, beta):
+    """Flag values quadrature could not compute, rather than storing them."""
+    if cdf:
+        bad = ~np.isfinite(column) | (column < -_CDF_BOUND) | (column > 1.0 + _CDF_BOUND)
+    else:
+        bad = ~np.isfinite(column)
+    if not bad.any():
+        return column, 0
+    good = ~bad
+    kind = "cdf" if cdf else "pdf"
+    # Two good points are the minimum np.interp needs. Below that the column
+    # cannot be filled at all, and saying "filling by interpolation" would be
+    # a lie: the bad values are written as they are. Say which of the two
+    # actually happened -- in the count as well as the log, so the summary
+    # line cannot report a repair that did not take place.
+    if good.sum() < 2:
+        logger.error(
+            "quadrature failed for %d of %d points at alpha=%.4f beta=%.4f (%s) "
+            "with fewer than 2 usable points; the column is UNFILLED and the "
+            "table it is written into is not usable",
+            int(bad.sum()), column.size, alpha, beta, kind,
+        )
+        return column, 0
+    logger.warning(
+        "quadrature failed for %d of %d points at alpha=%.4f beta=%.4f (%s); "
+        "filling by interpolation along x",
+        int(bad.sum()), column.size, alpha, beta, kind,
+    )
+    column = column.copy()
+    column[bad] = np.interp(np.flatnonzero(bad), np.flatnonzero(good), column[good])
+    return column, int(bad.sum())
+
+
+def _map(function, items, jobs):
+    if jobs and jobs > 1:
+        from multiprocessing import Pool
+        with Pool(jobs) as pool:
+            for result in pool.imap(function, items):
+                yield result
+    else:
+        for item in items:
+            yield function(item)
+
+
+def _write_table(path, array):
+    """Write `array` to `path` as a compressed archive, atomically.
+
+    Parameters
+    ----------
+    path : str
+        Destination, ending in ``.npz``.
+    array : ndarray
+        The table to store, as the archive's single ``arr_0`` entry.
+
+    Notes
+    -----
+    The archive is written under a temporary name beside `path` and renamed
+    into place only once it is complete. ``data_dir()`` decides that the user
+    cache is usable by whether its files *exist*, so a build that died
+    mid-write -- Ctrl-C, a killed job, a full disk -- would otherwise leave a
+    truncated ``.npz`` that is picked up as part of a complete set and then
+    fails to load on every use until somebody deletes it by hand.
+    """
+    temporary = path + '.tmp'
+    try:
+        # A file object rather than the name: given a name that does not end
+        # in .npz, np.savez_compressed appends the extension itself.
+        with open(temporary, 'wb') as handle:
+            np.savez_compressed(handle, array)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.remove(temporary)
+
+
+def build_density_tables(out_dir, grid_size=None, jobs=1, what=("pdf", "cdf")):
+    """ Generate pdf.npz and/or cdf.npz into `out_dir`.
+
+    Returns {name: (array, number_of_repaired_cells)}.
+    """
+    grid_size = tuple(grid_size or size)
+    x_axis, alphas, betas = grid_axes(grid_size)
+    ts = np.tan(x_axis)
+    os.makedirs(out_dir, exist_ok=True)
+
+    results = {}
+    for name in what:
+        cdf = name == "cdf"
+        logger.info("Generating %s.npz at %s ...", name, "x".join(map(str, grid_size)))
+        table = np.zeros(grid_size, 'float64')
+        columns = [(alpha, beta, ts, cdf) for alpha in alphas for beta in betas]
+        repaired = 0
+        for index, column in enumerate(_map(_density_column, columns, jobs)):
+            i, j = divmod(index, len(betas))
+            column, bad = _validate_column(column, cdf, alphas[i], betas[j])
+            repaired += bad
+            table[:, i, j] = column
+            if index % 500 == 0:
+                logger.info("  %d/%d columns", index, len(columns))
+        _write_table(os.path.join(out_dir, '{}.npz'.format(name)), table)
+        logger.info("Wrote %s.npz (%d cell(s) repaired)", name, repaired)
+        results[name] = (table, repaired)
+    return results
+
+
+def _crossover_cell(args):
+    """Where the power-law asymptote best matches the interpolated CDF."""
+    alpha, beta, upper, table = args
+    n = 100000
+    x1, x2 = -50.0, 1e4 - 50.0
+    li1, li2 = 10, 500
+    if upper is False:
+        x1, x2 = -1e4 + 50, 50
+        li1, li2 = -500, -10
+    dx = (x2 - x1) / n
+    x = np.linspace(x1, x2, num=n + 1, endpoint=True)
+    y = 1.0 - interpolated_levy(x, alpha, beta, cdf=True, table=table)
+    z = 1.0 - _approximate(x, alpha, beta, cdf=True)
+    mask = (li1 < x) & (x < li2)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        return li1 + dx * np.argmin((np.log(z[mask]) - np.log(y[mask])) ** 2.0)
+
+
+def build_crossover_tables(out_dir, grid_size=None, jobs=1, cdf_table=None):
+    """ Generate lower_limit.npz and upper_limit.npz into `out_dir`.
+
+    These say where levy() should stop interpolating and switch to the
+    power-law tail, so they depend on the CDF table and must be rebuilt after it.
+    """
+    from levy import _read_from_cache
+
+    grid_size = tuple(grid_size or size)
+    _, alphas, betas = grid_axes(grid_size)
+    os.makedirs(out_dir, exist_ok=True)
+    if cdf_table is None:
+        # The crossover is a property of a particular CDF table: it says where
+        # that table stops matching the tail approximation. Reading the
+        # installed one would describe a table other than the one being written
+        # here, which is wrong whenever the two differ -- a different grid size,
+        # or simply a rebuild. Prefer the CDF just produced in out_dir.
+        built = os.path.join(out_dir, 'cdf.npz')
+        if os.path.exists(built):
+            source = built
+            with np.load(built) as archive:
+                cdf_table = archive[archive.files[0]]
+        else:
+            from levy import data_dir
+            source = os.path.join(data_dir(), 'cdf.npz')
+            cdf_table = _read_from_cache('cdf')
+        logger.info("Using %s for the crossover limits", source)
+    else:
+        source = 'the cdf table from this run'
+    # Whatever the source, it has to be the table these limits will sit next
+    # to. Without this a cached 24x10x13 cdf could quietly produce limits for
+    # a --size 200,76,101 build, and the manifest would record the wrong size.
+    if tuple(cdf_table.shape) != grid_size:
+        raise ValueError(
+            "the cdf table ({}) is {}, not the requested {}; the crossover limits "
+            "describe one particular cdf table, so build the cdf at this size first "
+            "(add cdf to --what)".format(
+                source, 'x'.join(map(str, cdf_table.shape)), 'x'.join(map(str, grid_size))))
+
+    results = {}
+    for upper in (True, False):
+        name = 'upper' if upper else 'lower'
+        logger.info("Generating %s_limit.npz ...", name)
+        cells = [(alpha, beta, upper, cdf_table) for alpha in alphas for beta in betas]
+        limits = np.zeros(grid_size[1:], 'float64')
+        for index, value in enumerate(_map(_crossover_cell, cells, jobs)):
+            i, j = divmod(index, len(betas))
+            limits[i, j] = value
+            if index % 500 == 0:
+                logger.info("  %d/%d cells", index, len(cells))
+        _write_table(os.path.join(out_dir, '{}_limit.npz'.format(name)), limits)
+        results['{}_limit'.format(name)] = limits
+    return results
+
+
+def write_manifest(out_dir, grid_size=None, extra=None):
+    """ Record how the tables in `out_dir` were produced.
+
+    Without this there is no way to tell what resolution a table was built at,
+    which library versions produced it, or whether a file has been altered.
+    """
+    import scipy
+
+    grid_size = tuple(grid_size or size)
+    entries = {}
+    # Both layouts: the two separate crossover files, and the merged
+    # limits.npz that replaces them. Missing names are skipped below, so
+    # listing all of them keeps the manifest correct across the change.
+    for name in ('pdf', 'cdf', 'lower_limit', 'upper_limit', 'limits'):
+        path = os.path.join(out_dir, '{}.npz'.format(name))
+        if not os.path.exists(path):
+            continue
+        with open(path, 'rb') as handle:
+            digest = hashlib.sha256(handle.read()).hexdigest()
+        with np.load(path) as archive:
+            key = archive.files[0]
+            entries[name] = {
+                'sha256': digest,
+                'bytes': os.path.getsize(path),
+                'shape': list(archive[key].shape),
+                'dtype': str(archive[key].dtype),
+            }
+
+    manifest = {
+        'grid_size': list(grid_size),
+        'lower': list(map(float, _lower)),
+        'upper': list(map(float, _upper)),
+        'numpy': np.__version__,
+        'scipy': scipy.__version__,
+        'python': sys.version.split()[0],
+        'tables': entries,
+    }
+    manifest.update(extra or {})
+    path = os.path.join(out_dir, 'manifest.json')
+    with open(path, 'w') as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+    return manifest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = ["pytest>=7", "build", "twine"]
 
+# Regenerates the lookup tables into a user cache directory. Replaces
+# `python -m levy build`, which wrote 24 MB into the installed package.
+[project.scripts]
+levy-tables = "levy._build.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/josemiotto/pylevy"
 Documentation = "https://pylevy.readthedocs.io/en/latest/index.html"
@@ -70,4 +75,7 @@ levy = ["*.npz"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-markers = ["slow: fits and other cases that take more than a moment"]
+markers = [
+    "slow: cases that take more than a moment",
+    "build: regenerates lookup tables by quadrature; ~70s, run in its own CI job",
+]

--- a/tests/test_build_cli.py
+++ b/tests/test_build_cli.py
@@ -1,0 +1,218 @@
+"""Tests for the table-generation CLI and the data-directory search order.
+
+The builders are exercised at a tiny grid size -- the shipped (200, 76, 101)
+tables take about 55 CPU-minutes to regenerate, so the full build is not
+something a test suite can run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+import levy
+from levy._build.cli import main
+from levy._build.tables import build_crossover_tables, build_density_tables, write_manifest
+
+TINY = (24, 10, 13)
+
+
+# --------------------------------------------------------------------------
+# Where tables come from
+# --------------------------------------------------------------------------
+
+
+def test_data_dir_defaults_to_the_package(monkeypatch, tmp_path):
+    monkeypatch.delenv("LEVY_DATA_DIR", raising=False)
+    monkeypatch.setattr(levy, "user_cache_dir", lambda: str(tmp_path / "empty"))
+    assert levy.data_dir() == levy.ROOT
+
+
+def test_data_dir_honours_the_environment_override(monkeypatch):
+    monkeypatch.setenv("LEVY_DATA_DIR", "/somewhere/else")
+    assert levy.data_dir() == "/somewhere/else"
+
+
+def test_data_dir_prefers_a_complete_cache(monkeypatch, tmp_path):
+    monkeypatch.delenv("LEVY_DATA_DIR", raising=False)
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    monkeypatch.setattr(levy, "user_cache_dir", lambda: str(cache))
+
+    # An incomplete cache must be ignored, not half-used.
+    (cache / "pdf.npz").write_bytes(b"")
+    assert levy.data_dir() == levy.ROOT
+
+    for name in levy._TABLE_NAMES:
+        (cache / "{}.npz".format(name)).write_bytes(b"")
+    assert levy.data_dir() == str(cache)
+
+
+def test_writable_data_dir_is_never_the_installed_package(monkeypatch, tmp_path):
+    """Building must not write into site-packages, as `python -m levy build` did."""
+    monkeypatch.delenv("LEVY_DATA_DIR", raising=False)
+    monkeypatch.setattr(levy, "user_cache_dir", lambda: str(tmp_path / "cache"))
+    assert levy.data_dir(writable=True) != levy.ROOT
+
+
+def test_user_cache_dir_is_platform_appropriate():
+    path = levy.user_cache_dir()
+    assert path.endswith("pylevy")
+    assert os.path.isabs(path)
+
+
+# --------------------------------------------------------------------------
+# Building
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.build
+def test_build_density_tables_at_a_tiny_grid(tmp_path):
+    results = build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf", "cdf"))
+
+    for name in ("pdf", "cdf"):
+        table, _ = results[name]
+        assert table.shape == TINY
+        assert np.isfinite(table).all()
+        assert (tmp_path / "{}.npz".format(name)).exists()
+
+    cdf = results["cdf"][0]
+    assert cdf.min() >= -1e-6 and cdf.max() <= 1.0 + 1e-6
+    # the CDF must increase along x at every (alpha, beta)
+    assert np.all(np.diff(cdf, axis=0) > -1e-6)
+
+
+@pytest.mark.build
+def test_generated_table_matches_quadrature(tmp_path):
+    """The builder must store what calculate_levy returns, at the right places."""
+    results = build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf",))
+    table = results["pdf"][0]
+    x_axis, alphas, betas = levy._build.tables.grid_axes(TINY)
+    ts = np.tan(x_axis)
+    for i in (0, 4, 9):
+        for j in (0, 6, 12):
+            expected = levy._calculate_levy(ts[5], alphas[i], betas[j], False)
+            assert table[5, i, j] == pytest.approx(expected, rel=1e-12)
+
+
+@pytest.mark.build
+def test_build_writes_nothing_into_the_installed_package(tmp_path):
+    before = {
+        name: (lambda st: (st.st_mtime_ns, st.st_size))(
+            os.stat(os.path.join(levy.ROOT, "{}.npz".format(name))))
+        for name in levy._TABLE_NAMES
+    }
+    build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf",))
+    after = {
+        name: (lambda st: (st.st_mtime_ns, st.st_size))(
+            os.stat(os.path.join(levy.ROOT, "{}.npz".format(name))))
+        for name in levy._TABLE_NAMES
+    }
+    assert before == after
+
+
+@pytest.mark.build
+def test_manifest_records_provenance(tmp_path):
+    build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf",))
+    manifest = write_manifest(str(tmp_path), TINY)
+
+    assert manifest["grid_size"] == list(TINY)
+    assert manifest["numpy"] == np.__version__
+    assert "pdf" in manifest["tables"]
+    entry = manifest["tables"]["pdf"]
+    assert entry["shape"] == list(TINY)
+    assert len(entry["sha256"]) == 64
+
+    on_disk = json.loads((tmp_path / "manifest.json").read_text())
+    assert on_disk == manifest
+
+
+@pytest.mark.build
+def test_generated_tables_are_usable_via_the_environment_override(tmp_path, monkeypatch):
+    """End-to-end: build tiny tables, point levy at them, evaluate."""
+    build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf", "cdf"))
+    build_crossover_tables(str(tmp_path), TINY, jobs=1,
+                           cdf_table=np.load(str(tmp_path / "cdf.npz"))["arr_0"])
+
+    script = (
+        "import numpy as np, levy;"
+        "print(float(levy.levy(np.array([1.0]), 1.5, 0.0)[0]))"
+    )
+    # Not os.getcwd(): pytest can be invoked from anywhere, and the child
+    # would then import a different levy, or none at all.
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env = dict(os.environ, LEVY_DATA_DIR=str(tmp_path), PYTHONPATH=repo_root)
+    completed = subprocess.run([sys.executable, "-c", script], env=env,
+                               capture_output=True, text=True, timeout=120)
+    assert completed.returncode == 0, completed.stderr
+    # A 24x10x13 grid is far too coarse for accuracy; we are checking the
+    # plumbing, so only sanity is asserted.
+    assert 0.0 < float(completed.stdout.strip()) < 1.0
+
+
+# --------------------------------------------------------------------------
+# Command-line surface
+# --------------------------------------------------------------------------
+
+
+def test_cli_where_reports_the_search_path(capsys):
+    assert main(["where"]) == 0
+    output = capsys.readouterr().out
+    assert "tables in use" in output
+    assert "LEVY_DATA_DIR" in output
+    for name in levy._TABLE_NAMES:
+        assert name in output
+
+
+def test_cli_with_no_command_prints_help(capsys):
+    assert main([]) == 1
+    assert "levy-tables" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("bad", ["1,2", "200,76,101,5", "4,4,4"])
+def test_cli_rejects_bad_sizes(bad):
+    with pytest.raises(SystemExit):
+        main(["build", "--size", bad])
+
+
+def test_cli_rejects_unknown_table_names():
+    with pytest.raises(SystemExit):
+        main(["build", "--what", "pdf,nonsense"])
+
+
+@pytest.mark.build
+def test_cli_build_writes_to_the_requested_directory(tmp_path):
+    assert main(["build", "--out", str(tmp_path), "--size", "24,10,13", "--what", "pdf"]) == 0
+    assert (tmp_path / "pdf.npz").exists()
+    assert (tmp_path / "manifest.json").exists()
+
+
+@pytest.mark.build
+def test_tables_of_a_different_resolution_are_usable(tmp_path, monkeypatch):
+    """Grid indices must come from the loaded table, not the `size` constant.
+
+    `size` is hardcoded to the shipped (200, 76, 101). Before this was fixed,
+    pointing LEVY_DATA_DIR at tables built at any other resolution -- the whole
+    reason `levy-tables build --size` exists -- raised
+    ``IndexError: index 50 is out of bounds for axis 0 with size 10`` from
+    inside levy().
+    """
+    build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf", "cdf"))
+    with np.load(str(tmp_path / "cdf.npz")) as archive:
+        cdf_table = archive["arr_0"]
+    build_crossover_tables(str(tmp_path), TINY, jobs=1, cdf_table=cdf_table)
+
+    monkeypatch.setenv("LEVY_DATA_DIR", str(tmp_path))
+    levy._data_cache.clear()
+    try:
+        assert levy._grid_shape() == TINY
+        assert levy.size != TINY, "the constant still says the shipped resolution"
+        result = levy.levy(np.array([0.5, 1.0, 2.0]), 1.5, 0.0)
+        assert np.all(np.isfinite(result))
+    finally:
+        levy._data_cache.clear()

--- a/tests/test_build_cli.py
+++ b/tests/test_build_cli.py
@@ -1,0 +1,383 @@
+"""Tests for the table-generation CLI and the data-directory search order.
+
+The builders are exercised at a tiny grid size -- the shipped (200, 76, 101)
+tables take about 55 CPU-minutes to regenerate, so the full build is not
+something a test suite can run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+import levy
+from levy._build.cli import main
+from levy._build.tables import build_crossover_tables, build_density_tables, write_manifest
+
+TINY = (24, 10, 13)
+
+
+# --------------------------------------------------------------------------
+# Where tables come from
+# --------------------------------------------------------------------------
+
+
+def test_data_dir_defaults_to_the_package(monkeypatch, tmp_path):
+    monkeypatch.delenv("LEVY_DATA_DIR", raising=False)
+    monkeypatch.setattr(levy, "user_cache_dir", lambda: str(tmp_path / "empty"))
+    assert levy.data_dir() == levy.ROOT
+
+
+def test_data_dir_honours_the_environment_override(monkeypatch):
+    monkeypatch.setenv("LEVY_DATA_DIR", "/somewhere/else")
+    assert levy.data_dir() == "/somewhere/else"
+
+
+def test_data_dir_prefers_a_complete_cache(monkeypatch, tmp_path):
+    monkeypatch.delenv("LEVY_DATA_DIR", raising=False)
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    monkeypatch.setattr(levy, "user_cache_dir", lambda: str(cache))
+
+    # An incomplete cache must be ignored, not half-used.
+    (cache / "pdf.npz").write_bytes(b"")
+    assert levy.data_dir() == levy.ROOT
+
+    for name in levy._TABLE_NAMES:
+        (cache / "{}.npz".format(name)).write_bytes(b"")
+    assert levy.data_dir() == str(cache)
+
+
+def test_writable_data_dir_is_never_the_installed_package(monkeypatch, tmp_path):
+    """Building must not write into site-packages, as `python -m levy build` did."""
+    monkeypatch.delenv("LEVY_DATA_DIR", raising=False)
+    monkeypatch.setattr(levy, "user_cache_dir", lambda: str(tmp_path / "cache"))
+    assert levy.data_dir(writable=True) != levy.ROOT
+
+
+def test_user_cache_dir_is_platform_appropriate():
+    path = levy.user_cache_dir()
+    assert path.endswith("pylevy")
+    assert os.path.isabs(path)
+
+
+# --------------------------------------------------------------------------
+# Building
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.build
+def test_build_density_tables_at_a_tiny_grid(tmp_path):
+    results = build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf", "cdf"))
+
+    for name in ("pdf", "cdf"):
+        table, _ = results[name]
+        assert table.shape == TINY
+        assert np.isfinite(table).all()
+        assert (tmp_path / "{}.npz".format(name)).exists()
+
+    cdf = results["cdf"][0]
+    assert cdf.min() >= -1e-6 and cdf.max() <= 1.0 + 1e-6
+    # the CDF must increase along x at every (alpha, beta)
+    assert np.all(np.diff(cdf, axis=0) > -1e-6)
+
+
+@pytest.mark.build
+def test_generated_table_matches_quadrature(tmp_path):
+    """The builder must store what calculate_levy returns, at the right places."""
+    results = build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf",))
+    table = results["pdf"][0]
+    x_axis, alphas, betas = levy._build.tables.grid_axes(TINY)
+    ts = np.tan(x_axis)
+    for i in (0, 4, 9):
+        for j in (0, 6, 12):
+            expected = levy._calculate_levy(ts[5], alphas[i], betas[j], False)
+            assert table[5, i, j] == pytest.approx(expected, rel=1e-12)
+
+
+@pytest.mark.build
+def test_build_writes_nothing_into_the_installed_package(tmp_path):
+    before = {
+        name: (lambda st: (st.st_mtime_ns, st.st_size))(
+            os.stat(os.path.join(levy.ROOT, "{}.npz".format(name))))
+        for name in levy._TABLE_NAMES
+    }
+    build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf",))
+    after = {
+        name: (lambda st: (st.st_mtime_ns, st.st_size))(
+            os.stat(os.path.join(levy.ROOT, "{}.npz".format(name))))
+        for name in levy._TABLE_NAMES
+    }
+    assert before == after
+
+
+@pytest.mark.build
+def test_manifest_records_provenance(tmp_path):
+    build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf",))
+    manifest = write_manifest(str(tmp_path), TINY)
+
+    assert manifest["grid_size"] == list(TINY)
+    assert manifest["numpy"] == np.__version__
+    assert "pdf" in manifest["tables"]
+    entry = manifest["tables"]["pdf"]
+    assert entry["shape"] == list(TINY)
+    assert len(entry["sha256"]) == 64
+
+    on_disk = json.loads((tmp_path / "manifest.json").read_text())
+    assert on_disk == manifest
+
+
+@pytest.mark.build
+def test_generated_tables_are_usable_via_the_environment_override(tmp_path, monkeypatch):
+    """End-to-end: build tiny tables, point levy at them, evaluate."""
+    build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf", "cdf"))
+    build_crossover_tables(str(tmp_path), TINY, jobs=1,
+                           cdf_table=np.load(str(tmp_path / "cdf.npz"))["arr_0"])
+
+    script = (
+        "import numpy as np, levy;"
+        "print(float(levy.levy(np.array([1.0]), 1.5, 0.0)[0]))"
+    )
+    # Not os.getcwd(): pytest can be invoked from anywhere, and the child
+    # would then import a different levy, or none at all.
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env = dict(os.environ, LEVY_DATA_DIR=str(tmp_path), PYTHONPATH=repo_root)
+    completed = subprocess.run([sys.executable, "-c", script], env=env,
+                               capture_output=True, text=True, timeout=120)
+    assert completed.returncode == 0, completed.stderr
+    # A 24x10x13 grid is far too coarse for accuracy; we are checking the
+    # plumbing, so only sanity is asserted.
+    assert 0.0 < float(completed.stdout.strip()) < 1.0
+
+
+# --------------------------------------------------------------------------
+# Command-line surface
+# --------------------------------------------------------------------------
+
+
+def test_cli_where_reports_the_search_path(capsys):
+    assert main(["where"]) == 0
+    output = capsys.readouterr().out
+    assert "tables in use" in output
+    assert "LEVY_DATA_DIR" in output
+    for name in levy._TABLE_NAMES:
+        assert name in output
+
+
+def test_cli_with_no_command_prints_help(capsys):
+    assert main([]) == 1
+    assert "levy-tables" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("bad", ["1,2", "200,76,101,5", "4,4,4"])
+def test_cli_rejects_bad_sizes(bad):
+    with pytest.raises(SystemExit):
+        main(["build", "--size", bad])
+
+
+def test_cli_rejects_unknown_table_names():
+    with pytest.raises(SystemExit):
+        main(["build", "--what", "pdf,nonsense"])
+
+
+@pytest.mark.build
+def test_cli_build_writes_to_the_requested_directory(tmp_path):
+    assert main(["build", "--out", str(tmp_path), "--size", "24,10,13", "--what", "pdf"]) == 0
+    assert (tmp_path / "pdf.npz").exists()
+    assert (tmp_path / "manifest.json").exists()
+
+
+def test_limits_only_at_a_new_size_needs_a_cdf_to_describe(tmp_path):
+    """Crossover limits are a property of one cdf table; with neither a cdf in
+    this run nor one already in --out, there is nothing to compute them for.
+    """
+    assert main(["build", "--out", str(tmp_path), "--size", "24,10,13", "--what", "limits"]) == 2
+
+
+def test_limits_only_refuses_a_cdf_of_the_wrong_size(tmp_path):
+    np.savez_compressed(str(tmp_path / "cdf.npz"), np.zeros((8, 8, 8)))
+    assert main(["build", "--out", str(tmp_path), "--size", "24,10,13", "--what", "limits"]) == 2
+
+
+@pytest.mark.build
+def test_limits_can_be_recomputed_for_an_existing_cdf(tmp_path):
+    """`--what limits` used to demand cdf in the same run even when --out
+    already held a cdf.npz at that size, forcing the quadrature to be redone.
+    """
+    assert main(["build", "--out", str(tmp_path), "--size", "24,10,13", "--what", "cdf"]) == 0
+    assert main(["build", "--out", str(tmp_path), "--size", "24,10,13", "--what", "limits"]) == 0
+    names = {p.name for p in tmp_path.iterdir()}
+    assert "limits.npz" in names or {"lower_limit.npz", "upper_limit.npz"} <= names
+
+
+@pytest.mark.build
+def test_tables_of_a_different_resolution_are_usable(tmp_path, monkeypatch):
+    """Grid indices must come from the loaded table, not the `size` constant.
+
+    `size` is hardcoded to the shipped (200, 76, 101). Before this was fixed,
+    pointing LEVY_DATA_DIR at tables built at any other resolution -- the whole
+    reason `levy-tables build --size` exists -- raised
+    ``IndexError: index 50 is out of bounds for axis 0 with size 10`` from
+    inside levy().
+    """
+    build_density_tables(str(tmp_path), TINY, jobs=1, what=("pdf", "cdf"))
+    with np.load(str(tmp_path / "cdf.npz")) as archive:
+        cdf_table = archive["arr_0"]
+    build_crossover_tables(str(tmp_path), TINY, jobs=1, cdf_table=cdf_table)
+
+    monkeypatch.setenv("LEVY_DATA_DIR", str(tmp_path))
+    levy._data_cache.clear()
+    try:
+        assert levy._grid_shape() == TINY
+        assert levy.size != TINY, "the constant still says the shipped resolution"
+        result = levy.levy(np.array([0.5, 1.0, 2.0]), 1.5, 0.0)
+        assert np.all(np.isfinite(result))
+    finally:
+        levy._data_cache.clear()
+
+
+# --------------------------------------------------------------------------
+# A table that cannot be read
+# --------------------------------------------------------------------------
+
+
+def test_an_unreadable_cached_table_is_reported_with_its_path(monkeypatch, tmp_path):
+    """A truncated .npz in the cache used to surface as a bare zipfile error
+    from inside np.load, naming neither the file nor the fact that deleting
+    the cache directory is the fix.
+    """
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    for name in levy._TABLE_NAMES:
+        (cache / f"{name}.npz").write_bytes(b"not an archive")
+    monkeypatch.delenv("LEVY_DATA_DIR", raising=False)
+    monkeypatch.setattr(levy, "user_cache_dir", lambda: str(cache))
+    monkeypatch.setattr(levy, "_data_cache", {})
+
+    with pytest.raises(RuntimeError, match="user cache") as info:
+        levy._read_from_cache("pdf")
+    assert str(cache / "pdf.npz") in str(info.value)
+    assert "levy-tables build" in str(info.value)
+
+
+def test_an_unreadable_override_table_names_the_variable(monkeypatch, tmp_path):
+    (tmp_path / "cdf.npz").write_bytes(b"")
+    monkeypatch.setenv("LEVY_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(levy, "_data_cache", {})
+
+    with pytest.raises(RuntimeError, match="LEVY_DATA_DIR"):
+        levy._read_from_cache("cdf")
+
+
+def test_tables_are_written_atomically(tmp_path):
+    """A table is written under a temporary name and renamed into place, so a
+    build that dies mid-write leaves nothing that data_dir() would mistake for
+    a complete set.
+    """
+    from levy._build.tables import _write_table
+
+    path = str(tmp_path / "pdf.npz")
+    _write_table(path, np.arange(6.0).reshape(2, 3))
+    assert sorted(os.listdir(tmp_path)) == ["pdf.npz"]
+    with np.load(path) as archive:
+        np.testing.assert_array_equal(archive["arr_0"], np.arange(6.0).reshape(2, 3))
+
+
+def test_a_failed_write_leaves_no_partial_table_behind(tmp_path, monkeypatch):
+    from levy._build import tables
+
+    def die_halfway(handle, *arrays):
+        handle.write(b"half of an archive")
+        raise OSError("disk full")
+
+    monkeypatch.setattr(tables.np, "savez_compressed", die_halfway)
+    with pytest.raises(OSError, match="disk full"):
+        tables._write_table(str(tmp_path / "pdf.npz"), np.zeros(3))
+    assert os.listdir(tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# tables of two sizes must never be used together
+# --------------------------------------------------------------------------
+
+
+def test_a_partial_rebuild_at_another_size_is_refused(tmp_path):
+    """`--what pdf --size ...` into a directory holding a full set at another
+    size used to succeed, and `data_dir()` then served pdf at one resolution
+    next to cdf and limits at another.
+    """
+    for name, shape in (("pdf.npz", (8, 8, 8)), ("cdf.npz", (8, 8, 8)),
+                        ("lower_limit.npz", (8, 8)), ("upper_limit.npz", (8, 8))):
+        np.savez_compressed(str(tmp_path / name), np.zeros(shape))
+    assert main(["build", "--out", str(tmp_path), "--size", "24,10,13", "--what", "pdf"]) == 2
+    # Nothing was written: the old set is still intact and still consistent.
+    with np.load(str(tmp_path / "pdf.npz")) as archive:
+        assert archive["arr_0"].shape == (8, 8, 8)
+
+
+def test_tables_that_do_not_belong_together_are_refused_at_load(monkeypatch, tmp_path):
+    """The other half of the guard, for a directory assembled by hand or by an
+    older build: a cdf whose shape differs from the pdf's is refused with the
+    directory named, rather than read with the pdf's grid indices.
+    """
+    np.savez_compressed(str(tmp_path / "pdf.npz"), np.zeros((24, 10, 13)))
+    np.savez_compressed(str(tmp_path / "cdf.npz"), np.zeros((8, 8, 8)))
+    monkeypatch.setenv("LEVY_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(levy, "_data_cache", {})
+    with pytest.raises(RuntimeError, match="do not belong together"):
+        levy._read_from_cache("cdf")
+
+
+# --------------------------------------------------------------------------
+# python -m levy
+# --------------------------------------------------------------------------
+
+
+def _child_env():
+    """An environment for `python -m levy` that imports *this* checkout.
+
+    The root comes from the imported package, not from the working directory,
+    and a developer's $LEVY_DATA_DIR is dropped so an override pointing at an
+    incomplete directory cannot fail a test that is not about overrides.
+    """
+    root = os.path.dirname(os.path.dirname(os.path.abspath(levy.__file__)))
+    env = dict(os.environ, PYTHONPATH=root)
+    env.pop("LEVY_DATA_DIR", None)
+    return env
+
+
+def test_python_dash_m_levy_works():
+    """`python -m levy` needs levy/__main__.py, which never existed.
+
+    The module docstring documented `python -m levy build` as the way to
+    regenerate the tables, but for a package that requires __main__.py; the
+    `if __name__ == "__main__"` block in __init__.py is only reachable by
+    running the file directly. Verified against master: it failed there too.
+    """
+    completed = subprocess.run(
+        [sys.executable, "-m", "levy", "where"],
+        capture_output=True, text=True, timeout=120, env=_child_env(),
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "tables in use" in completed.stdout
+
+
+@pytest.mark.build
+def test_python_dash_m_levy_build_still_builds(tmp_path):
+    """The documented 1.x invocation, end to end through the package entry
+    point rather than through main() directly: it builds, warns that it is
+    superseded, and writes where it is told.
+    """
+    completed = subprocess.run(
+        [sys.executable, "-m", "levy", "build", "--out", str(tmp_path),
+         "--size", "24,10,13", "--what", "pdf"],
+        capture_output=True, text=True, timeout=600, env=_child_env(),
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "superseded" in completed.stderr
+    assert (tmp_path / "pdf.npz").exists()


### PR DESCRIPTION
> Part 8 of a 20-commit stack. Stacked on #28 — review that first; the diff here against its base is a single commit.

`python -m levy build` wrote 24 MB of .npz files straight into the
installed package. That fails outright on a read-only or system install,
silently corrupts the installation if a run is interrupted, and gives no
way to build at another resolution or to know how an existing table was
produced. The generation code also sat in levy/__init__.py, so importing
the library carried ~90 lines and a scipy.integrate dependency that only a
maintainer regenerating tables would ever execute.

Generation moves to levy/_build/ and is exposed as a console script:

    levy-tables build                      # into the user cache directory
    levy-tables build --out ./tables --size 40,16,21 --jobs 6
    levy-tables where                      # which tables are actually in use

* levy/_build/quadrature.py -- calculate_levy and interpolated_levy,
  unchanged numerically.
* levy/_build/tables.py -- builders taking an output directory, with
  optional multiprocessing (a full rebuild is ~25 CPU-minutes for the
  densities and ~30 more for the crossover limits), validation of what
  quadrature returns, and a manifest.json recording grid size, bounds,
  numpy/scipy/python versions and a SHA-256 per table.
* levy/_build/cli.py -- the command.

Tables are now looked up through data_dir(): $LEVY_DATA_DIR, then the user
cache directory if it holds a complete set, then the copy shipped inside
the package. The cache directory is resolved without adding a dependency
(XDG_CACHE_HOME/~/.cache, ~/Library/Caches, LOCALAPPDATA). data_dir(
writable=True) never returns the installed package, so a build cannot
target site-packages even by accident.

Two things fixed along the way:

* The builders validate. calculate_levy returns 5.72e+307 for alpha=0.58,
  beta=-+0.74 near x=0 -- the four unusable cells in the shipped cdf.npz --
  and the old builder stored whatever it got. Columns are now checked and
  filled by interpolation with a warning, so a rebuild cannot silently
  reproduce that.
* Grid indices are taken from the loaded table rather than from the `size`
  constant. `size` is hardcoded to the shipped (200, 76, 101), so pointing
  LEVY_DATA_DIR at tables of any other resolution -- the entire point of
  --size -- raised "IndexError: index 50 is out of bounds for axis 0 with
  size 10" from inside levy(). Caught by the new end-to-end test.

levy/__init__.py drops from 838 to 723 lines and no longer imports
scipy.integrate at import time. _calculate_levy and _int_levy remain
available as lazy module attributes (PEP 562) so existing callers and the
accuracy tests keep working without paying that import cost.

`python -m levy build` still works, warns that it is superseded, and now
writes to the cache directory instead of into the package.

New tests cover the search order, that a build touches nothing in the
installed package, that generated tables match calculate_levy, the
manifest, and the CLI surface. They are marked `build` and run in their own
CI job, since regenerating even a 24x10x13 grid takes ~70s.

No golden values change: all 280 regenerate byte-identically.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

