### PR TITLE
NumPy-style docstrings everywhere, enforced by ruff and numpydoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,14 +166,9 @@ jobs:
       - name: Verify golden file
         run: python tests/golden/generate.py --check
 
-  legacy-doctests:
-    name: legacy doctests (known failing)
+  lint:
+    name: lint and docstrings
     runs-on: ubuntu-latest
-    # Informational, not a gate. These are the package's only pre-existing
-    # tests and 4 of them fail on current NumPy/SciPy for two independent
-    # reasons: last-digit drift in the L-BFGS-B optimum, and NumPy 2 rendering
-    # scalars as np.float64(...). Replacing them is the point of this PR.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -181,10 +176,45 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
+      - name: Install lint dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install numpy scipy
+          python -m pip install -e ".[lint]"
+
+      # Rules and per-file ignores live in pyproject.toml. `D` runs under the
+      # numpy convention, so this covers the grammar of every docstring.
+      - name: ruff
+        run: python -m ruff check .
+
+      # Complements ruff: numpydoc checks the docstring against the signature
+      # -- every parameter documented, in order, with a type, and a Returns
+      # section that matches. ruff cannot see that far.
+      - name: numpydoc
+        run: python -m numpydoc lint src/levy/*.py src/levy/_build/*.py
+
+  doctests:
+    name: doctests
+    runs-on: ubuntu-latest
+    # A real gate, replacing the informational "legacy doctests" job. The old
+    # one ran `python -m doctest levy/__init__.py`, which after the src/ layout
+    # move pointed at a path that no longer exists -- and, piped into `tail`,
+    # reported success while testing nothing.
+    #
+    # The examples are now written so they can be gated: values are rounded to
+    # 6 decimals and fit results compared with a tolerance, since the old
+    # doctests failed precisely because they pinned 17 digits of an L-BFGS-B
+    # optimum.
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
 
       - name: Run doctests
-        run: python -m doctest levy/__init__.py -v | tail -n 1
+        run: python -m pytest --doctest-modules src/levy -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,14 +216,9 @@ jobs:
           print("shipped data present:", sorted(n for n in in_wheel if "/data/" in n))
           PY
 
-  legacy-doctests:
-    name: legacy doctests (known failing)
+  lint:
+    name: lint and docstrings
     runs-on: ubuntu-latest
-    # Informational, not a gate. These are the package's only pre-existing
-    # tests and 4 of them fail on current NumPy/SciPy for two independent
-    # reasons: last-digit drift in the L-BFGS-B optimum, and NumPy 2 rendering
-    # scalars as np.float64(...). Replacing them is the point of this PR.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -231,10 +226,45 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
+      - name: Install lint dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install numpy scipy
+          python -m pip install -e ".[lint]"
+
+      # Rules and per-file ignores live in pyproject.toml. `D` runs under the
+      # numpy convention, so this covers the grammar of every docstring.
+      - name: ruff
+        run: python -m ruff check .
+
+      # Complements ruff: numpydoc checks the docstring against the signature
+      # -- every parameter documented, in order, with a type, and a Returns
+      # section that matches. ruff cannot see that far.
+      - name: numpydoc
+        run: python -m numpydoc lint src/levy/*.py src/levy/_build/*.py
+
+  doctests:
+    name: doctests
+    runs-on: ubuntu-latest
+    # A real gate, replacing the informational "legacy doctests" job. The old
+    # one ran `python -m doctest levy/__init__.py`, which after the src/ layout
+    # move pointed at a path that no longer exists -- and, piped into `tail`,
+    # reported success while testing nothing.
+    #
+    # The examples are now written so they can be gated: values are rounded to
+    # 6 decimals and fit results compared with a tolerance, since the old
+    # doctests failed precisely because they pinned 17 digits of an L-BFGS-B
+    # optimum.
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
 
       - name: Run doctests
-        run: python -m doctest levy/__init__.py -v | tail -n 1
+        run: python -m pytest --doctest-modules src/levy -q

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #
@@ -14,7 +13,7 @@
 #
 import os
 import sys
-import unittest.mock as mock
+
 sys.path.insert(0, os.path.abspath('../../../'))
 
 # -- Project information -----------------------------------------------------
@@ -42,8 +41,15 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
-    'sphinx.ext.mathjax'
+    'sphinx.ext.mathjax',
+    # The docstrings are NumPy style now; without napoleon, autodoc renders the
+    # section underlines as literal text. The rest of the docs configuration
+    # (the sys.path level, the hardcoded version, the theme) is left alone here.
+    'sphinx.ext.napoleon',
 ]
+
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.9"
 authors = [
     { name = "Paul Harrison" },
     { name = "José María Miotto", email = "josemiotto@gmail.com" },
+    { name = "Esteban Carisimo" },
 ]
 maintainers = [{ name = "José María Miotto", email = "josemiotto@gmail.com" }]
 keywords = [
@@ -45,6 +46,9 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = ["pytest>=7", "build", "twine"]
+# Pinned to a minor series: ruff adds rules in every release, so an unpinned
+# floor turns a green branch red on somebody else's schedule.
+lint = ["ruff>=0.16,<0.17", "numpydoc>=1.6"]
 
 # Regenerates the lookup tables into a user cache directory. Replaces
 # `python -m levy build`, which wrote 24 MB into the installed package.
@@ -79,7 +83,49 @@ levy = ["data/*.npz", "data/manifest.json"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# So `pytest` works in a checkout with nothing installed, and so
+# `--doctest-modules src/levy` can find the package without a conftest of its
+# own. An installed copy still wins for `pip install`-based CI legs.
+pythonpath = ["src", "tests"]
 markers = [
     "slow: cases that take more than a moment",
     "build: regenerates lookup tables by quadrature; ~70s, run in its own CI job",
 ]
+
+# Docstring style. `D` is checked under the numpy convention, so ruff enforces
+# the section grammar; numpydoc (below) enforces that the sections agree with
+# the signature. Line length is 100 rather than 88: the numerical prose in
+# these docstrings, and the table in `_grid_index`, do not read well narrower.
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "D", "UP", "B", "SIM"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.per-file-ignores]
+# Test and script docstrings are notes to the next reader, not API reference;
+# the numpydoc grammar buys nothing there and `D` would only add noise.
+"tests/**" = ["D"]
+"scripts/**" = ["D"]
+"docs/**" = ["D"]   # Sphinx conf.py conventionally has no docstrings
+
+# numpydoc checks the docstring against the signature: every parameter present,
+# in order, with a type. Only `src/levy` is covered -- see the lint CI job.
+#
+# Listing a code after "all" turns it OFF. The four disabled here are the
+# maximalist ones:
+#   GL01  wants the summary on the line *after* the opening quotes, which is
+#         the exact opposite of ruff's D212. One of the two has to go.
+#   ES01  an extended summary on every private helper is padding.
+#   SA01  a See Also on every function is padding; the ones that help are there.
+#   EX01  an example on every function would mean examples for `_grid_shape`.
+[tool.numpydoc_validation]
+checks = ["all", "GL01", "ES01", "SA01", "EX01"]
+# __init__'s parameters are documented in the class docstring, per the numpydoc
+# style guide itself.
+exclude = ['\.__init__$']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.9"
 authors = [
     { name = "Paul Harrison" },
     { name = "José María Miotto", email = "josemiotto@gmail.com" },
+    { name = "Esteban Carisimo" },
 ]
 maintainers = [{ name = "José María Miotto", email = "josemiotto@gmail.com" }]
 keywords = [
@@ -45,6 +46,9 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = ["pytest>=7", "build", "twine"]
+# Pinned to a minor series: ruff adds rules in every release, so an unpinned
+# floor turns a green branch red on somebody else's schedule.
+lint = ["ruff>=0.16,<0.17", "numpydoc>=1.6"]
 
 # Regenerates the lookup tables into a user cache directory. Replaces
 # `python -m levy build`, which wrote 24 MB into the installed package.
@@ -79,7 +83,57 @@ levy = ["data/*.npz", "data/manifest.json"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# So `pytest` works in a checkout with nothing installed, and so
+# `--doctest-modules src/levy` can find the package without a conftest of its
+# own. Note that pytest *prepends* these, so the checkout's src/ takes
+# precedence over any separately installed copy -- which is what we want
+# here, and is harmless on the CI legs because those install with `-e`, so
+# the installed copy is this same tree.
+pythonpath = ["src", "tests"]
 markers = [
     "slow: cases that take more than a moment",
     "build: regenerates lookup tables by quadrature; ~70s, run in its own CI job",
 ]
+
+# Docstring style. `D` is checked under the numpy convention, so ruff enforces
+# the section grammar; numpydoc (below) enforces that the sections agree with
+# the signature. Line length is 100 rather than 88: the numerical prose in
+# these docstrings, and the table in `_grid_index`, do not read well narrower.
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+src = ["src", "tests"]
+# Named explicitly because ruff's default list excludes any directory called
+# `_build` -- meant for Sphinx output -- which silently skipped
+# src/levy/_build, the table generator. These are the directories that hold
+# generated or third-party files here.
+exclude = [".git", ".venv", "build", "dist", "docs/_build", "*.egg-info"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "D", "UP", "B", "SIM"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.per-file-ignores]
+# Test and script docstrings are notes to the next reader, not API reference;
+# the numpydoc grammar buys nothing there and `D` would only add noise.
+"tests/**" = ["D"]
+"scripts/**" = ["D"]
+"docs/**" = ["D"]   # Sphinx conf.py conventionally has no docstrings
+
+# numpydoc checks the docstring against the signature: every parameter present,
+# in order, with a type. Only `src/levy` is covered -- see the lint CI job.
+#
+# Listing a code after "all" turns it OFF. The four disabled here are the
+# maximalist ones:
+#   GL01  wants the summary on the line *after* the opening quotes, which is
+#         the exact opposite of ruff's D212. One of the two has to go.
+#   ES01  an extended summary on every private helper is padding.
+#   SA01  a See Also on every function is padding; the ones that help are there.
+#   EX01  an example on every function would mean examples for `_grid_shape`.
+[tool.numpydoc_validation]
+checks = ["all", "GL01", "ES01", "SA01", "EX01"]
+# __init__'s parameters are documented in the class docstring, per the numpydoc
+# style guide itself.
+exclude = ['\.__init__$']

--- a/scripts/compare_installs.py
+++ b/scripts/compare_installs.py
@@ -54,7 +54,7 @@ def probe(interpreter):
         [interpreter, "-c", PROBE], capture_output=True, text=True, timeout=600
     )
     if completed.returncode != 0:
-        raise SystemExit("{} failed:\n{}".format(interpreter, completed.stderr))
+        raise SystemExit(f"{interpreter} failed:\n{completed.stderr}")
     return json.loads(completed.stdout)
 
 

--- a/scripts/convert_tables_to_float32.py
+++ b/scripts/convert_tables_to_float32.py
@@ -37,16 +37,13 @@ def report(name, original):
         relative = np.abs(back - original) / np.maximum(np.abs(original), 1e-300)
     finite = np.isfinite(relative)
     print(
-        "  {:<12} max rel {:.3e}   p99.9 rel {:.3e}   max abs {:.3e}".format(
-            name,
-            relative[finite].max(),
-            np.percentile(relative[finite], 99.9),
-            np.abs(back - original).max(),
-        )
+        f"  {name:<12} max rel {relative[finite].max():.3e}"
+        f"   p99.9 rel {np.percentile(relative[finite], 99.9):.3e}"
+        f"   max abs {np.abs(back - original).max():.3e}"
     )
-    assert np.isfinite(converted).all(), "{} produced non-finite float32 values".format(name)
+    assert np.isfinite(converted).all(), f"{name} produced non-finite float32 values"
     positive_lost = int(((original > 0) & (converted == 0)).sum())
-    assert positive_lost == 0, "{}: {} positive values underflowed".format(name, positive_lost)
+    assert positive_lost == 0, f"{name}: {positive_lost} positive values underflowed"
     return converted
 
 
@@ -55,7 +52,7 @@ def main():
     parser.add_argument("--dry-run", action="store_true", help="measure but do not write")
     args = parser.parse_args()
 
-    print("reading tables from {}".format(levy.data_dir()))
+    print(f"reading tables from {levy.data_dir()}")
     pdf = levy._read_from_cache("pdf")
     cdf = levy._read_from_cache("cdf")
     lower = levy._read_from_cache("lower_limit")
@@ -80,13 +77,16 @@ def main():
     # arrays. Merging them was proposed on the unmerged `dev` branch (3ab5d8e).
     np.savez_compressed(os.path.join(OUT_DIR, "limits.npz"), lower=lower32, upper=upper32)
 
-    write_manifest(OUT_DIR, extra={"source": "converted from the float64 tables", "dtype": "float32"})
+    write_manifest(
+        OUT_DIR,
+        extra={"source": "converted from the float64 tables", "dtype": "float32"},
+    )
 
-    print("\nwrote {}".format(OUT_DIR))
+    print(f"\nwrote {OUT_DIR}")
     before = sum(
-        os.path.getsize(os.path.join(levy.ROOT, "{}.npz".format(n)))
+        os.path.getsize(os.path.join(levy.ROOT, f"{n}.npz"))
         for n in ("pdf", "cdf", "lower_limit", "upper_limit")
-        if os.path.exists(os.path.join(levy.ROOT, "{}.npz".format(n)))
+        if os.path.exists(os.path.join(levy.ROOT, f"{n}.npz"))
     )
     after = sum(
         os.path.getsize(os.path.join(OUT_DIR, f))
@@ -94,14 +94,14 @@ def main():
         if f.endswith(".npz")
     )
     if before:
-        print("  {:.2f} MB -> {:.2f} MB  ({:.0f}% smaller)".format(
-            before / 1e6, after / 1e6, 100 * (1 - after / before)))
+        print(f"  {before / 1e6:.2f} MB -> {after / 1e6:.2f} MB  "
+              f"({100 * (1 - after / before):.0f}% smaller)")
     else:
-        # `before` is a filtered sum, so it is 0 once the float64 originals
-        # are gone -- on a tree where this already ran, or one checked out
-        # after the conversion landed. Nothing to compare against.
-        print("  wrote {:.2f} MB (no float64 originals here to compare "
-              "against)".format(after / 1e6))
+        # `before` is a filtered sum, so it is 0 once the float64 originals are
+        # gone -- on a tree where this already ran, or one checked out after the
+        # conversion landed. Nothing to compare against.
+        print(f"  wrote {after / 1e6:.2f} MB "
+              "(no float64 originals here to compare against)")
     return 0
 
 

--- a/scripts/convert_tables_to_float32.py
+++ b/scripts/convert_tables_to_float32.py
@@ -46,16 +46,13 @@ def report(name, original):
         relative = np.abs(back - original) / np.maximum(np.abs(original), 1e-300)
     finite = np.isfinite(relative)
     print(
-        "  {:<12} max rel {:.3e}   p99.9 rel {:.3e}   max abs {:.3e}".format(
-            name,
-            relative[finite].max(),
-            np.percentile(relative[finite], 99.9),
-            np.abs(back - original).max(),
-        )
+        f"  {name:<12} max rel {relative[finite].max():.3e}"
+        f"   p99.9 rel {np.percentile(relative[finite], 99.9):.3e}"
+        f"   max abs {np.abs(back - original).max():.3e}"
     )
-    assert np.isfinite(converted).all(), "{} produced non-finite float32 values".format(name)
+    assert np.isfinite(converted).all(), f"{name} produced non-finite float32 values"
     positive_lost = int(((original > 0) & (converted == 0)).sum())
-    assert positive_lost == 0, "{}: {} positive values underflowed".format(name, positive_lost)
+    assert positive_lost == 0, f"{name}: {positive_lost} positive values underflowed"
     return converted
 
 
@@ -68,11 +65,11 @@ def main():
     args = parser.parse_args()
 
     for name in ("pdf", "cdf", "lower_limit", "upper_limit"):
-        if not os.path.exists(os.path.join(args.source, "{}.npz".format(name))):
-            print("no {}.npz in {}; point --source at the float64 archives".format(
-                name, args.source), file=sys.stderr)
+        if not os.path.exists(os.path.join(args.source, f"{name}.npz")):
+            print(f"no {name}.npz in {args.source}; point --source at the float64 archives",
+                  file=sys.stderr)
             return 2
-    print("reading float64 tables from {}".format(args.source))
+    print(f"reading float64 tables from {args.source}")
     pdf = load_legacy(args.source, "pdf")
     cdf = load_legacy(args.source, "cdf")
     lower = load_legacy(args.source, "lower_limit")
@@ -100,13 +97,16 @@ def main():
     # arrays. Merging them was proposed on the unmerged `dev` branch (3ab5d8e).
     _write_table(os.path.join(OUT_DIR, "limits.npz"), lower=lower32, upper=upper32)
 
-    write_manifest(OUT_DIR, extra={"source": "converted from the float64 tables", "dtype": "float32"})
+    write_manifest(
+        OUT_DIR,
+        extra={"source": "converted from the float64 tables", "dtype": "float32"},
+    )
 
-    print("\nwrote {}".format(OUT_DIR))
+    print(f"\nwrote {OUT_DIR}")
     before = sum(
-        os.path.getsize(os.path.join(args.source, "{}.npz".format(n)))
+        os.path.getsize(os.path.join(args.source, f"{n}.npz"))
         for n in ("pdf", "cdf", "lower_limit", "upper_limit")
-        if os.path.exists(os.path.join(args.source, "{}.npz".format(n)))
+        if os.path.exists(os.path.join(args.source, f"{n}.npz"))
     )
     after = sum(
         os.path.getsize(os.path.join(OUT_DIR, f))
@@ -114,14 +114,14 @@ def main():
         if f.endswith(".npz")
     )
     if before:
-        print("  {:.2f} MB -> {:.2f} MB  ({:.0f}% smaller)".format(
-            before / 1e6, after / 1e6, 100 * (1 - after / before)))
+        print(f"  {before / 1e6:.2f} MB -> {after / 1e6:.2f} MB  "
+              f"({100 * (1 - after / before):.0f}% smaller)")
     else:
-        # `before` is a filtered sum, so it is 0 once the float64 originals
-        # are gone -- on a tree where this already ran, or one checked out
-        # after the conversion landed. Nothing to compare against.
-        print("  wrote {:.2f} MB (no float64 originals here to compare "
-              "against)".format(after / 1e6))
+        # `before` is a filtered sum, so it is 0 once the float64 originals are
+        # gone -- on a tree where this already ran, or one checked out after the
+        # conversion landed. Nothing to compare against.
+        print(f"  wrote {after / 1e6:.2f} MB "
+              "(no float64 originals here to compare against)")
     return 0
 
 

--- a/src/levy/__init__.py
+++ b/src/levy/__init__.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -14,39 +13,35 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-"""
-This is a package for calculation of Levy stable distributions
-(probability density function and cumulative density function) and for
-fitting these distributions to data.
+r"""Calculation and maximum-likelihood fitting of Levy alpha-stable distributions.
 
-It operates by interpolating values from a table, as direct computation
-of these distributions requires a lengthy numerical integration. This
-interpolation scheme allows fast fitting of data by Maximum Likelihood.
+Direct computation of these distributions requires a lengthy numerical
+integration, so the package interpolates values from a precomputed table
+instead. That is what makes fitting by maximum likelihood fast enough to be
+practical.
 
-Notes on the parameters
------------------------
-- the parameters of the Levy stable distribution can be given in multiple ways: parametrizations.
-  Here, you can use both parametrizations 0 and 1, in the notation of Nolan
-  (http://fs2.american.edu/jpnolan/www/stable/stable.html) and
-  parametrizations A, B and M from Zolotarev (Chance and Stability).
+Notes
+-----
+**Parametrizations.** The parameters of a Levy stable distribution can be
+written down in several ways. Available here are 0 and 1 in the notation of
+Nolan [1]_, and M, A and B from Zolotarev [2]_.
 
-- Nolan parametrizations are a bit easier to understand.
-  Parametrization 0 is typically preferred for numerical calculations, and
-  has :math:`E(X)=\\delta_0-\\beta\\gamma\\tan(\\pi\\alpha/2)` while
-  parametrization 1 is preferred for better intuition, since :math:`E(X)=\\delta_1`.
+Nolan's are the easier two to reason about. Parametrization 0 is typically
+preferred for numerical calculations and has
+:math:`E(X)=\delta_0-\beta\gamma\tan(\pi\alpha/2)`, while 1 is preferred for
+intuition, since :math:`E(X)=\delta_1`.
 
-- parametrizations are dealt automatically by the module, you just need
-  to specify which one you want to use. Also, you can use the function
-  Parameters.convert to transform the parameters from one parametrization
-  to another. The module uses internally parametrization 0.
+Parametrizations are handled by the module; you only say which one you are
+using. :meth:`~levy.parametrization.Parameters.convert` moves a parameter array
+between any two of them. Internally everything runs in parametrization 0, which
+is what the lookup tables are built in.
 
-- pylevy does not support alpha values lower than 0.5.
+``alpha`` below 0.5 is not supported: the tables do not cover it, and passing a
+smaller value raises :exc:`ValueError`.
 
-Module layout
--------------
-The implementation used to be a single 800-line ``__init__.py``. It is now
-split by concern, and this module re-exports the whole public surface, so
-``import levy`` behaves exactly as before:
+**Module layout.** The implementation used to be a single 800-line
+``__init__.py``. It is now split by concern, and this module re-exports the
+whole public surface, so ``import levy`` behaves exactly as before:
 
 ===================== =========================================================
 ``constants``         grid geometry, fit bounds, parametrization metadata
@@ -58,6 +53,23 @@ split by concern, and this module re-exports the whole public surface, so
 ``sampling``          ``random``
 ``_build``            offline table generation (only the CLI imports it)
 ===================== =========================================================
+
+References
+----------
+.. [1] J. P. Nolan, "Univariate Stable Distributions", Springer, 2020.
+       https://edspace.american.edu/jpnolan/stable/
+.. [2] V. M. Zolotarev, "One-dimensional Stable Distributions", AMS, 1986.
+
+Examples
+--------
+>>> import numpy as np
+>>> import levy
+>>> np.round(levy.levy(np.array([1.0, 2.0]), 1.5, 0.0, cdf=True), 6)
+array([0.756342, 0.89496 ])
+>>> np.random.seed(0)
+>>> x = levy.random(1.5, 0.0, 0.0, 1.0, shape=(200,))
+>>> levy.fit_levy(x)[0]
+par=0, alpha=1.52, beta=-0.08, mu=0.05, sigma=0.99
 """
 
 from levy._logging import logger  # noqa: F401  (re-exported)
@@ -79,7 +91,7 @@ from levy.distribution import (  # noqa: F401  (re-exported)
     neglog_levy,
 )
 from levy.fitting import fit_levy  # noqa: F401  (re-exported)
-from levy.interpolation import _interpolate, _reflect
+from levy.interpolation import _interpolate, _reflect  # noqa: F401  (re-exported)
 from levy.parametrization import (  # noqa: F401  (re-exported)
     Parameters,
     _phi,
@@ -92,15 +104,15 @@ from levy.sampling import (  # noqa: F401  (re-exported)
     random,
 )
 from levy.tables import (  # noqa: F401  (re-exported)
+    _CDF_TOLERANCE,
+    _TABLE_NAMES,
     PACKAGED_DATA,
     ROOT,
-    _CDF_TOLERANCE,
     _data_cache,
     _has_complete_tables,
     _load_table,
     _read_from_cache,
     _repair_table,
-    _TABLE_NAMES,
     data_dir,
     user_cache_dir,
 )
@@ -142,7 +154,27 @@ _MOVED_TO_BUILD = {
 
 
 def __getattr__(name):
+    """Resolve the table-generation helpers that moved into ``levy._build``.
+
+    PEP 562 module-level lookup, so ``levy._calculate_levy`` still works
+    without ``import levy`` pulling in ``scipy.integrate``.
+
+    Parameters
+    ----------
+    name : str
+        Attribute being looked up.
+
+    Returns
+    -------
+    object
+        The relocated helper.
+
+    Raises
+    ------
+    AttributeError
+        For any other name, as a module lookup normally would.
+    """
     if name in _MOVED_TO_BUILD:
         from levy import _build
         return getattr(_build, _MOVED_TO_BUILD[name])
-    raise AttributeError('module {!r} has no attribute {!r}'.format(__name__, name))
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/src/levy/__init__.py
+++ b/src/levy/__init__.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -14,39 +13,35 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-"""
-This is a package for calculation of Levy stable distributions
-(probability density function and cumulative density function) and for
-fitting these distributions to data.
+r"""Calculation and maximum-likelihood fitting of Levy alpha-stable distributions.
 
-It operates by interpolating values from a table, as direct computation
-of these distributions requires a lengthy numerical integration. This
-interpolation scheme allows fast fitting of data by Maximum Likelihood.
+Direct computation of these distributions requires a lengthy numerical
+integration, so the package interpolates values from a precomputed table
+instead. That is what makes fitting by maximum likelihood fast enough to be
+practical.
 
-Notes on the parameters
------------------------
-- the parameters of the Levy stable distribution can be given in multiple ways: parametrizations.
-  Here, you can use both parametrizations 0 and 1, in the notation of Nolan
-  (http://fs2.american.edu/jpnolan/www/stable/stable.html) and
-  parametrizations A, B and M from Zolotarev (Chance and Stability).
+Notes
+-----
+**Parametrizations.** The parameters of a Levy stable distribution can be
+written down in several ways. Available here are 0 and 1 in the notation of
+Nolan [1]_, and M, A and B from Zolotarev [2]_.
 
-- Nolan parametrizations are a bit easier to understand.
-  Parametrization 0 is typically preferred for numerical calculations, and
-  has :math:`E(X)=\\delta_0-\\beta\\gamma\\tan(\\pi\\alpha/2)` while
-  parametrization 1 is preferred for better intuition, since :math:`E(X)=\\delta_1`.
+Nolan's are the easier two to reason about. Parametrization 0 is typically
+preferred for numerical calculations and has
+:math:`E(X)=\delta_0-\beta\gamma\tan(\pi\alpha/2)`, while 1 is preferred for
+intuition, since :math:`E(X)=\delta_1`.
 
-- parametrizations are dealt automatically by the module, you just need
-  to specify which one you want to use. Also, you can use the function
-  Parameters.convert to transform the parameters from one parametrization
-  to another. The module uses internally parametrization 0.
+Parametrizations are handled by the module; you only say which one you are
+using. :meth:`~levy.parametrization.Parameters.convert` moves a parameter array
+between any two of them. Internally everything runs in parametrization 0, which
+is what the lookup tables are built in.
 
-- pylevy does not support alpha values lower than 0.5.
+``alpha`` below 0.5 is not supported: the tables do not cover it, and passing a
+smaller value raises :exc:`ValueError`.
 
-Module layout
--------------
-The implementation used to be a single 800-line ``__init__.py``. It is now
-split by concern, and this module re-exports the whole public surface, so
-``import levy`` behaves exactly as before:
+**Module layout.** The implementation used to be a single 800-line
+``__init__.py``. It is now split by concern, and this module re-exports the
+whole public surface, so ``import levy`` behaves exactly as before:
 
 ===================== =========================================================
 ``constants``         grid geometry, fit bounds, parametrization metadata
@@ -58,6 +53,24 @@ split by concern, and this module re-exports the whole public surface, so
 ``sampling``          ``random``
 ``_build``            offline table generation (only the CLI imports it)
 ===================== =========================================================
+
+References
+----------
+.. [1] J. P. Nolan, "Univariate Stable Distributions", Springer, 2020.
+       https://edspace.american.edu/jpnolan/stable/
+.. [2] V. M. Zolotarev, "One-dimensional Stable Distributions", AMS, 1986.
+
+Examples
+--------
+>>> import numpy as np
+>>> import levy
+>>> np.round(levy.levy(np.array([1.0, 2.0]), 1.5, 0.0, cdf=True), 6)
+array([0.756342, 0.89496 ])
+>>> np.random.seed(0)
+>>> x = levy.random(1.5, 0.0, 0.0, 1.0, shape=(200,))
+>>> parameters, nll = levy.fit_levy(x)
+>>> bool(np.allclose(parameters.get('0'), [1.525, -0.078, 0.048, 0.986], atol=5e-3))
+True
 """
 
 from levy._logging import logger  # noqa: F401  (re-exported)
@@ -79,7 +92,7 @@ from levy.distribution import (  # noqa: F401  (re-exported)
     neglog_levy,
 )
 from levy.fitting import fit_levy  # noqa: F401  (re-exported)
-from levy.interpolation import _interpolate, _reflect
+from levy.interpolation import _interpolate, _reflect  # noqa: F401  (re-exported)
 from levy.parametrization import (  # noqa: F401  (re-exported)
     Parameters,
     _phi,
@@ -92,15 +105,15 @@ from levy.sampling import (  # noqa: F401  (re-exported)
     random,
 )
 from levy.tables import (  # noqa: F401  (re-exported)
+    _CDF_TOLERANCE,
+    _TABLE_NAMES,
     PACKAGED_DATA,
     ROOT,
-    _CDF_TOLERANCE,
     _data_cache,
     _has_complete_tables,
     _load_table,
     _read_from_cache,
     _repair_table,
-    _TABLE_NAMES,
     data_dir,
     user_cache_dir,
 )
@@ -142,7 +155,27 @@ _MOVED_TO_BUILD = {
 
 
 def __getattr__(name):
+    """Resolve the table-generation helpers that moved into ``levy._build``.
+
+    PEP 562 module-level lookup, so ``levy._calculate_levy`` still works
+    without ``import levy`` pulling in ``scipy.integrate``.
+
+    Parameters
+    ----------
+    name : str
+        Attribute being looked up.
+
+    Returns
+    -------
+    object
+        The relocated helper.
+
+    Raises
+    ------
+    AttributeError
+        For any other name, as a module lookup normally would.
+    """
     if name in _MOVED_TO_BUILD:
         from levy import _build
         return getattr(_build, _MOVED_TO_BUILD[name])
-    raise AttributeError('module {!r} has no attribute {!r}'.format(__name__, name))
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/src/levy/__main__.py
+++ b/src/levy/__main__.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Entry point for ``python -m levy``.
 
 This file did not exist before, which means ``python -m levy build`` -- the

--- a/src/levy/_build/__init__.py
+++ b/src/levy/_build/__init__.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Offline generation of the lookup tables pylevy interpolates from.
 
 Nothing here is needed to *use* the package. It is imported only by the

--- a/src/levy/_build/cli.py
+++ b/src/levy/_build/cli.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """``levy-tables``: regenerate the lookup tables.
 
     levy-tables build                    # into the user cache directory
@@ -21,24 +20,74 @@ logger = logging.getLogger("levy._build")
 
 
 def _parse_size(text):
+    """Parse an ``x,alpha,beta`` grid size from the command line.
+
+    Parameters
+    ----------
+    text : str
+        Three comma-separated integers, e.g. ``"200,76,101"``.
+
+    Returns
+    -------
+    tuple of int
+        The grid shape.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If there are not three of them, or any is below 8, which is the
+        smallest grid cubic interpolation can use.
+    """
     parts = [int(p) for p in text.split(",")]
     if len(parts) != 3:
-        raise argparse.ArgumentTypeError("expected three comma-separated integers, e.g. 200,76,101")
+        raise argparse.ArgumentTypeError(
+            "expected three comma-separated integers, e.g. 200,76,101")
     if any(p < 8 for p in parts):
-        raise argparse.ArgumentTypeError("each dimension must be at least 8 for cubic interpolation")
+        raise argparse.ArgumentTypeError(
+            "each dimension must be at least 8 for cubic interpolation")
     return tuple(parts)
 
 
 def _parse_what(text):
+    """Parse the comma-separated list of tables to build.
+
+    Parameters
+    ----------
+    text : str
+        Any of ``pdf``, ``cdf`` and ``limits``, comma-separated.
+
+    Returns
+    -------
+    list of str
+        The requested tables, in the order given.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If any name is not one of the three.
+    """
     allowed = {"pdf", "cdf", "limits"}
     what = [p.strip() for p in text.split(",") if p.strip()]
     unknown = set(what) - allowed
     if unknown:
-        raise argparse.ArgumentTypeError("unknown table(s): {}".format(", ".join(sorted(unknown))))
+        raise argparse.ArgumentTypeError(
+            "unknown table(s): {}".format(", ".join(sorted(unknown))))
     return what
 
 
 def build(args):
+    """Run the ``build`` subcommand.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed arguments: ``out``, ``size``, ``what`` and ``jobs``.
+
+    Returns
+    -------
+    int
+        Process exit status.
+    """
     from levy import data_dir
     from levy._build.tables import build_crossover_tables, build_density_tables, write_manifest
 
@@ -62,37 +111,65 @@ def build(args):
             return 2
         build_crossover_tables(out_dir, args.size, jobs=args.jobs, cdf_table=cdf_table)
 
-    manifest = write_manifest(out_dir, args.size, extra={"seconds": round(time.time() - started, 1)})
-    logger.info("Done in %.1fs. Manifest: %s", time.time() - started, os.path.join(out_dir, "manifest.json"))
+    manifest = write_manifest(
+        out_dir, args.size, extra={"seconds": round(time.time() - started, 1)})
+    logger.info("Done in %.1fs. Manifest: %s",
+                time.time() - started, os.path.join(out_dir, "manifest.json"))
     for name, entry in sorted(manifest["tables"].items()):
         logger.info("  %-12s %8.2f MB  %s", name, entry["bytes"] / 1e6, entry["sha256"][:16])
     return 0
 
 
 def where(args):
+    """Run the ``where`` subcommand, reporting which tables are in use.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed arguments. Unused; present for the subcommand dispatch.
+
+    Returns
+    -------
+    int
+        Process exit status.
+    """
     import levy
 
-    print("tables in use : {}".format(levy.data_dir()))
-    print("packaged      : {}".format(levy.PACKAGED_DATA))
-    print("user cache    : {}".format(levy.user_cache_dir()))
+    print(f"tables in use : {levy.data_dir()}")
+    print(f"packaged      : {levy.PACKAGED_DATA}")
+    print(f"user cache    : {levy.user_cache_dir()}")
     print("LEVY_DATA_DIR : {}".format(os.environ.get("LEVY_DATA_DIR", "(unset)")))
     directory = levy.data_dir()
     for name in sorted(os.listdir(directory)) if os.path.isdir(directory) else []:
         if not name.endswith((".npz", ".json")):
             continue
         size_mb = os.path.getsize(os.path.join(directory, name)) / 1e6
-        print("  {:<16} {:8.2f} MB".format(name, size_mb))
+        print(f"  {name:<16} {size_mb:8.2f} MB")
     return 0
 
 
 def main(argv=None):
+    """Entry point for the ``levy-tables`` console script.
+
+    Parameters
+    ----------
+    argv : sequence of str, optional
+        Command-line arguments. Read from ``sys.argv`` when omitted.
+
+    Returns
+    -------
+    int
+        Process exit status.
+    """
     parser = argparse.ArgumentParser(prog="levy-tables", description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("-v", "--verbose", action="store_true", help="verbose (DEBUG) logging")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="verbose (DEBUG) logging")
     subparsers = parser.add_subparsers(dest="command")
 
     build_parser = subparsers.add_parser("build", help="regenerate the lookup tables")
-    build_parser.add_argument("--out", help="output directory (default: the user cache directory)")
+    build_parser.add_argument(
+        "--out", help="output directory (default: the user cache directory)")
     build_parser.add_argument("--size", type=_parse_size, default=None,
                               help="grid as x,alpha,beta (default: 200,76,101)")
     build_parser.add_argument("--what", type=_parse_what, default=["pdf", "cdf", "limits"],

--- a/src/levy/_build/cli.py
+++ b/src/levy/_build/cli.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """``levy-tables``: regenerate the lookup tables.
 
     levy-tables build                    # into the user cache directory
@@ -21,20 +20,58 @@ logger = logging.getLogger("levy._build")
 
 
 def _parse_size(text):
+    """Parse an ``x,alpha,beta`` grid size from the command line.
+
+    Parameters
+    ----------
+    text : str
+        Three comma-separated integers, e.g. ``"200,76,101"``.
+
+    Returns
+    -------
+    tuple of int
+        The grid shape.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If there are not three of them, or any is below 8, which is the
+        smallest grid cubic interpolation can use.
+    """
     parts = [int(p) for p in text.split(",")]
     if len(parts) != 3:
-        raise argparse.ArgumentTypeError("expected three comma-separated integers, e.g. 200,76,101")
+        raise argparse.ArgumentTypeError(
+            "expected three comma-separated integers, e.g. 200,76,101")
     if any(p < 8 for p in parts):
-        raise argparse.ArgumentTypeError("each dimension must be at least 8 for cubic interpolation")
+        raise argparse.ArgumentTypeError(
+            "each dimension must be at least 8 for cubic interpolation")
     return tuple(parts)
 
 
 def _parse_what(text):
+    """Parse the comma-separated list of tables to build.
+
+    Parameters
+    ----------
+    text : str
+        Any of ``pdf``, ``cdf`` and ``limits``, comma-separated.
+
+    Returns
+    -------
+    list of str
+        The requested tables, in the order given.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If any name is not one of the three.
+    """
     allowed = {"pdf", "cdf", "limits"}
     what = [p.strip() for p in text.split(",") if p.strip()]
     unknown = set(what) - allowed
     if unknown:
-        raise argparse.ArgumentTypeError("unknown table(s): {}".format(", ".join(sorted(unknown))))
+        raise argparse.ArgumentTypeError(
+            "unknown table(s): {}".format(", ".join(sorted(unknown))))
     return what
 
 
@@ -47,13 +84,30 @@ _WRITES = {
 
 
 def _tables_left_over(out_dir, size, what):
-    """Return the tables in `out_dir` this run will not rewrite, that are not `size`.
+    """Find tables in `out_dir` that this run would leave at another size.
 
-    `data_dir()` takes a directory on the strength of which files exist, so a
-    partial rebuild at a new size would leave the untouched tables at the old
-    one and the set would be used together: the grid index comes from the
-    pdf's shape, and the other tables would be read with it. Refusing here
-    keeps a cache internally consistent by construction.
+    Parameters
+    ----------
+    out_dir : str
+        Directory the build writes to.
+    size : tuple of int
+        Grid shape being built.
+    what : list of str
+        The ``--what`` items, i.e. which tables this run rewrites.
+
+    Returns
+    -------
+    list of str
+        One description per offending file, ``"name is AxBxC"``; empty when
+        the directory holds nothing that would clash.
+
+    Notes
+    -----
+    ``data_dir()`` takes a directory on the strength of which files exist, so
+    a partial rebuild at a new size would leave the untouched tables at the
+    old one and the set would be used together: the grid index comes from
+    the pdf's shape, and the other tables would be read with it. Refusing
+    here keeps a cache internally consistent by construction.
     """
     import numpy as np
 
@@ -75,6 +129,18 @@ def _tables_left_over(out_dir, size, what):
 
 
 def build(args):
+    """Run the ``build`` subcommand.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed arguments: ``out``, ``size``, ``what`` and ``jobs``.
+
+    Returns
+    -------
+    int
+        Process exit status.
+    """
     from levy import data_dir
     from levy._build.tables import build_crossover_tables, build_density_tables, write_manifest
 
@@ -109,23 +175,37 @@ def build(args):
             logger.error("%s", error)
             return 2
 
-    manifest = write_manifest(out_dir, args.size, extra={"seconds": round(time.time() - started, 1)})
-    logger.info("Done in %.1fs. Manifest: %s", time.time() - started, os.path.join(out_dir, "manifest.json"))
+    manifest = write_manifest(
+        out_dir, args.size, extra={"seconds": round(time.time() - started, 1)})
+    logger.info("Done in %.1fs. Manifest: %s",
+                time.time() - started, os.path.join(out_dir, "manifest.json"))
     for name, entry in sorted(manifest["tables"].items()):
         logger.info("  %-12s %8.2f MB  %s", name, entry["bytes"] / 1e6, entry["sha256"][:16])
     return 0
 
 
 def where(args):
+    """Run the ``where`` subcommand, reporting which tables are in use.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed arguments. Unused; present for the subcommand dispatch.
+
+    Returns
+    -------
+    int
+        Process exit status.
+    """
     import levy
 
-    print("tables in use : {}".format(levy.data_dir()))
-    print("packaged      : {}".format(levy.PACKAGED_DATA))
-    print("user cache    : {}".format(levy.user_cache_dir()))
+    print(f"tables in use : {levy.data_dir()}")
+    print(f"packaged      : {levy.PACKAGED_DATA}")
+    print(f"user cache    : {levy.user_cache_dir()}")
     print("LEVY_DATA_DIR : {}".format(os.environ.get("LEVY_DATA_DIR", "(unset)")))
     directory = levy.data_dir()
     if not os.path.isdir(directory):
-        print("  {} is not a directory".format(directory))
+        print(f"  {directory} is not a directory")
         return 1
 
     # The required set, each marked present or MISSING, rather than whatever
@@ -145,23 +225,37 @@ def where(args):
     for name in expected + ["manifest.json"]:
         path = os.path.join(directory, name)
         if os.path.exists(path):
-            print("  {:<16} {:8.2f} MB".format(name, os.path.getsize(path) / 1e6))
+            print(f"  {name:<16} {os.path.getsize(path) / 1e6:8.2f} MB")
         elif name == "manifest.json":
-            print("  {:<16} (none: not built by levy-tables)".format(name))
+            print(f"  {name:<16} (none: not built by levy-tables)")
         else:
-            print("  {:<16} MISSING".format(name))
+            print(f"  {name:<16} MISSING")
             missing += 1
     return 1 if missing else 0
 
 
 def main(argv=None):
+    """Entry point for the ``levy-tables`` console script.
+
+    Parameters
+    ----------
+    argv : sequence of str, optional
+        Command-line arguments. Read from ``sys.argv`` when omitted.
+
+    Returns
+    -------
+    int
+        Process exit status.
+    """
     parser = argparse.ArgumentParser(prog="levy-tables", description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("-v", "--verbose", action="store_true", help="verbose (DEBUG) logging")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="verbose (DEBUG) logging")
     subparsers = parser.add_subparsers(dest="command")
 
     build_parser = subparsers.add_parser("build", help="regenerate the lookup tables")
-    build_parser.add_argument("--out", help="output directory (default: the user cache directory)")
+    build_parser.add_argument(
+        "--out", help="output directory (default: the user cache directory)")
     build_parser.add_argument("--size", type=_parse_size, default=None,
                               help="grid as x,alpha,beta (default: 200,76,101)")
     build_parser.add_argument("--what", type=_parse_what, default=["pdf", "cdf", "limits"],

--- a/src/levy/_build/quadrature.py
+++ b/src/levy/_build/quadrature.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Direct numerical evaluation of the Levy stable density, by quadrature.
 
 This is the ground truth the interpolation tables are built from, and the
@@ -17,23 +16,40 @@ __all__ = ["calculate_levy", "interpolated_levy"]
 
 
 def calculate_levy(x, alpha, beta, cdf=False):
-    """ Levy stable distribution by numerical integration.
+    """Evaluate the Levy stable distribution by numerical integration.
 
+    Parameters
+    ----------
+    x : float
+        Point to evaluate at, in tangent space: ``levy(2, 1.5, 0)`` corresponds
+        to ``calculate_levy(np.tan(2), 1.5, 0)``.
+    alpha : float
+        Index of stability.
+    beta : float
+        Skewness.
+    cdf : bool, default False
+        Return the cdf instead of the pdf.
+
+    Returns
+    -------
+    float
+        The density, or the distribution function, at `x`.
+
+    Notes
+    -----
     Used to build the lookup tables, and as the reference in accuracy tests.
-    Note that to evaluate at a 'true' x the tangent must be applied:
-    ``levy(2, 1.5, 0) == calculate_levy(np.tan(2), 1.5, 0)``.
+    "0" parametrization as per Nolan. The special case ``alpha == 1`` is
+    handled separately; because of an error in the numerical integration, its
+    lower limit is 1e-10 rather than 0.
 
-    "0" parametrization as per Nolan. The special case alpha == 1 is handled
-    separately; because of an error in the numerical integration, its lower
-    limit is 1e-10 rather than 0.
-
-    Known limitation: for alpha = 0.58, beta = -+0.74 and |x| near 0.0079 --
-    the two grid points closest to zero -- ``integrate.quad``'s oscillatory
-    routine fails and returns ~5.72e+307. Those are exactly the four unusable
-    cells in the shipped cdf.npz. The weight passed to quad is sin(x*u) or
-    cos(x*u), whose period grows without bound as x approaches zero, which is
-    where the routine breaks down. Callers building tables should validate the
-    result rather than trusting it; see levy._build.tables.
+    Known limitation: for ``alpha = 0.58``, ``beta = -+0.74`` and ``|x|`` near
+    0.0079 -- the two grid points closest to zero -- ``integrate.quad``'s
+    oscillatory routine fails and returns ~5.72e+307. Those are exactly the
+    four unusable cells in the shipped ``cdf.npz``. The weight passed to quad
+    is ``sin(x*u)`` or ``cos(x*u)``, whose period grows without bound as `x`
+    approaches zero, which is where the routine breaks down. Callers building
+    tables should validate the result rather than trusting it; see
+    :mod:`levy._build.tables`.
     """
     from scipy import integrate
 
@@ -80,11 +96,32 @@ def calculate_levy(x, alpha, beta, cdf=False):
 
 
 def interpolated_levy(x, alpha, beta, cdf=False, table=None):
-    """ Interpolate the table without replacing the tails.
+    """Interpolate the table without replacing the tails.
 
-    ``levy.levy`` splices the power-law asymptote onto the tails; this does not,
-    which is what the crossover search needs in order to find where the two
-    agree.
+    Parameters
+    ----------
+    x : array_like
+        Points to evaluate at, in real space; the arctangent is applied here.
+    alpha : float
+        Index of stability.
+    beta : float
+        Skewness.
+    cdf : bool, default False
+        Interpolate the cdf table instead of the pdf table.
+    table : ndarray, optional
+        Table to interpolate. Loaded from the cache when omitted, which is what
+        a table build in progress must *not* do.
+
+    Returns
+    -------
+    ndarray
+        Interpolated values, with no tail replacement.
+
+    Notes
+    -----
+    ``levy.levy`` splices the power-law asymptote onto the tails; this does
+    not, which is what the crossover search needs in order to find where the
+    two agree.
 
     May return slightly negative values: Catmull-Rom weights have negative
     lobes, so even a non-negative grid can interpolate below zero.

--- a/src/levy/_build/quadrature.py
+++ b/src/levy/_build/quadrature.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Direct numerical evaluation of the Levy stable density, by quadrature.
 
 This is the ground truth the interpolation tables are built from, and the
@@ -17,23 +16,44 @@ __all__ = ["calculate_levy", "interpolated_levy"]
 
 
 def calculate_levy(x, alpha, beta, cdf=False):
-    """ Levy stable distribution by numerical integration.
+    """Evaluate the Levy stable distribution by numerical integration.
 
+    Parameters
+    ----------
+    x : float
+        Point to evaluate at, on the real line -- the same coordinate
+        :func:`levy.distribution.levy` takes, so ``levy(2, 1.5, 0)``
+        corresponds to ``calculate_levy(2, 1.5, 0)``. The table builder
+        evaluates this at ``tan`` of each grid coordinate, which is how the
+        grid's arctan axis covers the whole line.
+    alpha : float
+        Index of stability.
+    beta : float
+        Skewness.
+    cdf : bool, default False
+        Return the cdf instead of the pdf.
+
+    Returns
+    -------
+    float
+        The density, or the distribution function, at `x`.
+
+    Notes
+    -----
     Used to build the lookup tables, and as the reference in accuracy tests.
-    Note that to evaluate at a 'true' x the tangent must be applied:
-    ``levy(2, 1.5, 0) == calculate_levy(np.tan(2), 1.5, 0)``.
+    "0" parametrization as per Nolan. The special case ``alpha == 1`` is
+    handled separately; because of an error in the numerical integration, its
+    lower limit is 1e-10 rather than 0.
 
-    "0" parametrization as per Nolan. The special case alpha == 1 is handled
-    separately; because of an error in the numerical integration, its lower
-    limit is 1e-10 rather than 0.
-
-    Known limitation: for alpha = 0.58, beta = -+0.74 and |x| near 0.0079 --
-    the two grid points closest to zero -- ``integrate.quad``'s oscillatory
-    routine fails and returns ~5.72e+307. Those are exactly the four unusable
-    cells in the shipped cdf.npz. The weight passed to quad is sin(x*u) or
-    cos(x*u), whose period grows without bound as x approaches zero, which is
-    where the routine breaks down. Callers building tables should validate the
-    result rather than trusting it; see levy._build.tables.
+    Known limitation: for ``alpha = 0.58``, ``beta = -0.74`` or ``+0.74``,
+    and ``|x|`` near 0.0079 -- the two grid points closest to zero --
+    ``integrate.quad``'s
+    oscillatory routine fails and returns ~5.72e+307. Those are exactly the
+    four unusable cells in the shipped ``cdf.npz``. The weight passed to quad
+    is ``sin(x*u)`` or ``cos(x*u)``, whose period grows without bound as `x`
+    approaches zero, which is where the routine breaks down. Callers building
+    tables should validate the result rather than trusting it; see
+    :mod:`levy._build.tables`.
     """
     from scipy import integrate
 
@@ -80,11 +100,32 @@ def calculate_levy(x, alpha, beta, cdf=False):
 
 
 def interpolated_levy(x, alpha, beta, cdf=False, table=None):
-    """ Interpolate the table without replacing the tails.
+    """Interpolate the table without replacing the tails.
 
-    ``levy.levy`` splices the power-law asymptote onto the tails; this does not,
-    which is what the crossover search needs in order to find where the two
-    agree.
+    Parameters
+    ----------
+    x : array_like
+        Points to evaluate at, in real space; the arctangent is applied here.
+    alpha : float
+        Index of stability.
+    beta : float
+        Skewness.
+    cdf : bool, default False
+        Interpolate the cdf table instead of the pdf table.
+    table : ndarray, optional
+        Table to interpolate. Loaded from the cache when omitted, which is what
+        a table build in progress must *not* do.
+
+    Returns
+    -------
+    ndarray
+        Interpolated values, with no tail replacement.
+
+    Notes
+    -----
+    ``levy.levy`` splices the power-law asymptote onto the tails; this does
+    not, which is what the crossover search needs in order to find where the
+    two agree.
 
     May return slightly negative values: Catmull-Rom weights have negative
     lobes, so even a non-negative grid can interpolate below zero.

--- a/src/levy/_build/tables.py
+++ b/src/levy/_build/tables.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Builders for the four lookup tables, with provenance and validation.
 
 Differences from the previous ``_make_dist_data_file`` / ``_make_limit_data_files``:
@@ -36,8 +35,20 @@ _CDF_BOUND = 1e-6
 
 
 def grid_axes(grid_size=None):
-    """ The x, alpha and beta axes of the lookup grid.
+    """Return the x, alpha and beta axes of the lookup grid.
 
+    Parameters
+    ----------
+    grid_size : tuple of int, optional
+        Shape to build. Defaults to the shipped ``levy.size``.
+
+    Returns
+    -------
+    list of ndarray
+        The three axes, in order.
+
+    Notes
+    -----
     x is stored in arctan space, so the grid covers the whole real line; the
     tables hold values at ``tan(x_axis)``.
     """
@@ -49,13 +60,43 @@ def grid_axes(grid_size=None):
 
 
 def _density_column(args):
-    """One (alpha, beta) column of the table. Top level, so it can be pickled."""
+    """Compute one (alpha, beta) column of the table.
+
+    Parameters
+    ----------
+    args : tuple
+        ``(alpha, beta, ts, cdf)``. Packed into a single argument, and defined
+        at module level, so that ``multiprocessing`` can pickle the call.
+
+    Returns
+    -------
+    ndarray
+        The column, one entry per point in ``ts``.
+    """
     alpha, beta, ts, cdf = args
     return np.array([calculate_levy(t, alpha, beta, cdf) for t in ts])
 
 
 def _validate_column(column, cdf, alpha, beta):
-    """Flag values quadrature could not compute, rather than storing them."""
+    """Replace values quadrature could not compute, rather than storing them.
+
+    Parameters
+    ----------
+    column : ndarray
+        One freshly computed column.
+    cdf : bool
+        Whether `column` is from the cdf table, which additionally has to lie
+        in ``[0, 1]``.
+    alpha, beta : float
+        Reported in the warning; not used in the check.
+
+    Returns
+    -------
+    column : ndarray
+        The column, with unusable cells filled in along x.
+    n_bad : int
+        How many cells were replaced.
+    """
     if cdf:
         bad = ~np.isfinite(column) | (column < -_CDF_BOUND) | (column > 1.0 + _CDF_BOUND)
     else:
@@ -86,6 +127,22 @@ def _validate_column(column, cdf, alpha, beta):
 
 
 def _map(function, items, jobs):
+    """Map `function` over `items`, in a process pool when `jobs` exceeds one.
+
+    Parameters
+    ----------
+    function : callable
+        Applied to each item. Must be picklable when `jobs` > 1.
+    items : sequence
+        The work list.
+    jobs : int
+        Worker processes. One or fewer runs in this process.
+
+    Yields
+    ------
+    object
+        Each result, in the order of `items`.
+    """
     if jobs and jobs > 1:
         from multiprocessing import Pool
         with Pool(jobs) as pool:
@@ -97,9 +154,23 @@ def _map(function, items, jobs):
 
 
 def build_density_tables(out_dir, grid_size=None, jobs=1, what=("pdf", "cdf")):
-    """ Generate pdf.npz and/or cdf.npz into `out_dir`.
+    """Generate pdf.npz and/or cdf.npz into `out_dir`.
 
-    Returns {name: (array, number_of_repaired_cells)}.
+    Parameters
+    ----------
+    out_dir : str
+        Directory to write into. Created if missing.
+    grid_size : tuple of int, optional
+        Shape to build. Defaults to the shipped ``levy.size``.
+    jobs : int, default 1
+        Worker processes. A full build is ~25 CPU-minutes.
+    what : sequence of {'pdf', 'cdf'}, default ('pdf', 'cdf')
+        Which densities to build.
+
+    Returns
+    -------
+    dict
+        ``{name: (array, number_of_repaired_cells)}``.
     """
     grid_size = tuple(grid_size or size)
     x_axis, alphas, betas = grid_axes(grid_size)
@@ -120,14 +191,25 @@ def build_density_tables(out_dir, grid_size=None, jobs=1, what=("pdf", "cdf")):
             table[:, i, j] = column
             if index % 500 == 0:
                 logger.info("  %d/%d columns", index, len(columns))
-        np.savez_compressed(os.path.join(out_dir, '{}.npz'.format(name)), table)
+        np.savez_compressed(os.path.join(out_dir, f'{name}.npz'), table)
         logger.info("Wrote %s.npz (%d cell(s) repaired)", name, repaired)
         results[name] = (table, repaired)
     return results
 
 
 def _crossover_cell(args):
-    """Where the power-law asymptote best matches the interpolated CDF."""
+    """Find where the power-law asymptote best matches the interpolated CDF.
+
+    Parameters
+    ----------
+    args : tuple
+        ``(alpha, beta, upper, table)``, packed so the call can be pickled.
+
+    Returns
+    -------
+    float
+        The crossover point, on the side selected by ``upper``.
+    """
     alpha, beta, upper, table = args
     n = 100000
     x1, x2 = -50.0, 1e4 - 50.0
@@ -145,10 +227,30 @@ def _crossover_cell(args):
 
 
 def build_crossover_tables(out_dir, grid_size=None, jobs=1, cdf_table=None):
-    """ Generate lower_limit.npz and upper_limit.npz into `out_dir`.
+    """Generate lower_limit.npz and upper_limit.npz into `out_dir`.
 
-    These say where levy() should stop interpolating and switch to the
-    power-law tail, so they depend on the CDF table and must be rebuilt after it.
+    Parameters
+    ----------
+    out_dir : str
+        Directory to write into. Created if missing.
+    grid_size : tuple of int, optional
+        Shape to build. Defaults to the shipped ``levy.size``.
+    jobs : int, default 1
+        Worker processes. A full build is ~30 CPU-minutes.
+    cdf_table : ndarray, optional
+        CDF table to search against. Read from the cache when omitted, which is
+        only correct if that table matches `grid_size`.
+
+    Returns
+    -------
+    dict
+        ``{'lower_limit': ndarray, 'upper_limit': ndarray}``.
+
+    Notes
+    -----
+    These say where :func:`levy.levy` should stop interpolating and switch to
+    the power-law tail, so they depend on the CDF table and must be rebuilt
+    after it.
     """
     from levy import _read_from_cache
 
@@ -179,14 +281,30 @@ def build_crossover_tables(out_dir, grid_size=None, jobs=1, cdf_table=None):
             limits[i, j] = value
             if index % 500 == 0:
                 logger.info("  %d/%d cells", index, len(cells))
-        np.savez_compressed(os.path.join(out_dir, '{}_limit.npz'.format(name)), limits)
-        results['{}_limit'.format(name)] = limits
+        np.savez_compressed(os.path.join(out_dir, f'{name}_limit.npz'), limits)
+        results[f'{name}_limit'] = limits
     return results
 
 
 def write_manifest(out_dir, grid_size=None, extra=None):
-    """ Record how the tables in `out_dir` were produced.
+    """Record how the tables in `out_dir` were produced.
 
+    Parameters
+    ----------
+    out_dir : str
+        Directory holding the tables. ``manifest.json`` is written here.
+    grid_size : tuple of int, optional
+        Shape the tables were built at. Defaults to the shipped ``levy.size``.
+    extra : dict, optional
+        Additional keys to merge into the manifest.
+
+    Returns
+    -------
+    dict
+        The manifest, as written.
+
+    Notes
+    -----
     Without this there is no way to tell what resolution a table was built at,
     which library versions produced it, or whether a file has been altered.
     """
@@ -198,7 +316,7 @@ def write_manifest(out_dir, grid_size=None, extra=None):
     # limits.npz that replaces them. Missing names are skipped below, so
     # listing all of them keeps the manifest correct across the change.
     for name in ('pdf', 'cdf', 'lower_limit', 'upper_limit', 'limits'):
-        path = os.path.join(out_dir, '{}.npz'.format(name))
+        path = os.path.join(out_dir, f'{name}.npz')
         if not os.path.exists(path):
             continue
         with open(path, 'rb') as handle:

--- a/src/levy/_build/tables.py
+++ b/src/levy/_build/tables.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Builders for the four lookup tables, with provenance and validation.
 
 Differences from the previous ``_make_dist_data_file`` / ``_make_limit_data_files``:
@@ -36,8 +35,20 @@ _CDF_BOUND = 1e-6
 
 
 def grid_axes(grid_size=None):
-    """ The x, alpha and beta axes of the lookup grid.
+    """Return the x, alpha and beta axes of the lookup grid.
 
+    Parameters
+    ----------
+    grid_size : tuple of int, optional
+        Shape to build. Defaults to the shipped ``levy.size``.
+
+    Returns
+    -------
+    list of ndarray
+        The three axes, in order.
+
+    Notes
+    -----
     x is stored in arctan space, so the grid covers the whole real line; the
     tables hold values at ``tan(x_axis)``.
     """
@@ -49,13 +60,45 @@ def grid_axes(grid_size=None):
 
 
 def _density_column(args):
-    """One (alpha, beta) column of the table. Top level, so it can be pickled."""
+    """Compute one (alpha, beta) column of the table.
+
+    Parameters
+    ----------
+    args : tuple
+        ``(alpha, beta, ts, cdf)``. Packed into a single argument, and defined
+        at module level, so that ``multiprocessing`` can pickle the call.
+
+    Returns
+    -------
+    ndarray
+        The column, one entry per point in ``ts``.
+    """
     alpha, beta, ts, cdf = args
     return np.array([calculate_levy(t, alpha, beta, cdf) for t in ts])
 
 
 def _validate_column(column, cdf, alpha, beta):
-    """Flag values quadrature could not compute, rather than storing them."""
+    """Replace values quadrature could not compute, rather than storing them.
+
+    Parameters
+    ----------
+    column : ndarray
+        One freshly computed column.
+    cdf : bool
+        Whether `column` is from the cdf table, which additionally has to lie
+        in ``[0, 1]``.
+    alpha, beta : float
+        Reported in the warning; not used in the check.
+
+    Returns
+    -------
+    column : ndarray
+        The column, with unusable cells filled in along x -- unless fewer
+        than two usable points remain, in which case it is returned as it
+        came, unfilled, after an ERROR log line saying so.
+    n_bad : int
+        How many cells were replaced.
+    """
     if cdf:
         bad = ~np.isfinite(column) | (column < -_CDF_BOUND) | (column > 1.0 + _CDF_BOUND)
     else:
@@ -88,11 +131,26 @@ def _validate_column(column, cdf, alpha, beta):
 
 
 def _map(function, items, jobs):
+    """Map `function` over `items`, in a process pool when `jobs` exceeds one.
+
+    Parameters
+    ----------
+    function : callable
+        Applied to each item. Must be picklable when `jobs` > 1.
+    items : sequence
+        The work list.
+    jobs : int
+        Worker processes. One or fewer runs in this process.
+
+    Yields
+    ------
+    object
+        Each result, in the order of `items`.
+    """
     if jobs and jobs > 1:
         from multiprocessing import Pool
         with Pool(jobs) as pool:
-            for result in pool.imap(function, items):
-                yield result
+            yield from pool.imap(function, items)
     else:
         for item in items:
             yield function(item)
@@ -134,9 +192,23 @@ def _write_table(path, *arrays, **named):
 
 
 def build_density_tables(out_dir, grid_size=None, jobs=1, what=("pdf", "cdf")):
-    """ Generate pdf.npz and/or cdf.npz into `out_dir`.
+    """Generate pdf.npz and/or cdf.npz into `out_dir`.
 
-    Returns {name: (array, number_of_repaired_cells)}.
+    Parameters
+    ----------
+    out_dir : str
+        Directory to write into. Created if missing.
+    grid_size : tuple of int, optional
+        Shape to build. Defaults to the shipped ``levy.size``.
+    jobs : int, default 1
+        Worker processes. A full build is ~25 CPU-minutes.
+    what : sequence of {'pdf', 'cdf'}, default ('pdf', 'cdf')
+        Which densities to build.
+
+    Returns
+    -------
+    dict
+        ``{name: (array, number_of_repaired_cells)}``.
     """
     grid_size = tuple(grid_size or size)
     x_axis, alphas, betas = grid_axes(grid_size)
@@ -157,14 +229,25 @@ def build_density_tables(out_dir, grid_size=None, jobs=1, what=("pdf", "cdf")):
             table[:, i, j] = column
             if index % 500 == 0:
                 logger.info("  %d/%d columns", index, len(columns))
-        _write_table(os.path.join(out_dir, '{}.npz'.format(name)), table)
+        _write_table(os.path.join(out_dir, f'{name}.npz'), table)
         logger.info("Wrote %s.npz (%d cell(s) repaired)", name, repaired)
         results[name] = (table, repaired)
     return results
 
 
 def _crossover_cell(args):
-    """Where the power-law asymptote best matches the interpolated CDF."""
+    """Find where the power-law asymptote best matches the interpolated CDF.
+
+    Parameters
+    ----------
+    args : tuple
+        ``(alpha, beta, upper, table)``, packed so the call can be pickled.
+
+    Returns
+    -------
+    float
+        The crossover point, on the side selected by ``upper``.
+    """
     alpha, beta, upper, table = args
     n = 100000
     x1, x2 = -50.0, 1e4 - 50.0
@@ -182,16 +265,44 @@ def _crossover_cell(args):
 
 
 def build_crossover_tables(out_dir, grid_size=None, jobs=1, cdf_table=None):
-    """ Generate limits.npz -- the `lower` and `upper` crossover arrays -- into `out_dir`.
+    """Generate limits.npz -- the crossover arrays ``lower`` and ``upper`` -- into `out_dir`.
 
-    These say where levy() should stop interpolating and switch to the
-    power-law tail, so they depend on the CDF table and must be rebuilt after it.
+    Parameters
+    ----------
+    out_dir : str
+        Directory to write into. Created if missing.
+    grid_size : tuple of int, optional
+        Shape to build. Defaults to the shipped ``levy.size``.
+    jobs : int, default 1
+        Worker processes. A full build is ~30 CPU-minutes.
+    cdf_table : ndarray, optional
+        CDF table to search against. When omitted, ``out_dir/cdf.npz`` is used
+        if it exists, else the table :func:`levy.tables.data_dir` currently
+        selects; whichever source, it must match `grid_size`.
+
+    Returns
+    -------
+    dict
+        ``{'lower_limit': ndarray, 'upper_limit': ndarray}``.
+
+    Raises
+    ------
+    ValueError
+        If the cdf table, from whichever source, is not `grid_size`: the
+        limits describe one particular table and must not be computed from
+        another.
+
+    Notes
+    -----
+    These say where :func:`levy.distribution.levy` should stop interpolating
+    and switch to the power-law tail, so they depend on the CDF table and must
+    be rebuilt after it.
 
     The two arrays go into one merged file, the layout the package ships. Any
-    lower_limit.npz / upper_limit.npz from an older build are removed at the
-    same time: the loader prefers the merged file, so a stale one left next to
-    freshly built split files would silently win -- and the reverse would leave
-    stale split files behind to confuse `levy-tables where`.
+    ``lower_limit.npz`` / ``upper_limit.npz`` from an older build are removed
+    at the same time: the loader prefers the merged file, so a stale one left
+    next to freshly built split files would silently win -- and the reverse
+    would leave stale split files behind to confuse ``levy-tables where``.
     """
     from levy import _read_from_cache
 
@@ -237,7 +348,7 @@ def build_crossover_tables(out_dir, grid_size=None, jobs=1, cdf_table=None):
             limits[i, j] = value
             if index % 500 == 0:
                 logger.info("  %d/%d cells", index, len(cells))
-        results['{}_limit'.format(name)] = limits
+        results[f'{name}_limit'] = limits
     _write_table(os.path.join(out_dir, 'limits.npz'),
                  lower=results['lower_limit'], upper=results['upper_limit'])
     for stale in ('lower_limit.npz', 'upper_limit.npz'):
@@ -249,8 +360,24 @@ def build_crossover_tables(out_dir, grid_size=None, jobs=1, cdf_table=None):
 
 
 def write_manifest(out_dir, grid_size=None, extra=None):
-    """ Record how the tables in `out_dir` were produced.
+    """Record how the tables in `out_dir` were produced.
 
+    Parameters
+    ----------
+    out_dir : str
+        Directory holding the tables. ``manifest.json`` is written here.
+    grid_size : tuple of int, optional
+        Shape the tables were built at. Defaults to the shipped ``levy.size``.
+    extra : dict, optional
+        Additional keys to merge into the manifest.
+
+    Returns
+    -------
+    dict
+        The manifest, as written.
+
+    Notes
+    -----
     Without this there is no way to tell what resolution a table was built at,
     which library versions produced it, or whether a file has been altered.
     """
@@ -262,7 +389,7 @@ def write_manifest(out_dir, grid_size=None, extra=None):
     # limits.npz that replaces them. Missing names are skipped below, so
     # listing all of them keeps the manifest correct across the change.
     for name in ('pdf', 'cdf', 'lower_limit', 'upper_limit', 'limits'):
-        path = os.path.join(out_dir, '{}.npz'.format(name))
+        path = os.path.join(out_dir, f'{name}.npz')
         if not os.path.exists(path):
             continue
         with open(path, 'rb') as handle:

--- a/src/levy/_logging.py
+++ b/src/levy/_logging.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by

--- a/src/levy/constants.py
+++ b/src/levy/constants.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -18,6 +17,23 @@
 
 Kept in one place so the interpolation grid, the fit bounds and the
 parametrization tables cannot drift apart.
+
+Attributes
+----------
+size : tuple of int
+    Shape ``(x, alpha, beta)`` of the lookup tables shipped with the package.
+par_bounds : tuple of tuple
+    Box constraints handed to L-BFGS-B, in parametrization-0 order
+    ``(alpha, beta, mu, sigma)``. ``(None, None)`` means unbounded.
+par_names : dict of {str: list of str}
+    Parameter names for each of the five parametrizations. The order is
+    positional and shared with ``par_bounds``.
+default : dict of {str: dict}
+    Starting value of each parameter, per parametrization, used for the
+    components a caller did not fix.
+f_bounds : dict of {str: dict}
+    Per-parameter callables that fold a proposed value back into its feasible
+    range; see :func:`levy.interpolation._reflect`.
 """
 
 import numpy as np
@@ -28,24 +44,49 @@ __all__ = ['size', 'par_bounds', 'par_names', 'default', 'f_bounds']
 
 # Some constants of the program.
 # Dimensions: 0 - x, 1 - alpha, 2 - beta
-size = (200, 76, 101)  # size of the grid (xs, alpha, beta)
-_lower = np.array([-np.pi / 2 * 0.999, 0.5, -1.0])  # lower limit of parameters
-_upper = np.array([np.pi / 2 * 0.999, 2.0, 1.0])  # upper limit of parameters
+#: Size of the grid (xs, alpha, beta).
+size = (200, 76, 101)
+#: Lower limit of the grid along each dimension. ``x`` is stored in tan-space,
+#: hence the ``pi/2`` bounds, shrunk by 0.999 to stay off the pole.
+_lower = np.array([-np.pi / 2 * 0.999, 0.5, -1.0])
+#: Upper limit of the grid along each dimension.
+_upper = np.array([np.pi / 2 * 0.999, 2.0, 1.0])
 
-par_bounds = ((_lower[1], _upper[1]), (_lower[2], _upper[2]), (None, None), (1e-6, 1e10))  # parameter bounds for fit.
-par_names = {  # names of the parameters
+#: Parameter bounds for the fit, in parametrization-0 order.
+par_bounds = (
+    (_lower[1], _upper[1]),   # alpha
+    (_lower[2], _upper[2]),   # beta
+    (None, None),             # mu
+    (1e-6, 1e10),             # sigma
+)
+
+#: Names of the parameters, per parametrization.
+par_names = {
     '0': ['alpha', 'beta', 'mu', 'sigma'],
     '1': ['alpha', 'beta', 'mu', 'sigma'],
     'M': ['alpha', 'beta', 'gamma', 'lambda'],
     'A': ['alpha', 'beta', 'gamma', 'lambda'],
-    'B': ['alpha', 'beta', 'gamma', 'lambda']
+    'B': ['alpha', 'beta', 'gamma', 'lambda'],
 }
-default = [1.5, 0.0, 0.0, 1.0]  # default values of the parameters for fit.
-default = {k: {par_names[k][i]: default[i] for i in range(4)} for k in par_names.keys()}
-f_bounds = [
+
+# Positional defaults and bound-folders, expanded below into the per-name dicts
+# that are the public surface. Named separately rather than rebound, so that
+# `default` and `f_bounds` mean one thing only.
+_default_values = [1.5, 0.0, 0.0, 1.0]
+_bound_folders = [
     lambda x: _reflect(x, *par_bounds[0]),
     lambda x: _reflect(x, *par_bounds[1]),
     lambda x: x,
-    lambda x: _reflect(x, *par_bounds[3])
+    lambda x: _reflect(x, *par_bounds[3]),
 ]
-f_bounds = {k: {par_names[k][i]: f_bounds[i] for i in range(4)} for k in par_names.keys()}
+
+#: Default value of each parameter for the fit, keyed by parametrization.
+default = {
+    par: {names[i]: _default_values[i] for i in range(4)}
+    for par, names in par_names.items()
+}
+#: Bound-folding callable for each parameter, keyed by parametrization.
+f_bounds = {
+    par: {names[i]: _bound_folders[i] for i in range(4)}
+    for par, names in par_names.items()
+}

--- a/src/levy/distribution.py
+++ b/src/levy/distribution.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -25,34 +24,56 @@ from levy.tables import _read_from_cache
 
 __all__ = ['levy', 'neglog_levy']
 
-def _check_alpha_beta(alpha, beta):
-    """ Rejects parameters the lookup tables do not cover.
 
+def _check_alpha_beta(alpha, beta):
+    """Reject parameters the lookup tables do not cover.
+
+    Parameters
+    ----------
+    alpha : float
+        Index of stability, must lie in ``[0.5, 2]``.
+    beta : float
+        Skewness, must lie in ``[-1, 1]``.
+
+    Raises
+    ------
+    ValueError
+        If either parameter falls outside the tabulated range.
+
+    Notes
+    -----
     Without this, `alpha` below 0.5 produced a *negative* grid index, which is
-    a perfectly valid Python index: alpha=0.4 gave -4 and silently returned the
-    limits for alpha ~ 1.94. The old `except IndexError` guard only fired for
-    positive overflow, so under-range values failed silently while over-range
-    values raised.
+    a perfectly valid Python index: ``alpha=0.4`` gave -4 and silently returned
+    the limits for ``alpha ~ 1.94``. The old ``except IndexError`` guard only
+    fired for positive overflow, so under-range values failed silently while
+    over-range values raised.
     """
     if not (_lower[1] <= alpha <= _upper[1]):
         raise ValueError(
-            'alpha must be in [{}, {}], got {!r}. pylevy interpolates from a '
-            'lookup table that does not cover values outside that range.'.format(
-                _lower[1], _upper[1], alpha)
+            f'alpha must be in [{_lower[1]}, {_upper[1]}], got {alpha!r}. pylevy '
+            'interpolates from a lookup table that does not cover values '
+            'outside that range.'
         )
     if not (_lower[2] <= beta <= _upper[2]):
         raise ValueError(
-            'beta must be in [{}, {}], got {!r}.'.format(_lower[2], _upper[2], beta)
+            f'beta must be in [{_lower[2]}, {_upper[2]}], got {beta!r}.'
         )
 
 
 def _grid_shape():
-    """ Shape of the tables actually loaded.
+    """Return the shape of the tables actually loaded.
 
-    `size` is the resolution of the tables shipped with the package, but
-    `levy-tables build --size` can produce others and $LEVY_DATA_DIR can point
-    at them. Anything that converts a parameter into a grid index has to use
-    the real shape, not the constant: doing otherwise raised
+    Returns
+    -------
+    tuple of int
+        Shape of the pdf table, ``(x, alpha, beta)``.
+
+    Notes
+    -----
+    ``size`` is the resolution of the tables shipped with the package, but
+    ``levy-tables build --size`` can produce others and ``$LEVY_DATA_DIR`` can
+    point at them. Anything that converts a parameter into a grid index has to
+    use the real shape, not the constant: doing otherwise raised
     ``IndexError: index 50 is out of bounds for axis 0 with size 10`` as soon
     as a table of a different resolution was loaded.
     """
@@ -60,19 +81,38 @@ def _grid_shape():
 
 
 def _grid_index(value, axis, length=None):
-    """ Index of the grid cell used to look up the tail-crossover limits.
+    """Return the index of the grid cell used to look up the crossover limits.
 
+    Parameters
+    ----------
+    value : float
+        Parameter value along `axis`.
+    axis : {0, 1, 2}
+        Grid dimension: x, alpha or beta.
+    length : int, optional
+        Number of nodes along `axis`. Read from the loaded table when omitted.
+
+    Returns
+    -------
+    int
+        Index in ``[0, length - 1]``.
+
+    Notes
+    -----
     This truncates rather than rounding to nearest, which is almost certainly
     unintentional -- but it is deliberately left alone here, because measuring
     it showed that switching to nearest-neighbour does *not* improve accuracy.
 
     Over 300 sampled points where the two strategies disagree, compared against
-    `_calculate_levy` ground truth:
+    ``calculate_levy`` ground truth:
 
-        strategy      median rel err    mean       p90
-        truncate        1.1164e-02    3.5488e-01  1.4560
-        round           1.4552e-02    4.3251e-01  1.4656
-        bilinear        1.0106e-02    2.9459e-01  0.9723
+    ==========  ================  ==========  ======
+    strategy    median rel err    mean        p90
+    ==========  ================  ==========  ======
+    truncate    1.1164e-02        3.5488e-01  1.4560
+    round       1.4552e-02        4.3251e-01  1.4656
+    bilinear    1.0106e-02        2.9459e-01  0.9723
+    ==========  ================  ==========  ======
 
     Rounding is closer to truth on only 43% of those points and is worse on
     the median. The error is dominated by the discontinuity between the
@@ -91,9 +131,29 @@ def _grid_index(value, axis, length=None):
     index = int((value - _lower[axis]) / span * (length - 1))
     return min(length - 1, max(0, index))
 
+
 def _approximate(x, alpha, beta, cdf=False):
+    """Evaluate the power-law tail approximation, valid far from the origin.
+
+    Parameters
+    ----------
+    x : ndarray
+        Standardised values, outside the tabulated crossover limits.
+    alpha : float
+        Index of stability.
+    beta : float
+        Skewness.
+    cdf : bool, default False
+        Return the cdf instead of the pdf.
+
+    Returns
+    -------
+    ndarray
+        The asymptotic pdf or cdf at `x`.
+    """
     mask = (x > 0)
-    values = np.sin(np.pi * alpha / 2.0) * gamma(alpha) / np.pi * np.power(np.abs(x), -alpha - 1.0)
+    values = np.sin(np.pi * alpha / 2.0) * gamma(alpha) / np.pi * np.power(
+        np.abs(x), -alpha - 1.0)
     values[mask] *= (1.0 + beta)
     values[~mask] *= (1.0 - beta)
     if cdf:
@@ -105,41 +165,56 @@ def _approximate(x, alpha, beta, cdf=False):
 
 
 def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
+    """Evaluate the Levy stable pdf or cdf, in parametrization 0.
+
+    The tabulated region is interpolated and the tails are replaced by their
+    analytical power-law approximation.
+
+    Parameters
+    ----------
+    x : array_like
+        Values where the function is evaluated. A scalar in gives a scalar out.
+    alpha : float
+        Index of stability, or characteristic exponent, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location, ``delta`` in Nolan's notation.
+    sigma : float, default 1.0
+        Scale, ``gamma`` in Nolan's notation. Note that `sigma` here
+        corresponds to ``sqrt(2) * sigma`` of the Normal distribution.
+    cdf : bool, default False
+        Return the cdf instead of the pdf.
+
+    Returns
+    -------
+    float or ndarray
+        Values of the pdf, or of the cdf when `cdf` is True, at `x`.
+
+    Raises
+    ------
+    ValueError
+        If `alpha` or `beta` lies outside the tabulated range; the lookup table
+        this interpolates from does not cover those values.
+
+    See Also
+    --------
+    neglog_levy : Negative log density, as used by the fit.
+    levy.parametrization.Parameters.convert : Move between parametrizations.
+
+    Notes
+    -----
+    Parametrization 0 is implied. To pass parameters from another one, convert
+    them first with :meth:`~levy.parametrization.Parameters.convert`.
+
+    Examples
+    --------
+    >>> x = np.array([1.0, 2.0, 3.0])
+    >>> np.round(levy(x, 1.5, 0.0, cdf=True), 6)
+    array([0.756342, 0.89496 , 0.948402])
+    >>> np.round(levy(x, 1.5, 0.0), 6)
+    array([0.202038, 0.084539, 0.031509])
     """
-    Levy distribution with the tail replaced by the analytical (power law) approximation.
-
-    `alpha` in [0.5, 2] is the index of stability, or characteristic exponent.
-    Values outside that range raise ValueError: the lookup table this
-    interpolates from does not cover them.
-    `beta` in [-1, 1] is the skewness. `mu` in the reals and `sigma` > 0 are the
-    location and scale of the distribution (corresponding to `delta` and `gamma`
-    in Nolan's notation; note that sigma in levy corresponds to sqrt(2) sigma
-    in the Normal distribution).
-    *cdf* is a Boolean that specifies if it returns the cdf instead of the pdf.
-
-    It uses parametrization 0 (to get it from another parametrization, convert).
-
-    Example:
-        >>> x = np.array([1, 2, 3])
-        >>> levy(x, 1.5, 0, cdf=True)
-        array([0.75634202, 0.89496045, 0.94840227])
-
-    :param x: values where the function is evaluated
-    :type x: :class:`~numpy.ndarray`
-    :param alpha: alpha
-    :type alpha: float
-    :param beta: beta
-    :type beta: float
-    :param mu: mu
-    :type mu: float
-    :param sigma: sigma
-    :type sigma: float
-    :param cdf: it specifies if you want the cdf instead of the pdf
-    :type cdf: bool
-    :return: values of the pdf (or cdf if parameter 'cdf' is set to True) at 'x'
-    :rtype: :class:`~numpy.ndarray`
-    """
-
     _check_alpha_beta(alpha, beta)
 
     loc = mu
@@ -173,30 +248,38 @@ def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
 
 
 def neglog_levy(x, alpha, beta, mu, sigma):
+    """Evaluate the negative log density of the Levy stable distribution.
+
+    Parameters
+    ----------
+    x : array_like
+        Values where the function is evaluated.
+    alpha : float
+        Index of stability, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float
+        Location.
+    sigma : float
+        Scale.
+
+    Returns
+    -------
+    float or ndarray
+        Values of ``-log(pdf(x))``.
+
+    Notes
+    -----
+    Parametrization 0 is implied. Small or negative densities are capped at
+    1e-100 before the logarithm to preserve sanity: the shipped pdf table holds
+    1845 slightly negative cells, quadrature noise around values that should be
+    zero, and without the cap they would come back as NaN in the middle of a
+    likelihood sum.
+
+    Examples
+    --------
+    >>> x = np.array([1.0, 2.0, 3.0])
+    >>> np.round(neglog_levy(x, 1.5, 0.0, 0.0, 1.0), 6)
+    array([1.599299, 2.470541, 3.457474])
     """
-    Interpolate negative log densities of the Levy stable distribution
-    specified by `alpha` and `beta`. Small/negative densities are capped
-    at 1e-100 to preserve sanity.
-
-    It uses parametrization 0 (to get it from another parametrization, convert).
-
-    Example:
-        >>> x = np.array([1,2,3])
-        >>> neglog_levy(x, 1.5, 0.0, 0.0, 1.0)
-        array([1.59929892, 2.47054131, 3.45747366])
-
-    :param x: values where the function is evaluated
-    :type x: :class:`~numpy.ndarray`
-    :param alpha: alpha
-    :type alpha: float
-    :param beta: beta
-    :type beta: float
-    :param mu: mu
-    :type mu: float
-    :param sigma: sigma
-    :type sigma: float
-    :return: values of -log(pdf(x))
-    :rtype: :class:`~numpy.ndarray`
-    """
-
     return -np.log(np.maximum(1e-100, levy(x, alpha, beta, mu, sigma)))

--- a/src/levy/distribution.py
+++ b/src/levy/distribution.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -25,34 +24,56 @@ from levy.tables import _read_from_cache
 
 __all__ = ['levy', 'neglog_levy']
 
-def _check_alpha_beta(alpha, beta):
-    """ Rejects parameters the lookup tables do not cover.
 
+def _check_alpha_beta(alpha, beta):
+    """Reject parameters the lookup tables do not cover.
+
+    Parameters
+    ----------
+    alpha : float
+        Index of stability, must lie in ``[0.5, 2]``.
+    beta : float
+        Skewness, must lie in ``[-1, 1]``.
+
+    Raises
+    ------
+    ValueError
+        If either parameter falls outside the tabulated range.
+
+    Notes
+    -----
     Without this, `alpha` below 0.5 produced a *negative* grid index, which is
-    a perfectly valid Python index: alpha=0.4 gave -4 and silently returned the
-    limits for alpha ~ 1.94. The old `except IndexError` guard only fired for
-    positive overflow, so under-range values failed silently while over-range
-    values raised.
+    a perfectly valid Python index: ``alpha=0.4`` gave -4 and silently returned
+    the limits for ``alpha ~ 1.94``. The old ``except IndexError`` guard only
+    fired for positive overflow, so under-range values failed silently while
+    over-range values raised.
     """
     if not (_lower[1] <= alpha <= _upper[1]):
         raise ValueError(
-            'alpha must be in [{}, {}], got {!r}. pylevy interpolates from a '
-            'lookup table that does not cover values outside that range.'.format(
-                _lower[1], _upper[1], alpha)
+            f'alpha must be in [{_lower[1]}, {_upper[1]}], got {alpha!r}. pylevy '
+            'interpolates from a lookup table that does not cover values '
+            'outside that range.'
         )
     if not (_lower[2] <= beta <= _upper[2]):
         raise ValueError(
-            'beta must be in [{}, {}], got {!r}.'.format(_lower[2], _upper[2], beta)
+            f'beta must be in [{_lower[2]}, {_upper[2]}], got {beta!r}.'
         )
 
 
 def _grid_shape():
-    """ Shape of the tables actually loaded.
+    """Return the shape of the tables actually loaded.
 
-    `size` is the resolution of the tables shipped with the package, but
-    `levy-tables build --size` can produce others and $LEVY_DATA_DIR can point
-    at them. Anything that converts a parameter into a grid index has to use
-    the real shape, not the constant: doing otherwise raised
+    Returns
+    -------
+    tuple of int
+        Shape of the pdf table, ``(x, alpha, beta)``.
+
+    Notes
+    -----
+    ``size`` is the resolution of the tables shipped with the package, but
+    ``levy-tables build --size`` can produce others and ``$LEVY_DATA_DIR`` can
+    point at them. Anything that converts a parameter into a grid index has to
+    use the real shape, not the constant: doing otherwise raised
     ``IndexError: index 50 is out of bounds for axis 0 with size 10`` as soon
     as a table of a different resolution was loaded.
     """
@@ -60,19 +81,38 @@ def _grid_shape():
 
 
 def _grid_index(value, axis, length=None):
-    """ Index of the grid cell used to look up the tail-crossover limits.
+    """Return the index of the grid cell used to look up the crossover limits.
 
+    Parameters
+    ----------
+    value : float
+        Parameter value along `axis`.
+    axis : {0, 1, 2}
+        Grid dimension: x, alpha or beta.
+    length : int, optional
+        Number of nodes along `axis`. Read from the loaded table when omitted.
+
+    Returns
+    -------
+    int
+        Index in ``[0, length - 1]``.
+
+    Notes
+    -----
     This truncates rather than rounding to nearest, which is almost certainly
     unintentional -- but it is deliberately left alone here, because measuring
     it showed that switching to nearest-neighbour does *not* improve accuracy.
 
     Over 300 sampled points where the two strategies disagree, compared against
-    `_calculate_levy` ground truth:
+    :func:`levy._build.quadrature.calculate_levy` ground truth:
 
-        strategy      median rel err    mean       p90
-        truncate        1.1164e-02    3.5488e-01  1.4560
-        round           1.4552e-02    4.3251e-01  1.4656
-        bilinear        1.0106e-02    2.9459e-01  0.9723
+    ==========  ================  ==========  ======
+    strategy    median rel err    mean        p90
+    ==========  ================  ==========  ======
+    truncate    1.1164e-02        3.5488e-01  1.4560
+    round       1.4552e-02        4.3251e-01  1.4656
+    bilinear    1.0106e-02        2.9459e-01  0.9723
+    ==========  ================  ==========  ======
 
     Rounding is closer to truth on only 43% of those points and is worse on
     the median. The error is dominated by the discontinuity between the
@@ -91,9 +131,29 @@ def _grid_index(value, axis, length=None):
     index = int((value - _lower[axis]) / span * (length - 1))
     return min(length - 1, max(0, index))
 
+
 def _approximate(x, alpha, beta, cdf=False):
+    """Evaluate the power-law tail approximation, valid far from the origin.
+
+    Parameters
+    ----------
+    x : ndarray
+        Standardised values, outside the tabulated crossover limits.
+    alpha : float
+        Index of stability.
+    beta : float
+        Skewness.
+    cdf : bool, default False
+        Return the cdf instead of the pdf.
+
+    Returns
+    -------
+    ndarray
+        The asymptotic pdf or cdf at `x`.
+    """
     mask = (x > 0)
-    values = np.sin(np.pi * alpha / 2.0) * gamma(alpha) / np.pi * np.power(np.abs(x), -alpha - 1.0)
+    values = np.sin(np.pi * alpha / 2.0) * gamma(alpha) / np.pi * np.power(
+        np.abs(x), -alpha - 1.0)
     values[mask] *= (1.0 + beta)
     values[~mask] *= (1.0 - beta)
     if cdf:
@@ -105,41 +165,56 @@ def _approximate(x, alpha, beta, cdf=False):
 
 
 def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
+    """Evaluate the Levy stable pdf or cdf, in parametrization 0.
+
+    The tabulated region is interpolated and the tails are replaced by their
+    analytical power-law approximation.
+
+    Parameters
+    ----------
+    x : array_like
+        Values where the function is evaluated. A scalar in gives a scalar out.
+    alpha : float
+        Index of stability, or characteristic exponent, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location, ``delta`` in Nolan's notation.
+    sigma : float, default 1.0
+        Scale, ``gamma`` in Nolan's notation. Note that `sigma` here
+        corresponds to ``sqrt(2) * sigma`` of the Normal distribution.
+    cdf : bool, default False
+        Return the cdf instead of the pdf.
+
+    Returns
+    -------
+    float or ndarray
+        Values of the pdf, or of the cdf when `cdf` is True, at `x`.
+
+    Raises
+    ------
+    ValueError
+        If `alpha` or `beta` lies outside the tabulated range; the lookup table
+        this interpolates from does not cover those values.
+
+    See Also
+    --------
+    neglog_levy : Negative log density, as used by the fit.
+    levy.parametrization.Parameters.convert : Move between parametrizations.
+
+    Notes
+    -----
+    Parametrization 0 is implied. To pass parameters from another one, convert
+    them first with :meth:`~levy.parametrization.Parameters.convert`.
+
+    Examples
+    --------
+    >>> x = np.array([1.0, 2.0, 3.0])
+    >>> np.round(levy(x, 1.5, 0.0, cdf=True), 6)
+    array([0.756342, 0.89496 , 0.948402])
+    >>> np.round(levy(x, 1.5, 0.0), 6)
+    array([0.202038, 0.084539, 0.031509])
     """
-    Levy distribution with the tail replaced by the analytical (power law) approximation.
-
-    `alpha` in [0.5, 2] is the index of stability, or characteristic exponent.
-    Values outside that range raise ValueError: the lookup table this
-    interpolates from does not cover them.
-    `beta` in [-1, 1] is the skewness. `mu` in the reals and `sigma` > 0 are the
-    location and scale of the distribution (corresponding to `delta` and `gamma`
-    in Nolan's notation; note that sigma in levy corresponds to sqrt(2) sigma
-    in the Normal distribution).
-    *cdf* is a Boolean that specifies if it returns the cdf instead of the pdf.
-
-    It uses parametrization 0 (to get it from another parametrization, convert).
-
-    Example:
-        >>> x = np.array([1, 2, 3])
-        >>> levy(x, 1.5, 0, cdf=True)
-        array([0.75634202, 0.89496045, 0.94840227])
-
-    :param x: values where the function is evaluated
-    :type x: :class:`~numpy.ndarray`
-    :param alpha: alpha
-    :type alpha: float
-    :param beta: beta
-    :type beta: float
-    :param mu: mu
-    :type mu: float
-    :param sigma: sigma
-    :type sigma: float
-    :param cdf: it specifies if you want the cdf instead of the pdf
-    :type cdf: bool
-    :return: values of the pdf (or cdf if parameter 'cdf' is set to True) at 'x'
-    :rtype: :class:`~numpy.ndarray`
-    """
-
     _check_alpha_beta(alpha, beta)
 
     loc = mu
@@ -173,30 +248,38 @@ def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
 
 
 def neglog_levy(x, alpha, beta, mu, sigma):
+    """Evaluate the negative log density of the Levy stable distribution.
+
+    Parameters
+    ----------
+    x : array_like
+        Values where the function is evaluated.
+    alpha : float
+        Index of stability, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float
+        Location.
+    sigma : float
+        Scale.
+
+    Returns
+    -------
+    float or ndarray
+        Values of ``-log(pdf(x))``.
+
+    Notes
+    -----
+    Parametrization 0 is implied. Small or negative densities are capped at
+    1e-100 before the logarithm to preserve sanity: the shipped pdf table holds
+    1845 slightly negative cells, quadrature noise around values that should be
+    zero, and without the cap they would come back as NaN in the middle of a
+    likelihood sum.
+
+    Examples
+    --------
+    >>> x = np.array([1.0, 2.0, 3.0])
+    >>> np.round(neglog_levy(x, 1.5, 0.0, 0.0, 1.0), 6)
+    array([1.599299, 2.470541, 3.457474])
     """
-    Interpolate negative log densities of the Levy stable distribution
-    specified by `alpha` and `beta`. Small/negative densities are capped
-    at 1e-100 to preserve sanity.
-
-    It uses parametrization 0 (to get it from another parametrization, convert).
-
-    Example:
-        >>> x = np.array([1,2,3])
-        >>> neglog_levy(x, 1.5, 0.0, 0.0, 1.0)
-        array([1.59929892, 2.47054131, 3.45747366])
-
-    :param x: values where the function is evaluated
-    :type x: :class:`~numpy.ndarray`
-    :param alpha: alpha
-    :type alpha: float
-    :param beta: beta
-    :type beta: float
-    :param mu: mu
-    :type mu: float
-    :param sigma: sigma
-    :type sigma: float
-    :return: values of -log(pdf(x))
-    :rtype: :class:`~numpy.ndarray`
-    """
-
     return -np.log(np.maximum(1e-100, levy(x, alpha, beta, mu, sigma)))

--- a/src/levy/fitting.py
+++ b/src/levy/fitting.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -25,45 +24,91 @@ from levy.parametrization import Parameters
 
 __all__ = ['fit_levy']
 
+
 def fit_levy(x, par='0', **kwargs):
+    """Estimate the parameters of a Levy stable distribution by maximum likelihood.
+
+    By default, searches all possible Levy stable distributions. The search can
+    be restricted by pinning one or more parameters, in any of the five
+    available parametrizations.
+
+    Parameters
+    ----------
+    x : array_like
+        Values to be fitted.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the fit is carried out and reported in.
+    **kwargs
+        Any of the names in ``par_names[par]``. A parameter given a value is
+        held fixed; one left out is estimated.
+
+    Returns
+    -------
+    parameters : levy.parametrization.Parameters
+        The fitted parameters.
+    nll : float
+        Negative log likelihood of the data under them.
+
+    See Also
+    --------
+    levy.distribution.neglog_levy : The objective being minimised.
+
+    Notes
+    -----
+    The objective is minimised with L-BFGS-B over the free parameters only, box
+    constrained by ``par_bounds``. Since the likelihood is evaluated by
+    interpolating a lookup table, the optimum's last digits are not portable
+    across platforms; compare fitted parameters with a tolerance, never for
+    equality.
+
+    Examples
+    --------
+    >>> from levy.sampling import random
+    >>> np.random.seed(0)
+    >>> x = random(1.5, 0.0, 0.0, 1.0, shape=(200,))
+
+    Fit a stable distribution to x:
+
+    >>> parameters, nll = fit_levy(x)
+    >>> parameters
+    par=0, alpha=1.52, beta=-0.08, mu=0.05, sigma=0.99
+    >>> bool(abs(nll - 402.3715) < 1e-3)
+    True
+
+    Fit a symmetric stable distribution to x:
+
+    >>> fit_levy(x, beta=0.0)[0]
+    par=0, alpha=1.53, beta=0.00, mu=0.03, sigma=0.99
+
+    Fit a symmetric distribution centred on zero:
+
+    >>> fit_levy(x, beta=0.0, mu=0.0)[0]
+    par=0, alpha=1.53, beta=0.00, mu=0.00, sigma=0.99
+
+    Fit a Cauchy distribution:
+
+    >>> fit_levy(x, alpha=1.0, beta=0.0)[0]
+    par=0, alpha=1.00, beta=0.00, mu=0.10, sigma=0.90
     """
-    Estimate parameters of Levy stable distribution given data x, using
-    Maximum Likelihood estimation.
-
-    By default, searches all possible Levy stable distributions. However
-    you may restrict the search by specifying the values of one or more
-    parameters. Notice that the parameters to be fixed can be chosen in
-    all the available parametrizations {0, 1, A, B, M}.
-
-    Examples:
-        >>> np.random.seed(0)
-        >>> x = random(1.5, 0, 0, 1, shape=(200,))
-        >>> fit_levy(x) # -- Fit a stable distribution to x
-        (par=0, alpha=1.52, beta=-0.08, mu=0.05, sigma=0.99, 402.37150603509247)
-
-        >>> fit_levy(x, beta=0.0) # -- Fit a symmetric stable distribution to x
-        (par=0, alpha=1.53, beta=0.00, mu=0.03, sigma=0.99, 402.43833088693725)
-
-        >>> fit_levy(x, beta=0.0, mu=0.0) # -- Fit a symmetric distribution centered on zero to x
-        (par=0, alpha=1.53, beta=0.00, mu=0.00, sigma=0.99, 402.4736618823546)
-
-        >>> fit_levy(x, alpha=1.0, beta=0.0) # -- Fit a Cauchy distribution to x
-        (par=0, alpha=1.00, beta=0.00, mu=0.10, sigma=0.90, 416.54249079255976)
-
-    :param x: values to be fitted
-    :type x: :class:`~numpy.ndarray`
-    :param par: parametrization
-    :type par: str
-    :return: a tuple with a `Parameters` object and the negative log likelihood of the data.
-    :rtype: tuple
-    """
-
     values = {par_name: kwargs.get(par_name) for par_name in par_names[par]}
 
     parameters = Parameters(par=par, **values)
     temp = Parameters(par=par, **values)
 
     def neglog_density(param):
+        """Total negative log likelihood at one point of the free subspace.
+
+        Parameters
+        ----------
+        param : ndarray
+            Values for the free parameters only, in ``parameters.variables``
+            order.
+
+        Returns
+        -------
+        float
+            The objective L-BFGS-B minimises.
+        """
         temp.x = param
         alpha, beta, mu, sigma = temp.get('0')
         return np.sum(neglog_levy(x, alpha, beta, mu, sigma))

--- a/src/levy/fitting.py
+++ b/src/levy/fitting.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -25,45 +24,101 @@ from levy.parametrization import Parameters
 
 __all__ = ['fit_levy']
 
+
 def fit_levy(x, par='0', **kwargs):
+    """Estimate the parameters of a Levy stable distribution by maximum likelihood.
+
+    By default, searches all possible Levy stable distributions. The search can
+    be restricted by pinning one or more parameters, in any of the five
+    available parametrizations.
+
+    Parameters
+    ----------
+    x : array_like
+        Values to be fitted.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the fit is carried out and reported in.
+    **kwargs
+        Any of the names in ``par_names[par]``. A parameter given a value is
+        held fixed; one left out is estimated.
+
+    Returns
+    -------
+    parameters : levy.parametrization.Parameters
+        The fitted parameters.
+    nll : float
+        Negative log likelihood of the data under them.
+
+    See Also
+    --------
+    levy.distribution.neglog_levy : The objective being minimised.
+
+    Notes
+    -----
+    The objective is minimised with L-BFGS-B over the free parameters only, box
+    constrained by ``par_bounds``. Since the likelihood is evaluated by
+    interpolating a lookup table, the optimum's last digits are not portable
+    across platforms; compare fitted parameters with a tolerance, never for
+    equality.
+
+    Examples
+    --------
+    The fitted values are compared with a tolerance rather than printed: the
+    optimum's last digits are not portable (see Notes), and this sample's
+    alpha happens to sit 3e-5 from a two-decimal rounding boundary, so even
+    a rounded repr would flip between platforms.
+
+    >>> from levy.sampling import random
+    >>> np.random.seed(0)
+    >>> x = random(1.5, 0.0, 0.0, 1.0, shape=(200,))
+
+    Fit a stable distribution to x:
+
+    >>> parameters, nll = fit_levy(x)
+    >>> parameters.par, parameters.pnames
+    ('0', ['alpha', 'beta', 'mu', 'sigma'])
+    >>> bool(np.allclose(parameters.get('0'), [1.525, -0.078, 0.048, 0.986], atol=5e-3))
+    True
+    >>> bool(abs(nll - 402.3715) / 402.3715 < 1e-3)  # the suite's fit tolerance
+    True
+
+    Fit a symmetric stable distribution to x:
+
+    >>> symmetric, _ = fit_levy(x, beta=0.0)
+    >>> bool(np.allclose(symmetric.get('0'), [1.529, 0.0, 0.028, 0.988], atol=5e-3))
+    True
+
+    Fit a symmetric distribution centred on zero:
+
+    >>> centred, _ = fit_levy(x, beta=0.0, mu=0.0)
+    >>> bool(np.allclose(centred.get('0'), [1.531, 0.0, 0.0, 0.990], atol=5e-3))
+    True
+
+    Fit a Cauchy distribution:
+
+    >>> cauchy, _ = fit_levy(x, alpha=1.0, beta=0.0)
+    >>> bool(np.allclose(cauchy.get('0'), [1.0, 0.0, 0.101, 0.901], atol=5e-3))
+    True
     """
-    Estimate parameters of Levy stable distribution given data x, using
-    Maximum Likelihood estimation.
-
-    By default, searches all possible Levy stable distributions. However
-    you may restrict the search by specifying the values of one or more
-    parameters. Notice that the parameters to be fixed can be chosen in
-    all the available parametrizations {0, 1, A, B, M}.
-
-    Examples:
-        >>> np.random.seed(0)
-        >>> x = random(1.5, 0, 0, 1, shape=(200,))
-        >>> fit_levy(x) # -- Fit a stable distribution to x
-        (par=0, alpha=1.52, beta=-0.08, mu=0.05, sigma=0.99, 402.37150603509247)
-
-        >>> fit_levy(x, beta=0.0) # -- Fit a symmetric stable distribution to x
-        (par=0, alpha=1.53, beta=0.00, mu=0.03, sigma=0.99, 402.43833088693725)
-
-        >>> fit_levy(x, beta=0.0, mu=0.0) # -- Fit a symmetric distribution centered on zero to x
-        (par=0, alpha=1.53, beta=0.00, mu=0.00, sigma=0.99, 402.4736618823546)
-
-        >>> fit_levy(x, alpha=1.0, beta=0.0) # -- Fit a Cauchy distribution to x
-        (par=0, alpha=1.00, beta=0.00, mu=0.10, sigma=0.90, 416.54249079255976)
-
-    :param x: values to be fitted
-    :type x: :class:`~numpy.ndarray`
-    :param par: parametrization
-    :type par: str
-    :return: a tuple with a `Parameters` object and the negative log likelihood of the data.
-    :rtype: tuple
-    """
-
     values = {par_name: kwargs.get(par_name) for par_name in par_names[par]}
 
     parameters = Parameters(par=par, **values)
     temp = Parameters(par=par, **values)
 
     def neglog_density(param):
+        """Total negative log likelihood at one point of the free subspace.
+
+        Parameters
+        ----------
+        param : ndarray
+            Values for the free parameters only, in ``parameters.variables``
+            order.
+
+        Returns
+        -------
+        float
+            The objective L-BFGS-B minimises.
+        """
         temp.x = param
         alpha, beta, mu, sigma = temp.get('0')
         return np.sum(neglog_levy(x, alpha, beta, mu, sigma))

--- a/src/levy/interpolation.py
+++ b/src/levy/interpolation.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -25,15 +24,49 @@ import numpy as np
 
 __all__ = ['_interpolate', '_reflect']
 
-def _reflect(x, lower, upper):
-    """ Folds a value back inside the bounds, reflecting at each edge.
 
-    The in-bounds case returns x unchanged and bit-identical, which is what
+def _reflect(x, lower, upper):
+    """Fold a value back inside the bounds, reflecting at each edge.
+
+    Parameters
+    ----------
+    x : float
+        The value to fold.
+    lower : float
+        Lower bound, inclusive.
+    upper : float
+        Upper bound, inclusive.
+
+    Returns
+    -------
+    float
+        ``x`` unchanged when it is already inside ``[lower, upper]``, otherwise
+        the point reached by reflecting it off the two edges. A zero span
+        collapses to ``lower``.
+
+    Raises
+    ------
+    ValueError
+        If ``upper`` lies below ``lower``. Silently returning ``lower`` there
+        would hide a caller bug; the fixed bound boxes never produce it.
+
+    Notes
+    -----
+    The in-bounds case returns ``x`` unchanged and bit-identical, which is what
     happens on essentially every call: L-BFGS-B already respects the bounds it
     is given. Out of bounds, the fold is computed in closed form rather than by
-    repeated reflection, which used to be an unbounded `while 1:` loop -- with
-    the sigma bounds (1e-6, 1e10), reflecting 1e30 needs ~1e20 iterations and
-    never returns in practice.
+    repeated reflection, which used to be an unbounded ``while 1:`` loop --
+    with the sigma bounds ``(1e-6, 1e10)``, reflecting ``1e30`` needs ~1e20
+    iterations and never returns in practice.
+
+    Examples
+    --------
+    >>> _reflect(0.5, 0.0, 1.0)
+    0.5
+    >>> _reflect(1.25, 0.0, 1.0)   # 0.25 past the top edge, so 0.25 back down
+    0.75
+    >>> _reflect(-0.25, 0.0, 1.0)
+    0.25
     """
     if lower <= x <= upper:
         return x
@@ -41,7 +74,7 @@ def _reflect(x, lower, upper):
     span = upper - lower
     if span < 0:
         raise ValueError(
-            "reflection bounds are reversed: lower={}, upper={}".format(lower, upper)
+            f"reflection bounds are reversed: lower={lower}, upper={upper}"
         )
     if span == 0:
         return lower
@@ -51,7 +84,49 @@ def _reflect(x, lower, upper):
 
 
 def _interpolate(points, grid, lower, upper):
-    """ Perform multi-dimensional Catmull-Rom cubic interpolation. """
+    """Perform multi-dimensional Catmull-Rom cubic interpolation.
+
+    Parameters
+    ----------
+    points : ndarray
+        Coordinates to evaluate at, shaped ``(..., ndim)``. The last axis
+        indexes the dimension and must match the rank of ``grid``.
+    grid : ndarray
+        Samples of the function on a regular ``ndim``-dimensional lattice.
+    lower : ndarray
+        Coordinate of the first grid node along each dimension, shape
+        ``(ndim,)``.
+    upper : ndarray
+        Coordinate of the last grid node along each dimension, shape
+        ``(ndim,)``.
+
+    Returns
+    -------
+    ndarray
+        Interpolated values, shaped like ``points`` without its last axis.
+
+    Notes
+    -----
+    Catmull-Rom takes its tangents from centred differences, which are exact
+    for a quadratic but not for a cubic; it therefore reproduces quadratics to
+    machine precision. Indices are clamped at the edges, so points outside
+    ``[lower, upper]`` are extrapolated from the boundary cell rather than
+    raising.
+
+    The accumulator is ``float64`` regardless of the dtype of ``grid``. That is
+    what lets the shipped tables be stored as ``float32`` without changing a
+    line here: the weights promote the gathered values on multiplication.
+
+    Examples
+    --------
+    Sampling ``f(t) = t**2`` on five nodes over ``[0, 4]`` and asking for a
+    point that is not a node reproduces the quadratic exactly:
+
+    >>> grid = np.array([0.0, 1.0, 4.0, 9.0, 16.0])
+    >>> points = np.array([[2.5]])
+    >>> np.round(_interpolate(points, grid, np.array([0.0]), np.array([4.0])), 12)
+    array([6.25])
+    """
     point_shape = np.shape(points)[:-1]
     points = np.reshape(points, (np.multiply.reduce(point_shape), np.shape(points)[-1]))
 
@@ -78,8 +153,8 @@ def _interpolate(points, grid, lower, upper):
         ravel_offset = 0
         for j in range(dims):
             n = (i >> (j * 2)) % 4
-            ravel_offset = ravel_offset * grid_shape[j] + np.maximum(0, np.minimum(grid_shape[j] - 1, floors[:, j] +
-                                                                                   (n - 1)))
+            ravel_offset = ravel_offset * grid_shape[j] + np.maximum(
+                0, np.minimum(grid_shape[j] - 1, floors[:, j] + (n - 1)))
             weights *= weighters[n][:, j]
 
         result += weights * np.take(ravel_grid, ravel_offset)

--- a/src/levy/parametrization.py
+++ b/src/levy/parametrization.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -18,6 +17,18 @@
 
 Nolan 0 and 1, Zolotarev M, A and B. Everything is routed through
 parametrization 0, which is what the lookup tables are built in.
+
+Attributes
+----------
+convert_to_par0 : dict of {str: callable}
+    Maps a parameter array from the named parametrization into 0.
+convert_from_par0 : dict of {str: callable}
+    Maps a parameter array from parametrization 0 into the named one.
+
+References
+----------
+.. [1] J. P. Nolan, "Univariate Stable Distributions", Springer, 2020.
+.. [2] V. M. Zolotarev, "One-dimensional Stable Distributions", AMS, 1986.
 """
 
 import numpy as np
@@ -27,12 +38,38 @@ from levy.constants import default, f_bounds, par_names
 
 __all__ = ['Parameters', 'convert_to_par0', 'convert_from_par0']
 
+
 def _psi(alpha):
+    """Return Zolotarev's psi, the half-turn used by parametrization B.
+
+    Parameters
+    ----------
+    alpha : float or ndarray
+        Index of stability.
+
+    Returns
+    -------
+    float or ndarray
+        ``pi / 2 * (alpha - 1 - sign(alpha - 1))``.
+    """
     return np.pi / 2 * (alpha - 1 - np.sign(alpha - 1))
 
 
 def _phi(alpha, beta):
-    """ Common function. """
+    """Return the skewness term shared by every parametrization change.
+
+    Parameters
+    ----------
+    alpha : float or ndarray
+        Index of stability.
+    beta : float or ndarray
+        Skewness.
+
+    Returns
+    -------
+    float or ndarray
+        ``beta * tan(pi * alpha / 2)``, which diverges as `alpha` approaches 1.
+    """
     return beta * np.tan(np.pi * alpha / 2.0)
 
 
@@ -93,39 +130,73 @@ convert_from_par0 = {
 }
 
 
-class Parameters(object):
-    """
-    This class is a wrap for the parameters; it works such that if we fit
-    fixing one or more parameters, the optimization only acts on the other
-    (the key thing here is the setter).
-    The only useful function to be used directly is `convert`, which allows
-    to transform parameters from one parametrization to another.
-    Available parametrizations are {0, 1, A, B, M}.
+class Parameters:
+    """A parameter vector that knows which of its components are free.
+
+    Fitting with one or more parameters held fixed works by letting the
+    optimizer see only the free components: :attr:`x` reads and writes that
+    subvector, and the setter folds each proposed value back into its feasible
+    range. The only method generally useful on its own is :meth:`convert`.
+
+    Parameters
+    ----------
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the values are given in.
+    **kwargs
+        One entry per name in ``par_names[par]``. ``None`` marks a free
+        parameter, which starts from its default; anything else fixes it.
+
+    Attributes
+    ----------
+    par : str
+        The parametrization in use.
+    pnames : list of str
+        Parameter names, in positional order.
+    variables : list of int
+        Positions of the free parameters.
+    fixed : list of int
+        Positions of the fixed parameters.
+    fixed_values : list
+        The values those fixed positions were pinned to.
+
+    Examples
+    --------
+    >>> p = Parameters(par='0', alpha=1.5, beta=None, mu=0.0, sigma=None)
+    >>> p.variables
+    [1, 3]
+    >>> p.x
+    array([0., 1.])
     """
 
     @classmethod
     def convert(cls, pars, par_in, par_out):
-        """
-        Use to convert a parameter array from one parametrization to another.
+        """Convert a parameter array from one parametrization to another.
 
-        Examples:
-            >>> a = np.array([1.6, 0.5, 0.3, 1.2])
-            >>> b = Parameters.convert(a, '1', 'B')
-            >>> b
-            array([1.6       , 0.55457302, 0.2460079 , 1.4243171 ])
-            >>> c = Parameters.convert(b, 'B', '1')
-            >>> c
-            array([1.6, 0.5, 0.3, 1.2])
-            >>> np.testing.assert_allclose(a, c)
+        Parameters
+        ----------
+        pars : ndarray
+            Array of parameters to be converted.
+        par_in : {'0', '1', 'M', 'A', 'B'}
+            Parametrization of the input array.
+        par_out : {'0', '1', 'M', 'A', 'B'}
+            Parametrization of the output array.
 
-        :param pars: array of parameters to be converted
-        :type pars: :class:`~numpy.ndarray`
-        :param par_in: parametrization of the input array
-        :type par_in: str
-        :param par_out: parametrization of the output array
-        :type par_out: str
-        :return: array of parameters in the desired parametrization
-        :rtype: :class:`~numpy.ndarray`
+        Returns
+        -------
+        ndarray
+            Array of parameters in the desired parametrization. `pars` itself
+            is returned when the two parametrizations coincide.
+
+        Examples
+        --------
+        >>> a = np.array([1.6, 0.5, 0.3, 1.2])
+        >>> b = Parameters.convert(a, '1', 'B')
+        >>> np.round(b, 6)
+        array([1.6     , 0.554573, 0.246008, 1.424317])
+        >>> c = Parameters.convert(b, 'B', '1')
+        >>> np.round(c, 6)
+        array([1.6, 0.5, 0.3, 1.2])
+        >>> np.testing.assert_allclose(a, c)
         """
         res = pars
         if par_out != par_in:
@@ -137,40 +208,91 @@ class Parameters(object):
     def __init__(self, par='0', **kwargs):
         self.par = par
         self.pnames = par_names[self.par]
-        self._x = np.array([default[par][k] if kwargs[k] is None else kwargs[k] for k in self.pnames])
+        self._x = np.array(
+            [default[par][k] if kwargs[k] is None else kwargs[k] for k in self.pnames])
         self.variables = [i for i, k in enumerate(self.pnames) if kwargs[k] is None]
         self.fixed = [i for i, k in enumerate(self.pnames) if kwargs[k] is not None]
-        self.fixed_values = [kwargs[k] for i, k in enumerate(self.pnames) if kwargs[k] is not None]
+        self.fixed_values = [kwargs[k] for k in self.pnames if kwargs[k] is not None]
 
     def get(self, par_out=None):
-        """
-        Same as `convert` but using from within the Parameter object.
+        """Return the full parameter vector, optionally in another parametrization.
 
-        Examples:
-            >>> p = Parameters(par='1', alpha=1.5, beta=0.5, mu=0, sigma=1.2)  # to convert
-            >>> p.get('B')  # returns the parameters in the parametrization B
-            array([1.5       , 0.59033447, 0.03896531, 1.46969385])
+        Parameters
+        ----------
+        par_out : {'0', '1', 'M', 'A', 'B'}, optional
+            Parametrization to return. Defaults to the object's own.
 
+        Returns
+        -------
+        ndarray
+            All four parameters, fixed and free alike.
+
+        Examples
+        --------
+        >>> p = Parameters(par='1', alpha=1.5, beta=0.5, mu=0, sigma=1.2)
+        >>> np.round(p.get('B'), 6)   # the same distribution, written in B
+        array([1.5     , 0.590334, 0.038965, 1.469694])
         """
         if par_out is None:
             par_out = self.par
         return Parameters.convert(self._x, self.par, par_out)
 
     def __str__(self):
-        txt = ', '.join(['{{0[{0}]}}: {{1[{1}]:.2f}}'.format(i, i) for i in range(4)])
-        txt += '. Parametrization: {2}.'
-        return txt.format(self.pnames, self.get(), self.par)
+        """Render the parameters and their parametrization, for humans.
+
+        Returns
+        -------
+        str
+            Formatted as ``"alpha: 1.50, ... . Parametrization: 1."``.
+        """
+        body = ', '.join(
+            f'{name}: {value:.2f}' for name, value in zip(self.pnames, self.get()))
+        return f'{body}. Parametrization: {self.par}.'
 
     def __repr__(self):
-        txt = 'par={2}, ' + ', '.join(['{{0[{0}]}}={{1[{1}]:.2f}}'.format(i, i) for i in range(4)])
-        return txt.format(self.pnames, self.get(), self.par)
+        """Render the parametrization and the parameters, keyword-style.
+
+        Returns
+        -------
+        str
+            Formatted as ``"par=1, alpha=1.50, beta=0.50, ..."``.
+        """
+        body = ', '.join(
+            f'{name}={value:.2f}' for name, value in zip(self.pnames, self.get()))
+        return f'par={self.par}, {body}'
 
     @property
     def x(self):
+        """Get the free parameters only, in positional order.
+
+        Assigning to this writes those positions back, folding each value into
+        its feasible range first. It accepts a
+        ``scipy.optimize.OptimizeResult``, an ndarray, a list or a tuple, which
+        is what lets ``optimize.minimize``'s result be handed straight back.
+
+        Returns
+        -------
+        ndarray
+            The components listed in :attr:`variables`.
+        """
         return self._x[self.variables]
 
     @x.setter
     def x(self, values):
+        """Write the free parameters back, folded into their feasible ranges.
+
+        Parameters
+        ----------
+        values : OptimizeResult or ndarray or list or tuple
+            One value per free parameter, in :attr:`variables` order.
+
+        Raises
+        ------
+        TypeError
+            If `values` is none of the accepted types.
+        ValueError
+            If `values` does not hold exactly one entry per free parameter.
+        """
         # Dispatch on the type rather than on its name, and reject anything
         # else explicitly: without the else branch, `vals` stayed unbound and
         # assigning e.g. a list raised UnboundLocalError instead of TypeError.
@@ -183,18 +305,16 @@ class Parameters(object):
         else:
             raise TypeError(
                 'expected an OptimizeResult, ndarray, list or tuple, '
-                'got {}'.format(type(values).__name__)
+                f'got {type(values).__name__}'
             )
         # One value per free parameter. Without this the loop below indexes
         # off the end and reports a bare IndexError naming neither the setter
         # nor the length it wanted.
         if len(vals) != len(self.variables):
             raise ValueError(
-                'expected {} value(s) for the free parameters {}, got {}'.format(
-                    len(self.variables),
-                    [self.pnames[i] for i in self.variables],
-                    len(vals)
-                )
+                f'expected {len(self.variables)} value(s) for the free '
+                f'parameters {[self.pnames[i] for i in self.variables]}, '
+                f'got {len(vals)}'
             )
         for j, i in enumerate(self.variables):
             self._x[i] = f_bounds[self.par][self.pnames[i]](vals[j])

--- a/src/levy/parametrization.py
+++ b/src/levy/parametrization.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -18,6 +17,18 @@
 
 Nolan 0 and 1, Zolotarev M, A and B. Everything is routed through
 parametrization 0, which is what the lookup tables are built in.
+
+Attributes
+----------
+convert_to_par0 : dict of {str: callable}
+    Maps a parameter array from the named parametrization into 0.
+convert_from_par0 : dict of {str: callable}
+    Maps a parameter array from parametrization 0 into the named one.
+
+References
+----------
+.. [1] J. P. Nolan, "Univariate Stable Distributions", Springer, 2020.
+.. [2] V. M. Zolotarev, "One-dimensional Stable Distributions", AMS, 1986.
 """
 
 import numpy as np
@@ -27,12 +38,38 @@ from levy.constants import default, f_bounds, par_names
 
 __all__ = ['Parameters', 'convert_to_par0', 'convert_from_par0']
 
+
 def _psi(alpha):
+    """Return Zolotarev's psi, the half-turn used by parametrization B.
+
+    Parameters
+    ----------
+    alpha : float or ndarray
+        Index of stability.
+
+    Returns
+    -------
+    float or ndarray
+        ``pi / 2 * (alpha - 1 - sign(alpha - 1))``.
+    """
     return np.pi / 2 * (alpha - 1 - np.sign(alpha - 1))
 
 
 def _phi(alpha, beta):
-    """ Common function. """
+    """Return the skewness term shared by every parametrization change.
+
+    Parameters
+    ----------
+    alpha : float or ndarray
+        Index of stability.
+    beta : float or ndarray
+        Skewness.
+
+    Returns
+    -------
+    float or ndarray
+        ``beta * tan(pi * alpha / 2)``, which diverges as `alpha` approaches 1.
+    """
     return beta * np.tan(np.pi * alpha / 2.0)
 
 
@@ -93,39 +130,73 @@ convert_from_par0 = {
 }
 
 
-class Parameters(object):
-    """
-    This class is a wrap for the parameters; it works such that if we fit
-    fixing one or more parameters, the optimization only acts on the other
-    (the key thing here is the setter).
-    The only useful function to be used directly is `convert`, which allows
-    to transform parameters from one parametrization to another.
-    Available parametrizations are {0, 1, A, B, M}.
+class Parameters:
+    """A parameter vector that knows which of its components are free.
+
+    Fitting with one or more parameters held fixed works by letting the
+    optimizer see only the free components: :attr:`x` reads and writes that
+    subvector, and the setter folds each proposed value back into its feasible
+    range. The only method generally useful on its own is :meth:`convert`.
+
+    Parameters
+    ----------
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the values are given in.
+    **kwargs
+        One entry per name in ``par_names[par]``. ``None`` marks a free
+        parameter, which starts from its default; anything else fixes it.
+
+    Attributes
+    ----------
+    par : str
+        The parametrization in use.
+    pnames : list of str
+        Parameter names, in positional order.
+    variables : list of int
+        Positions of the free parameters.
+    fixed : list of int
+        Positions of the fixed parameters.
+    fixed_values : list
+        The values those fixed positions were pinned to.
+
+    Examples
+    --------
+    >>> p = Parameters(par='0', alpha=1.5, beta=None, mu=0.0, sigma=None)
+    >>> p.variables
+    [1, 3]
+    >>> p.x
+    array([0., 1.])
     """
 
     @classmethod
     def convert(cls, pars, par_in, par_out):
-        """
-        Use to convert a parameter array from one parametrization to another.
+        """Convert a parameter array from one parametrization to another.
 
-        Examples:
-            >>> a = np.array([1.6, 0.5, 0.3, 1.2])
-            >>> b = Parameters.convert(a, '1', 'B')
-            >>> b
-            array([1.6       , 0.55457302, 0.2460079 , 1.4243171 ])
-            >>> c = Parameters.convert(b, 'B', '1')
-            >>> c
-            array([1.6, 0.5, 0.3, 1.2])
-            >>> np.testing.assert_allclose(a, c)
+        Parameters
+        ----------
+        pars : ndarray
+            Array of parameters to be converted.
+        par_in : {'0', '1', 'M', 'A', 'B'}
+            Parametrization of the input array.
+        par_out : {'0', '1', 'M', 'A', 'B'}
+            Parametrization of the output array.
 
-        :param pars: array of parameters to be converted
-        :type pars: :class:`~numpy.ndarray`
-        :param par_in: parametrization of the input array
-        :type par_in: str
-        :param par_out: parametrization of the output array
-        :type par_out: str
-        :return: array of parameters in the desired parametrization
-        :rtype: :class:`~numpy.ndarray`
+        Returns
+        -------
+        ndarray
+            Array of parameters in the desired parametrization. `pars` itself
+            is returned when the two parametrizations coincide.
+
+        Examples
+        --------
+        >>> a = np.array([1.6, 0.5, 0.3, 1.2])
+        >>> b = Parameters.convert(a, '1', 'B')
+        >>> np.round(b, 6)
+        array([1.6     , 0.554573, 0.246008, 1.424317])
+        >>> c = Parameters.convert(b, 'B', '1')
+        >>> np.round(c, 6)
+        array([1.6, 0.5, 0.3, 1.2])
+        >>> np.testing.assert_allclose(a, c)
         """
         res = pars
         if par_out != par_in:
@@ -137,40 +208,91 @@ class Parameters(object):
     def __init__(self, par='0', **kwargs):
         self.par = par
         self.pnames = par_names[self.par]
-        self._x = np.array([default[par][k] if kwargs[k] is None else kwargs[k] for k in self.pnames])
+        self._x = np.array(
+            [default[par][k] if kwargs[k] is None else kwargs[k] for k in self.pnames])
         self.variables = [i for i, k in enumerate(self.pnames) if kwargs[k] is None]
         self.fixed = [i for i, k in enumerate(self.pnames) if kwargs[k] is not None]
-        self.fixed_values = [kwargs[k] for i, k in enumerate(self.pnames) if kwargs[k] is not None]
+        self.fixed_values = [kwargs[k] for k in self.pnames if kwargs[k] is not None]
 
     def get(self, par_out=None):
-        """
-        Same as `convert` but using from within the Parameter object.
+        """Return the full parameter vector, optionally in another parametrization.
 
-        Examples:
-            >>> p = Parameters(par='1', alpha=1.5, beta=0.5, mu=0, sigma=1.2)  # to convert
-            >>> p.get('B')  # returns the parameters in the parametrization B
-            array([1.5       , 0.59033447, 0.03896531, 1.46969385])
+        Parameters
+        ----------
+        par_out : {'0', '1', 'M', 'A', 'B'}, optional
+            Parametrization to return. Defaults to the object's own.
 
+        Returns
+        -------
+        ndarray
+            All four parameters, fixed and free alike.
+
+        Examples
+        --------
+        >>> p = Parameters(par='1', alpha=1.5, beta=0.5, mu=0, sigma=1.2)
+        >>> np.round(p.get('B'), 6)   # the same distribution, written in B
+        array([1.5     , 0.590334, 0.038965, 1.469694])
         """
         if par_out is None:
             par_out = self.par
         return Parameters.convert(self._x, self.par, par_out)
 
     def __str__(self):
-        txt = ', '.join(['{{0[{0}]}}: {{1[{1}]:.2f}}'.format(i, i) for i in range(4)])
-        txt += '. Parametrization: {2}.'
-        return txt.format(self.pnames, self.get(), self.par)
+        """Render the parameters and their parametrization, for humans.
+
+        Returns
+        -------
+        str
+            Formatted as ``"alpha: 1.50, ... . Parametrization: 1."``.
+        """
+        body = ', '.join(
+            f'{name}: {value:.2f}' for name, value in zip(self.pnames, self.get()))
+        return f'{body}. Parametrization: {self.par}.'
 
     def __repr__(self):
-        txt = 'par={2}, ' + ', '.join(['{{0[{0}]}}={{1[{1}]:.2f}}'.format(i, i) for i in range(4)])
-        return txt.format(self.pnames, self.get(), self.par)
+        """Render the parametrization and the parameters, keyword-style.
+
+        Returns
+        -------
+        str
+            Formatted as ``"par=1, alpha=1.50, beta=0.50, ..."``.
+        """
+        body = ', '.join(
+            f'{name}={value:.2f}' for name, value in zip(self.pnames, self.get()))
+        return f'par={self.par}, {body}'
 
     @property
     def x(self):
+        """Get the free parameters only, in positional order.
+
+        Assigning to this writes those positions back, folding each value into
+        its feasible range first. It accepts a
+        ``scipy.optimize.OptimizeResult``, an ndarray, a list or a tuple, which
+        is what lets ``optimize.minimize``'s result be handed straight back.
+
+        Returns
+        -------
+        ndarray
+            The components listed in :attr:`variables`.
+        """
         return self._x[self.variables]
 
     @x.setter
     def x(self, values):
+        """Write the free parameters back, folded into their feasible ranges.
+
+        Parameters
+        ----------
+        values : OptimizeResult or ndarray or list or tuple
+            One value per free parameter, in :attr:`variables` order.
+
+        Raises
+        ------
+        TypeError
+            If `values` is none of the accepted types.
+        ValueError
+            If `values` does not hold exactly one entry per free parameter.
+        """
         # Dispatch on the type rather than on its name, and reject anything
         # else explicitly: without the else branch, `vals` stayed unbound and
         # assigning e.g. a list raised UnboundLocalError instead of TypeError.
@@ -183,7 +305,7 @@ class Parameters(object):
         else:
             raise TypeError(
                 'expected an OptimizeResult, ndarray, list or tuple, '
-                'got {}'.format(type(values).__name__)
+                f'got {type(values).__name__}'
             )
         # A 0-D array has no len() -- np.array(1.5) used to fail with
         # "len() of unsized object" -- and a 2-D one would pass the length
@@ -193,18 +315,16 @@ class Parameters(object):
         if vals.ndim != 1:
             raise ValueError(
                 'expected a one-dimensional sequence of values, got an array '
-                'of shape {}'.format(vals.shape)
+                f'of shape {vals.shape}'
             )
         # One value per free parameter. Without this the loop below indexes
         # off the end and reports a bare IndexError naming neither the setter
         # nor the length it wanted.
         if len(vals) != len(self.variables):
             raise ValueError(
-                'expected {} value(s) for the free parameters {}, got {}'.format(
-                    len(self.variables),
-                    [self.pnames[i] for i in self.variables],
-                    len(vals)
-                )
+                f'expected {len(self.variables)} value(s) for the free '
+                f'parameters {[self.pnames[i] for i in self.variables]}, '
+                f'got {len(vals)}'
             )
         for j, i in enumerate(self.variables):
             self._x[i] = f_bounds[self.par][self.pnames[i]](vals[j])

--- a/src/levy/sampling.py
+++ b/src/levy/sampling.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -22,38 +21,81 @@ from levy.parametrization import _phi
 
 __all__ = ['random']
 
-#: How far random() moves alpha away from 1 before sampling a skewed draw,
-#: to keep tan(pi*alpha/2) off its pole. Module level so the tests assert
-#: against the value the sampler actually uses instead of a copy of it; the
-#: reasoning for the size of it is at the use site in random().
+# The Chambers-Mallows-Stuck sampler divides by (1 - alpha) implicitly, through
+# phi = beta * tan(pi * alpha / 2), so alpha exactly 1 has to be nudged off the
+# pole of the tangent.
+#
+# The nudge used to be 1e-15, which is far too close: tan(pi*alpha/2) is then
+# evaluated 1e-15 from its pole, where the unavoidable ~1e-16 rounding of the
+# argument becomes a ~11% relative error in the result. That is not cosmetic.
+# At beta = +-1 it made the base of the fractional power below go negative for
+# about 0.9% of draws, producing NaN, and the samples that did survive were
+# measurably from the wrong distribution (Kolmogorov-Smirnov against this
+# package's own CDF: p = 3e-07 over 200k draws).
+#
+# 1e-8 keeps the same limiting value -- beta*tan(pi*alpha/2)*sin((1-alpha)*b*pi)
+# tends to 2*beta*b whatever the radius -- while evaluating it accurately. It
+# sits in the middle of a wide plateau: every radius from 1e-10 to 1e-6 gives
+# NaN-free samples and KS p ~ 0.50, so this is not a tuned constant. The
+# distributional cost of shifting alpha by 1e-8 is far below sampling noise.
 _ALPHA_1_RADIUS = 1e-8
 
+
 def random(alpha, beta, mu=0.0, sigma=1.0, shape=()):
+    """Draw random values from an alpha-stable distribution, in parametrization 0.
+
+    Parameters
+    ----------
+    alpha : float
+        Index of stability.
+    beta : float
+        Skewness.
+    mu : float, default 0.0
+        Location.
+    sigma : float, default 1.0
+        Scale.
+    shape : tuple of int, default ()
+        Shape of the resulting array. The default draws a single scalar.
+
+    Returns
+    -------
+    float or ndarray
+        Generated random values.
+
+    See Also
+    --------
+    levy.parametrization.Parameters.convert : Move between parametrizations.
+
+    Notes
+    -----
+    Exact, in the sense of being derived directly from the definition of a
+    stable variable rather than by inverting an interpolated cdf. Draws come
+    from the legacy global ``numpy.random`` stream, so ``np.random.seed`` is
+    what makes a run reproducible.
+
+    ``alpha`` within 1e-8 of 1 is snapped to ``1 + 1e-8``, off the pole of the
+    tangent; the module-level comment on ``_ALPHA_1_RADIUS`` explains why.
+
+    References
+    ----------
+    .. [1] J. M. Chambers, C. L. Mallows and B. W. Stuck, "A Method for
+       Simulating Stable Random Variables", Journal of the American Statistical
+       Association 71(354), 340-344, 1976.
+
+    Examples
+    --------
+    >>> np.random.seed(0)
+    >>> np.round(random(1.5, 0.0, shape=(4,)), 6)   # parametrization 0 is implicit
+    array([0.218654, 0.775259, 0.454604, 0.10272 ])
+
+    Parameters given in another parametrization have to be converted first:
+
+    >>> from levy.parametrization import Parameters
+    >>> par = np.array([1.5, 0.905, 0.707, 1.414])
+    >>> rnd = random(*Parameters.convert(par, 'B', '0'), shape=(100,))
+    >>> rnd.shape
+    (100,)
     """
-    Generate random values sampled from an alpha-stable distribution.
-    Notice that this method is "exact", in the sense that is derived
-    directly from the definition of stable variable.
-    It uses parametrization 0 (to get it from another parametrization, convert).
-
-    Example:
-        >>> rnd = random(1.5, 0, shape=(100,))  # parametrization 0 is implicit
-        >>> par = np.array([1.5, 0.905, 0.707, 1.414])
-        >>> rnd = random(*Parameters.convert(par ,'B' ,'0'), shape=(100,))  # example with convert
-
-    :param alpha: alpha
-    :type alpha: float
-    :param beta: beta
-    :type beta: float
-    :param mu: mu
-    :type mu: float
-    :param sigma: sigma
-    :type sigma: float
-    :param shape: shape (numpy array type) of the resulting array
-    :type shape: tuple
-    :return: generated random values
-    :rtype: :class:`~numpy.ndarray`
-    """
-
     if alpha == 2:
         # mu and sigma have to be applied here too. This branch used to return
         # before reaching the `return mu + sigma * k` at the end of the
@@ -61,24 +103,6 @@ def random(alpha, beta, mu=0.0, sigma=1.0, shape=()):
         # zero with unit-ish scale.
         return mu + sigma * np.random.standard_normal(shape) * np.sqrt(2.0)
 
-    # The sampler below divides by (1 - alpha) implicitly, through
-    # phi = beta * tan(pi * alpha / 2), so alpha exactly 1 has to be nudged off
-    # the pole of the tangent.
-    #
-    # The nudge used to be 1e-15, which is far too close: tan(pi*alpha/2) is
-    # then evaluated 1e-15 from its pole, where the unavoidable ~1e-16 rounding
-    # of the argument becomes a ~11% relative error in the result. That is not
-    # cosmetic. At beta = +-1 it made the base of the fractional power below go
-    # negative for about 0.9% of draws, producing NaN, and the samples that did
-    # survive were measurably from the wrong distribution (Kolmogorov-Smirnov
-    # against this package's own CDF: p = 3e-07 over 200k draws).
-    #
-    # 1e-8 keeps the same limiting value -- beta*tan(pi*alpha/2)*sin((1-alpha)*b*pi)
-    # tends to 2*beta*b whatever the radius -- while evaluating it accurately.
-    # It sits in the middle of a wide plateau: every radius from 1e-10 to 1e-6
-    # gives NaN-free samples and KS p ~ 0.50, so this is not a tuned constant.
-    # The distributional cost of shifting alpha by 1e-8 is far below sampling
-    # noise.
     # copysign, not a bare +: nudging an alpha just *below* 1 up to
     # 1 + radius would hand the sampler the opposite side of the pole from
     # the one the caller asked for, and flip the sign of (1 - alpha). alpha
@@ -86,8 +110,7 @@ def random(alpha, beta, mu=0.0, sigma=1.0, shape=()):
     if np.absolute(alpha - 1.0) < _ALPHA_1_RADIUS:
         alpha = 1.0 + np.copysign(_ALPHA_1_RADIUS, alpha - 1.0)
 
-    # Chambers, Mallows & Stuck (1976), "A Method for Simulating Stable Random
-    # Variables", JASA 71(354), 340-344. Two uniforms are transformed into a
+    # Chambers, Mallows & Stuck (1976). Two uniforms are transformed into a
     # standard stable variate; mu and sigma are applied at the end.
     #
     # These were a..k before. The algebra is unchanged, only the names.

--- a/src/levy/sampling.py
+++ b/src/levy/sampling.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -22,40 +21,85 @@ from levy.parametrization import _phi
 
 __all__ = ['random']
 
-#: How far random() moves alpha away from 1 before sampling, to keep
-#: tan(pi*alpha/2) off its pole. The nudge depends on alpha alone: _phi()
-#: evaluates that tangent for every draw, symmetric ones included, so it is
-#: not only the skewed draws that need it. Module level so the tests assert
-#: against the value the sampler actually uses instead of a copy of it; the
-#: reasoning for the size of it is at the use site in random().
+# The Chambers-Mallows-Stuck sampler divides by (1 - alpha) implicitly, through
+# phi = beta * tan(pi * alpha / 2), so alpha exactly 1 has to be nudged off the
+# pole of the tangent. The nudge depends on alpha alone and is applied to
+# every draw, symmetric ones included: _phi() evaluates the tangent whatever
+# beta is.
+#
+# The nudge used to be 1e-15, which is far too close: tan(pi*alpha/2) is then
+# evaluated 1e-15 from its pole, where the unavoidable ~1e-16 rounding of the
+# argument becomes a ~11% relative error in the result. That is not cosmetic.
+# At beta = -1 or +1 it made the base of the fractional power below go
+# negative for about 0.9% of draws, producing NaN, and the samples that did survive were
+# measurably from the wrong distribution (Kolmogorov-Smirnov against this
+# package's own CDF: p = 3e-07 over 200k draws).
+#
+# 1e-8 keeps the same limiting value -- beta*tan(pi*alpha/2)*sin((1-alpha)*b*pi)
+# tends to 2*beta*b whatever the radius -- while evaluating it accurately. It
+# sits in the middle of a wide plateau: every radius from 1e-10 to 1e-6 gives
+# NaN-free samples and KS p ~ 0.50, so this is not a tuned constant. The
+# distributional cost of shifting alpha by 1e-8 is far below sampling noise.
 _ALPHA_1_RADIUS = 1e-8
 
+
 def random(alpha, beta, mu=0.0, sigma=1.0, shape=()):
+    """Draw random values from an alpha-stable distribution, in parametrization 0.
+
+    Parameters
+    ----------
+    alpha : float
+        Index of stability.
+    beta : float
+        Skewness.
+    mu : float, default 0.0
+        Location.
+    sigma : float, default 1.0
+        Scale.
+    shape : tuple of int, default ()
+        Shape of the resulting array. The default draws a single scalar.
+
+    Returns
+    -------
+    float or ndarray
+        Generated random values.
+
+    See Also
+    --------
+    levy.parametrization.Parameters.convert : Move between parametrizations.
+
+    Notes
+    -----
+    Exact, in the sense of being derived directly from the definition of a
+    stable variable rather than by inverting an interpolated cdf. Draws come
+    from the legacy global ``numpy.random`` stream, so ``np.random.seed`` is
+    what makes a run reproducible.
+
+    ``alpha`` within 1e-8 of 1 is moved 1e-8 away from it, off the pole of the
+    tangent, keeping the side it was already on -- an ``alpha`` just below 1
+    goes to ``1 - 1e-8``, not across to ``1 + 1e-8``. Exactly 1.0 goes up. The
+    module-level comment on ``_ALPHA_1_RADIUS`` explains the size of it.
+
+    References
+    ----------
+    .. [1] J. M. Chambers, C. L. Mallows and B. W. Stuck, "A Method for
+       Simulating Stable Random Variables", Journal of the American Statistical
+       Association 71(354), 340-344, 1976.
+
+    Examples
+    --------
+    >>> np.random.seed(0)
+    >>> np.round(random(1.5, 0.0, shape=(4,)), 6)   # parametrization 0 is implicit
+    array([0.218654, 0.775259, 0.454604, 0.10272 ])
+
+    Parameters given in another parametrization have to be converted first:
+
+    >>> from levy.parametrization import Parameters
+    >>> par = np.array([1.5, 0.905, 0.707, 1.414])
+    >>> rnd = random(*Parameters.convert(par, 'B', '0'), shape=(100,))
+    >>> rnd.shape
+    (100,)
     """
-    Generate random values sampled from an alpha-stable distribution.
-    Notice that this method is "exact", in the sense that is derived
-    directly from the definition of stable variable.
-    It uses parametrization 0 (to get it from another parametrization, convert).
-
-    Example:
-        >>> rnd = random(1.5, 0, shape=(100,))  # parametrization 0 is implicit
-        >>> par = np.array([1.5, 0.905, 0.707, 1.414])
-        >>> rnd = random(*Parameters.convert(par ,'B' ,'0'), shape=(100,))  # example with convert
-
-    :param alpha: alpha
-    :type alpha: float
-    :param beta: beta
-    :type beta: float
-    :param mu: mu
-    :type mu: float
-    :param sigma: sigma
-    :type sigma: float
-    :param shape: shape (numpy array type) of the resulting array
-    :type shape: tuple
-    :return: generated random values
-    :rtype: :class:`~numpy.ndarray`
-    """
-
     if alpha == 2:
         # mu and sigma have to be applied here too. This branch used to return
         # before reaching the `return mu + sigma * k` at the end of the
@@ -63,24 +107,6 @@ def random(alpha, beta, mu=0.0, sigma=1.0, shape=()):
         # zero with unit-ish scale.
         return mu + sigma * np.random.standard_normal(shape) * np.sqrt(2.0)
 
-    # The sampler below divides by (1 - alpha) implicitly, through
-    # phi = beta * tan(pi * alpha / 2), so alpha exactly 1 has to be nudged off
-    # the pole of the tangent.
-    #
-    # The nudge used to be 1e-15, which is far too close: tan(pi*alpha/2) is
-    # then evaluated 1e-15 from its pole, where the unavoidable ~1e-16 rounding
-    # of the argument becomes a ~11% relative error in the result. That is not
-    # cosmetic. At beta = +-1 it made the base of the fractional power below go
-    # negative for about 0.9% of draws, producing NaN, and the samples that did
-    # survive were measurably from the wrong distribution (Kolmogorov-Smirnov
-    # against this package's own CDF: p = 3e-07 over 200k draws).
-    #
-    # 1e-8 keeps the same limiting value -- beta*tan(pi*alpha/2)*sin((1-alpha)*b*pi)
-    # tends to 2*beta*b whatever the radius -- while evaluating it accurately.
-    # It sits in the middle of a wide plateau: every radius from 1e-10 to 1e-6
-    # gives NaN-free samples and KS p ~ 0.50, so this is not a tuned constant.
-    # The distributional cost of shifting alpha by 1e-8 is far below sampling
-    # noise.
     # copysign, not a bare +: nudging an alpha just *below* 1 up to
     # 1 + radius would hand the sampler the opposite side of the pole from
     # the one the caller asked for, and flip the sign of (1 - alpha). alpha
@@ -88,8 +114,7 @@ def random(alpha, beta, mu=0.0, sigma=1.0, shape=()):
     if np.absolute(alpha - 1.0) < _ALPHA_1_RADIUS:
         alpha = 1.0 + np.copysign(_ALPHA_1_RADIUS, alpha - 1.0)
 
-    # Chambers, Mallows & Stuck (1976), "A Method for Simulating Stable Random
-    # Variables", JASA 71(354), 340-344. Two uniforms are transformed into a
+    # Chambers, Mallows & Stuck (1976). Two uniforms are transformed into a
     # standard stable variate; mu and sigma are applied at the end.
     #
     # These were a..k before. The algebra is unchanged, only the names.

--- a/src/levy/tables.py
+++ b/src/levy/tables.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -14,7 +13,15 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-"""Locating, loading, caching and repairing the lookup tables."""
+"""Locating, loading, caching and repairing the lookup tables.
+
+Attributes
+----------
+ROOT : str
+    Directory the installed package lives in.
+PACKAGED_DATA : str
+    Directory of the tables shipped inside the package.
+"""
 
 import os
 import sys
@@ -34,11 +41,20 @@ _data_cache = {}
 
 _TABLE_NAMES = ('pdf', 'cdf', 'lower_limit', 'upper_limit')
 
-def user_cache_dir():
-    """ Per-user directory where regenerated tables are looked for.
 
-    Resolved without a third-party dependency: XDG_CACHE_HOME or ~/.cache on
-    Unix, ~/Library/Caches on macOS, LOCALAPPDATA on Windows.
+def user_cache_dir():
+    """Return the per-user directory where regenerated tables are looked for.
+
+    Returns
+    -------
+    str
+        Path to the cache directory. It is not created here.
+
+    Notes
+    -----
+    Resolved without a third-party dependency: ``XDG_CACHE_HOME`` or
+    ``~/.cache`` on Unix, ``~/Library/Caches`` on macOS, ``LOCALAPPDATA`` on
+    Windows.
     """
     if sys.platform == 'win32':
         base = os.environ.get('LOCALAPPDATA') or os.path.expanduser(r'~\AppData\Local')
@@ -50,8 +66,21 @@ def user_cache_dir():
 
 
 def data_dir(writable=False):
-    """ Directory the lookup tables are read from.
+    """Return the directory the lookup tables are read from.
 
+    Parameters
+    ----------
+    writable : bool, default False
+        Ask for the directory a *new* build should be written to, rather than
+        the one the current tables are read from.
+
+    Returns
+    -------
+    str
+        Path to the directory.
+
+    Notes
+    -----
     Search order: ``$LEVY_DATA_DIR``, then the user cache directory if it holds
     a complete set, then the tables shipped inside the package.
 
@@ -76,17 +105,30 @@ def data_dir(writable=False):
 
 
 def _has_complete_tables(directory):
-    """ True if `directory` holds a usable set of tables, in either layout.
+    """Report whether `directory` holds a usable set of tables, in either layout.
 
-    The crossover limits ship as a single limits.npz with `lower` and `upper`
-    arrays; tables built by an older version have them as two separate files.
+    Parameters
+    ----------
+    directory : str
+        Directory to inspect. It need not exist.
+
+    Returns
+    -------
+    bool
+        True when the densities and the crossover limits are all present.
+
+    Notes
+    -----
+    The crossover limits ship as a single ``limits.npz`` with ``lower`` and
+    ``upper`` arrays; tables built by an older version have them as two
+    separate files.
     """
-    if not all(os.path.exists(os.path.join(directory, '{}.npz'.format(n)))
+    if not all(os.path.exists(os.path.join(directory, f'{n}.npz'))
                for n in ('pdf', 'cdf')):
         return False
     if os.path.exists(os.path.join(directory, 'limits.npz')):
         return True
-    return all(os.path.exists(os.path.join(directory, '{}.npz'.format(n)))
+    return all(os.path.exists(os.path.join(directory, f'{n}.npz'))
                for n in ('lower_limit', 'upper_limit'))
 
 
@@ -104,11 +146,27 @@ _CDF_TOLERANCE = 1e-6
 
 
 def _repair_table(key, table):
-    """ Replaces values the table generator failed to compute.
+    """Replace values the table generator failed to compute.
 
-    CDF cells outside [0, 1] (or non-finite) are replaced by linear
+    Parameters
+    ----------
+    key : {'pdf', 'cdf', 'lower_limit', 'upper_limit'}
+        Which table this is. Only ``'cdf'`` is inspected.
+    table : ndarray
+        The table as loaded from disk. Never modified in place.
+
+    Returns
+    -------
+    ndarray
+        `table` itself when there is nothing to repair, otherwise a repaired
+        copy.
+
+    Notes
+    -----
+    CDF cells outside ``[0, 1]`` (or non-finite) are replaced by linear
     interpolation along x, which is well justified here: the neighbours of the
-    known-bad cells are smooth and about 0.0128 apart.
+    known-bad cells are smooth and about 0.0128 apart. A repair is logged once
+    at ``WARNING``.
     """
     if key != 'cdf':
         return table
@@ -176,7 +234,19 @@ def _repair_table(key, table):
 
 
 def _read_from_cache(key):
-    """ Loads the file given by key """
+    """Return the named table, loading and repairing it on first use.
+
+    Parameters
+    ----------
+    key : {'pdf', 'cdf', 'lower_limit', 'upper_limit'}
+        Which table to return.
+
+    Returns
+    -------
+    ndarray
+        The table. The same object is handed out on every call, so callers must
+        treat it as read-only.
+    """
     try:
         return _data_cache[key]
     except KeyError:
@@ -185,10 +255,24 @@ def _read_from_cache(key):
 
 
 def _load_table(directory, key):
-    """ Read one table from `directory`, in either storage layout.
+    """Read one table from `directory`, in either storage layout.
 
-    np.load returns a lazy NpzFile; the array is materialised and the archive
-    closed rather than leaking the handle until garbage collection.
+    Parameters
+    ----------
+    directory : str
+        Directory holding the ``.npz`` archives.
+    key : {'pdf', 'cdf', 'lower_limit', 'upper_limit'}
+        Which table to read.
+
+    Returns
+    -------
+    ndarray
+        The materialised array.
+
+    Notes
+    -----
+    ``np.load`` returns a lazy ``NpzFile``; the array is materialised and the
+    archive closed rather than leaking the handle until garbage collection.
     """
     if key in ('lower_limit', 'upper_limit'):
         merged = os.path.join(directory, 'limits.npz')
@@ -196,5 +280,5 @@ def _load_table(directory, key):
             with np.load(merged) as archive:
                 return archive[key.split('_')[0]]
 
-    with np.load(os.path.join(directory, '{}.npz'.format(key))) as archive:
+    with np.load(os.path.join(directory, f'{key}.npz')) as archive:
         return archive[archive.files[0]]

--- a/src/levy/tables.py
+++ b/src/levy/tables.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #    Copyright (C) 2017 José M. Miotto
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -14,7 +13,15 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-"""Locating, loading, caching and repairing the lookup tables."""
+"""Locating, loading, caching and repairing the lookup tables.
+
+Attributes
+----------
+ROOT : str
+    Directory the installed package lives in.
+PACKAGED_DATA : str
+    Directory of the tables shipped inside the package.
+"""
 
 import os
 import sys
@@ -35,11 +42,20 @@ _data_cache = {}
 
 _TABLE_NAMES = ('pdf', 'cdf', 'lower_limit', 'upper_limit')
 
-def user_cache_dir():
-    """ Per-user directory where regenerated tables are looked for.
 
-    Resolved without a third-party dependency: XDG_CACHE_HOME or ~/.cache on
-    Unix, ~/Library/Caches on macOS, LOCALAPPDATA on Windows.
+def user_cache_dir():
+    """Return the per-user directory where regenerated tables are looked for.
+
+    Returns
+    -------
+    str
+        Path to the cache directory. It is not created here.
+
+    Notes
+    -----
+    Resolved without a third-party dependency: ``XDG_CACHE_HOME`` or
+    ``~/.cache`` on Unix, ``~/Library/Caches`` on macOS, ``LOCALAPPDATA`` on
+    Windows.
     """
     if sys.platform == 'win32':
         base = os.environ.get('LOCALAPPDATA') or os.path.expanduser(r'~\AppData\Local')
@@ -51,8 +67,21 @@ def user_cache_dir():
 
 
 def data_dir(writable=False):
-    """ Directory the lookup tables are read from.
+    """Return the directory the lookup tables are read from.
 
+    Parameters
+    ----------
+    writable : bool, default False
+        Ask for the directory a *new* build should be written to, rather than
+        the one the current tables are read from.
+
+    Returns
+    -------
+    str
+        Path to the directory.
+
+    Notes
+    -----
     Search order: ``$LEVY_DATA_DIR``, then the user cache directory if it holds
     a complete set, then the tables shipped inside the package.
 
@@ -77,24 +106,38 @@ def data_dir(writable=False):
 
 
 def _has_complete_tables(directory):
-    """ True if `directory` holds a usable set of tables, in either layout.
+    """Report whether `directory` holds a usable set of tables, in either layout.
 
-    The crossover limits ship as a single limits.npz with `lower` and `upper`
-    arrays; tables built by an older version have them as two separate files.
+    Parameters
+    ----------
+    directory : str
+        Directory to inspect. It need not exist.
+
+    Returns
+    -------
+    bool
+        True when the densities and the crossover limits are all present.
+
+    Notes
+    -----
+    The crossover limits ship as a single ``limits.npz`` with ``lower`` and
+    ``upper`` arrays; tables built by an older version have them as two
+    separate files.
     """
-    if not all(os.path.exists(os.path.join(directory, '{}.npz'.format(n)))
+    if not all(os.path.exists(os.path.join(directory, f'{n}.npz'))
                for n in ('pdf', 'cdf')):
         return False
     if os.path.exists(os.path.join(directory, 'limits.npz')):
         return True
-    return all(os.path.exists(os.path.join(directory, '{}.npz'.format(n)))
+    return all(os.path.exists(os.path.join(directory, f'{n}.npz'))
                for n in ('lower_limit', 'upper_limit'))
 
 
 # Cells of cdf.npz that scipy.integrate.quad failed to evaluate when the table
 # was generated. All four are at alpha index 4 (alpha = 0.58), beta indices 13
-# and 87 (beta = -+0.74), x indices 99 and 100 -- the two grid points closest to
-# x = 0, where the oscillatory weight used by _calculate_levy degenerates. They
+# and 87 (beta = -0.74 and +0.74), x indices 99 and 100 -- the two grid points
+# closest to x = 0, where the oscillatory weight used by _calculate_levy
+# degenerates. They
 # hold 5.72e+307 instead of a probability.
 #
 # This is not a storage error: _calculate_levy still returns 5.72e+307 for those
@@ -105,9 +148,24 @@ _CDF_TOLERANCE = 1e-6
 
 
 def _repair_table(key, table):
-    """ Replaces values the table generator failed to compute.
+    """Replace values the table generator failed to compute.
 
-    CDF cells outside [0, 1] (or non-finite) are replaced by linear
+    Parameters
+    ----------
+    key : {'pdf', 'cdf', 'lower_limit', 'upper_limit'}
+        Which table this is. Only ``'cdf'`` is inspected.
+    table : ndarray
+        The table as loaded from disk. Never modified in place.
+
+    Returns
+    -------
+    ndarray
+        `table` itself when there is nothing to repair, otherwise a repaired
+        copy.
+
+    Notes
+    -----
+    CDF cells outside ``[0, 1]`` (or non-finite) are replaced by linear
     interpolation along x, which is well justified here: the neighbours of the
     known-bad cells are smooth and about 0.0128 apart. A bad cell at either
     end of the x range has a usable neighbour on one side only and is copied
@@ -199,7 +257,19 @@ def _repair_table(key, table):
 
 
 def _read_from_cache(key):
-    """ Loads the file given by key """
+    """Return the named table, loading and repairing it on first use.
+
+    Parameters
+    ----------
+    key : {'pdf', 'cdf', 'lower_limit', 'upper_limit'}
+        Which table to return.
+
+    Returns
+    -------
+    ndarray
+        The table. The same object is handed out on every call, so callers must
+        treat it as read-only.
+    """
     try:
         return _data_cache[key]
     except KeyError:
@@ -211,9 +281,25 @@ def _read_from_cache(key):
 
 
 def _check_table_shape(key, table, directory):
-    """ Refuse a table whose shape does not match the pdf table's.
+    """Refuse a table whose shape does not match the pdf table's.
 
-    A directory is chosen by `data_dir()` on the strength of which files
+    Parameters
+    ----------
+    key : {'pdf', 'cdf', 'lower_limit', 'upper_limit'}
+        Which table this is. The pdf is the reference and is never refused.
+    table : ndarray
+        The table as loaded.
+    directory : str
+        Where it came from; named in the error.
+
+    Raises
+    ------
+    RuntimeError
+        If the shape does not agree with the pdf table's, naming both.
+
+    Notes
+    -----
+    A directory is chosen by :func:`data_dir` on the strength of which files
     exist, not what is in them, so a partial rebuild -- `levy-tables build
     --what pdf --size ...` into a cache that already held a full set -- could
     leave pdf.npz at one resolution next to a cdf and limits at another. The
@@ -227,29 +313,64 @@ def _check_table_shape(key, table, directory):
     expected = reference if key == 'cdf' else reference[1:]
     if tuple(table.shape) != tuple(expected):
         raise RuntimeError(
-            'the lookup tables in {} do not belong together: {} is {} but the pdf '
-            'table is {}. A partial rebuild has probably left tables of two '
-            'resolutions side by side; rebuild the whole set with `levy-tables '
-            'build`, or delete the directory to go back to the packaged tables.'.format(
-                directory, key, 'x'.join(map(str, table.shape)),
-                'x'.join(map(str, reference))))
+            f'the lookup tables in {directory} do not belong together: {key} is '
+            f'{"x".join(map(str, table.shape))} but the pdf table is '
+            f'{"x".join(map(str, reference))}. A partial rebuild has probably left '
+            f'tables of two resolutions side by side; rebuild the whole set with '
+            f'`levy-tables build`, or delete the directory to go back to the '
+            f'packaged tables.')
 
 
 def _load_table(directory, key):
-    """ Read one table from `directory`, in either storage layout.
+    """Read one table from `directory`, in either storage layout.
 
-    np.load returns a lazy NpzFile; the array is materialised and the archive
-    closed rather than leaking the handle until garbage collection.
+    Parameters
+    ----------
+    directory : str
+        Directory holding the ``.npz`` archives.
+    key : {'pdf', 'cdf', 'lower_limit', 'upper_limit'}
+        Which table to read.
+
+    Returns
+    -------
+    ndarray
+        The materialised array.
+
+    Notes
+    -----
+    ``np.load`` returns a lazy ``NpzFile``; the array is materialised and the
+    archive closed rather than leaking the handle until garbage collection.
     """
     if key in ('lower_limit', 'upper_limit'):
         merged = os.path.join(directory, 'limits.npz')
         if os.path.exists(merged):
             return _load_array(merged, directory, key.split('_')[0])
-    return _load_array(os.path.join(directory, '{}.npz'.format(key)), directory, None)
+    return _load_array(os.path.join(directory, f'{key}.npz'), directory, None)
 
 
 def _load_array(path, directory, name):
-    """ Read one array out of an archive, or say exactly why that failed. """
+    """Read one array out of an archive, or say exactly why that failed.
+
+    Parameters
+    ----------
+    path : str
+        The ``.npz`` archive to read.
+    directory : str
+        The directory ``data_dir()`` chose; only used to word the error.
+    name : str or None
+        Which array to take, or None for the archive's first (and only) one.
+
+    Returns
+    -------
+    ndarray
+        The materialised array.
+
+    Raises
+    ------
+    RuntimeError
+        If the archive is missing, empty, truncated, not an archive at all,
+        or lacks the array -- naming the file and what to do about it.
+    """
     try:
         with np.load(path) as archive:
             return archive[archive.files[0] if name is None else name]
@@ -278,17 +399,16 @@ def _unreadable_table(path, directory, error):
         do about it -- a bare ``BadZipFile: File is not a zip file`` from
         three frames down says none of those.
     """
-    what = 'cannot read the lookup table {} ({}: {}).'.format(
-        path, type(error).__name__, error)
+    what = f'cannot read the lookup table {path} ({type(error).__name__}: {error}).'
     if os.environ.get('LEVY_DATA_DIR'):
         return RuntimeError(
-            what + ' $LEVY_DATA_DIR points at {}; fix or rebuild the tables '
-            'there, or unset it to fall back to the packaged ones.'.format(directory))
+            f'{what} $LEVY_DATA_DIR points at {directory}; fix or rebuild the '
+            f'tables there, or unset it to fall back to the packaged ones.')
     if directory == PACKAGED_DATA:
         return RuntimeError(
-            what + ' This is the copy shipped inside the package, so the '
-            'installation itself is damaged; reinstall it.')
+            f'{what} This is the copy shipped inside the package, so the '
+            f'installation itself is damaged; reinstall it.')
     return RuntimeError(
-        what + ' The user cache at {} holds a table that cannot be read. Delete '
-        'that directory to go back to the packaged tables, or rerun '
-        '`levy-tables build`; `levy-tables where` shows which is in use.'.format(directory))
+        f'{what} The user cache at {directory} holds a table that cannot be '
+        f'read. Delete that directory to go back to the packaged tables, or '
+        f'rerun `levy-tables build`; `levy-tables where` shows which is in use.')

--- a/tests/test_build_cli.py
+++ b/tests/test_build_cli.py
@@ -63,7 +63,7 @@ def test_data_dir_accepts_the_legacy_split_limit_files(monkeypatch, tmp_path):
     cache.mkdir()
     monkeypatch.setattr(levy.tables, "user_cache_dir", lambda: str(cache))
     for name in ("pdf", "cdf", "lower_limit", "upper_limit"):
-        (cache / "{}.npz".format(name)).write_bytes(b"")
+        (cache / f"{name}.npz").write_bytes(b"")
     assert levy.data_dir() == str(cache)
 
 
@@ -93,7 +93,7 @@ def test_build_density_tables_at_a_tiny_grid(tmp_path):
         table, _ = results[name]
         assert table.shape == TINY
         assert np.isfinite(table).all()
-        assert (tmp_path / "{}.npz".format(name)).exists()
+        assert (tmp_path / f"{name}.npz").exists()
 
     cdf = results["cdf"][0]
     assert cdf.min() >= -1e-6 and cdf.max() <= 1.0 + 1e-6

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -37,7 +37,7 @@ def test_shipped_tables_fit_the_size_budget():
         for name in os.listdir(levy.PACKAGED_DATA)
         if name.endswith(".npz")
     )
-    assert total < 11e6, "shipped tables grew to {:.2f} MB".format(total / 1e6)
+    assert total < 11e6, f"shipped tables grew to {total / 1e6:.2f} MB"
 
 
 def test_limit_tables_are_merged():
@@ -86,7 +86,7 @@ def test_accuracy_against_quadrature_is_within_budget():
 
     errors = np.array(errors)
     assert np.median(errors) < INTERPOLATION_ERROR_BUDGET, (
-        "median relative error {:.3e} exceeds the budget".format(np.median(errors))
+        f"median relative error {np.median(errors):.3e} exceeds the budget"
     )
 
 
@@ -111,5 +111,5 @@ def test_fits_are_unaffected_by_table_precision():
         zip(("alpha", "beta", "mu", "sigma"), (1.5, 0.3, 0.0, 1.0))
     ):
         assert abs(means[index] - truth) < 4.0 * standard_errors[index] + 0.05, (
-            "{}: recovered {:.4f}, expected {:.4f}".format(name, means[index], truth)
+            f"{name}: recovered {means[index]:.4f}, expected {truth:.4f}"
         )

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -42,7 +42,7 @@ def test_shipped_tables_fit_the_size_budget():
         for name in os.listdir(levy.PACKAGED_DATA)
         if name.endswith(".npz")
     )
-    assert total < 11e6, "shipped tables grew to {:.2f} MB".format(total / 1e6)
+    assert total < 11e6, f"shipped tables grew to {total / 1e6:.2f} MB"
 
 
 def test_limit_tables_are_merged():
@@ -91,7 +91,7 @@ def test_accuracy_against_quadrature_is_within_budget():
 
     errors = np.array(errors)
     assert np.median(errors) < INTERPOLATION_ERROR_BUDGET, (
-        "median relative error {:.3e} exceeds the budget".format(np.median(errors))
+        f"median relative error {np.median(errors):.3e} exceeds the budget"
     )
 
 
@@ -119,5 +119,5 @@ def test_fits_from_the_float32_tables_recover_the_truth():
         zip(("alpha", "beta", "mu", "sigma"), (1.5, 0.3, 0.0, 1.0))
     ):
         assert abs(means[index] - truth) < 4.0 * standard_errors[index] + 0.05, (
-            "{}: recovered {:.4f}, expected {:.4f}".format(name, means[index], truth)
+            f"{name}: recovered {means[index]:.4f}, expected {truth:.4f}"
         )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -17,12 +17,12 @@ import os
 import subprocess
 import sys
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pytest
 
 import levy
-
 
 # --------------------------------------------------------------------------
 # Parameters.x setter (was: UnboundLocalError for anything but
@@ -154,21 +154,19 @@ def test_no_references_to_functions_that_do_not_exist():
     """`_limits()` and `change_par()` were referenced in commented-out code
     but have never existed anywhere in the package.
     """
-    with open(levy.__file__, encoding="utf-8") as handle:
-        source = handle.read()
+    source = Path(levy.__file__).read_text(encoding="utf-8")
     assert "_limits()" not in source
     assert "change_par(" not in source
 
 
 def test_library_code_does_not_print_to_stdout():
     """A library logs; it does not write to stdout. The __main__ block may."""
-    with open(levy.__file__, encoding="utf-8") as handle:
-        source = handle.read()
+    source = Path(levy.__file__).read_text(encoding="utf-8")
     body = source.split('if __name__ == "__main__":')[0]
     offending = [
         line.strip() for line in body.splitlines() if line.strip().startswith("print(")
     ]
-    assert not offending, "print() in library code: {}".format(offending)
+    assert not offending, f"print() in library code: {offending}"
 
 
 def test_module_logger_has_a_null_handler():
@@ -436,8 +434,7 @@ def test_sampler_has_no_single_letter_locals():
 
     import levy.sampling
 
-    with open(levy.sampling.__file__, encoding="utf-8") as handle:
-        source = handle.read()
+    source = Path(levy.sampling.__file__).read_text(encoding="utf-8")
     tree = ast.parse(source)
     offenders = set()
     for node in ast.walk(tree):
@@ -451,6 +448,4 @@ def test_sampler_has_no_single_letter_locals():
                     if isinstance(name, ast.Name) and len(name.id.lstrip("_")) <= 2:
                         offenders.add(name.id)
     offenders -= {"pi"}  # np.pi alias, reads fine
-    assert not offenders, "single/double-letter locals in the sampler: {}".format(
-        sorted(offenders)
-    )
+    assert not offenders, f"single/double-letter locals in the sampler: {sorted(offenders)}"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -17,12 +17,12 @@ import os
 import subprocess
 import sys
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pytest
 
 import levy
-
 
 # --------------------------------------------------------------------------
 # Parameters.x setter (was: UnboundLocalError for anything but
@@ -165,21 +165,19 @@ def test_no_references_to_functions_that_do_not_exist():
     """`_limits()` and `change_par()` were referenced in commented-out code
     but have never existed anywhere in the package.
     """
-    with open(levy.__file__, encoding="utf-8") as handle:
-        source = handle.read()
+    source = Path(levy.__file__).read_text(encoding="utf-8")
     assert "_limits()" not in source
     assert "change_par(" not in source
 
 
 def test_library_code_does_not_print_to_stdout():
     """A library logs; it does not write to stdout. The __main__ block may."""
-    with open(levy.__file__, encoding="utf-8") as handle:
-        source = handle.read()
+    source = Path(levy.__file__).read_text(encoding="utf-8")
     body = source.split('if __name__ == "__main__":')[0]
     offending = [
         line.strip() for line in body.splitlines() if line.strip().startswith("print(")
     ]
-    assert not offending, "print() in library code: {}".format(offending)
+    assert not offending, f"print() in library code: {offending}"
 
 
 def test_module_logger_has_a_null_handler():
@@ -505,8 +503,7 @@ def test_sampler_has_no_single_letter_locals():
 
     import levy.sampling
 
-    with open(levy.sampling.__file__, encoding="utf-8") as handle:
-        source = handle.read()
+    source = Path(levy.sampling.__file__).read_text(encoding="utf-8")
     tree = ast.parse(source)
     # Only the sampler itself. Walking the whole module would also judge
     # unrelated helpers and module-level assignments, which is not what this
@@ -529,6 +526,4 @@ def test_sampler_has_no_single_letter_locals():
                     if isinstance(name, ast.Name) and len(name.id.lstrip("_")) <= 2:
                         offenders.add(name.id)
     offenders -= {"pi"}  # np.pi alias, reads fine
-    assert not offenders, "single/double-letter locals in the sampler: {}".format(
-        sorted(offenders)
-    )
+    assert not offenders, f"single/double-letter locals in the sampler: {sorted(offenders)}"


### PR DESCRIPTION
> Part 12 of a 20-commit stack. Stacked on #32 — review that first; the diff here against its base is a single commit.

Every docstring in the package is rewritten in NumPy style, and the style is
now checked in CI rather than trusted. The two checks are complementary: ruff
runs pydocstyle under the numpy convention, so it enforces the section grammar;
numpydoc checks the docstring against the signature, so it catches a parameter
that is undocumented, out of order, or renamed away from the code. Config for
both lives in pyproject.toml.

Rule set is E,F,I,N,D,UP,B,SIM at line-length 100. `D` is ignored under tests/,
scripts/ and docs/, where a docstring is a note to the next reader rather than
API reference. Four numpydoc checks are switched off, each for a stated reason;
GL01 has to go because it is the exact opposite of ruff's D212.

The examples are now a gate, not decoration. `pytest --doctest-modules
src/levy` runs in CI and passes. That replaces the `legacy doctests` job, which
after the src/ layout move ran `python -m doctest levy/__init__.py` against a
path that no longer exists -- and, piped into `tail`, reported success while
testing nothing. The examples are written so they can be gated at all: values
rounded to 6 decimals, and the fit compared with a tolerance, since the
original doctests failed precisely because they pinned 17 digits of an L-BFGS-B
optimum.

sphinx.ext.napoleon is added to docs/source/conf.py, without which autodoc
would render the new section underlines as literal text. The rest of that file
(the sys.path level, the hardcoded version, the theme) is left for the docs PR.

No behaviour change. Beyond the docstrings, the diff is `.format()` -> f-string,
import sorting, dropping the Python-2 encoding declarations, `open()` ->
`Path.read_text()` in two tests, `_ALPHA_1_RADIUS` moved to module scope, and
`Parameters.__str__`/`__repr__` rewritten from nested format templates into
plain f-strings. `constants.py` stops rebinding `default` and `f_bounds` from
list to dict, so each name means one thing.

Evidence:

* Wheels built from the parent commit and from this one, installed into two
  venvs: all 99,312 values match bit for bit (scripts/compare_installs.py).
* Goldens unchanged -- 0 of 251 records moved; the file is untouched.
* 621 tests pass, plus the 7 table-generation tests, plus 10 doctests.
* __str__/__repr__ verified identical to the old implementation over 4,010
  comparisons across all five parametrizations, including -0.0, NaN and inf.

Adds Esteban Carisimo to the package authors.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

