### PR TITLE
Add a typed, validated API: pdf/cdf/logpdf/rvs/fit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "numpy<2" "scipy<1.12" pytest
+          python -m pip install "numpy<2" "scipy<1.12" pytest pydantic
           python -m pip install -e . --no-deps
 
       - name: Show environment
@@ -130,7 +130,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "numpy>=2,<3" "scipy>=1.13" pytest
+          python -m pip install "numpy>=2,<3" "scipy>=1.13" pytest pydantic
           python -m pip install -e . --no-deps
 
       - name: Show environment
@@ -191,6 +191,13 @@ jobs:
       # section that matches. ruff cannot see that far.
       - name: numpydoc
         run: python -m numpydoc lint src/levy/*.py src/levy/_build/*.py
+
+      # Strict, but only over the typed surface -- levy/api.py and
+      # levy/_typing.py. The numerical core has no annotations and is checked
+      # by tests instead; py.typed only promises that what is annotated is
+      # right, and this is what keeps that promise honest.
+      - name: mypy (typed surface)
+        run: python -m mypy
 
   doctests:
     name: doctests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "numpy<2" "scipy<1.12" pytest
+          python -m pip install "numpy<2" "scipy<1.12" pytest pydantic
           python -m pip install -e . --no-deps
 
       - name: Show environment
@@ -137,7 +137,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "numpy>=2,<3" "scipy>=1.13,<2" pytest
+          python -m pip install "numpy>=2,<3" "scipy>=1.13,<2" pytest pydantic
           python -m pip install -e . --no-deps
 
       - name: Show environment
@@ -241,6 +241,13 @@ jobs:
       # section that matches. ruff cannot see that far.
       - name: numpydoc
         run: python -m numpydoc lint src/levy/*.py src/levy/_build/*.py
+
+      # Strict, but only over the typed surface -- levy/api.py and
+      # levy/_typing.py. The numerical core has no annotations and is checked
+      # by tests instead; py.typed only promises that what is annotated is
+      # right, and this is what keeps that promise honest.
+      - name: mypy (typed surface)
+        run: python -m mypy
 
   doctests:
     name: doctests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,11 @@ classifiers = [
 # scipy 1.1.0 (2018), neither of which installs on any currently supported
 # Python -- and setup.py never read that file anyway, so the pins were not even
 # enforced at install time. Exact pins belong in an application, not a library.
-dependencies = ["numpy>=1.20", "scipy>=1.5"]
+# pydantic is used only at the API boundary, never inside a likelihood
+# evaluation -- tests/test_hot_loop.py enforces that. It buys the error a user
+# actually wants ("alpha must be >= 0.5", pointing at their call) instead of a
+# wrong number from a clamped table index.
+dependencies = ["numpy>=1.20", "scipy>=1.5", "pydantic>=2.0"]
 
 dynamic = ["version"]
 
@@ -48,7 +52,7 @@ dynamic = ["version"]
 dev = ["pytest>=7", "build", "twine"]
 # Pinned to a minor series: ruff adds rules in every release, so an unpinned
 # floor turns a green branch red on somebody else's schedule.
-lint = ["ruff>=0.16,<0.17", "numpydoc>=1.6"]
+lint = ["ruff>=0.16,<0.17", "numpydoc>=1.6", "mypy>=1.8"]
 
 # Regenerates the lookup tables into a user cache directory. Replaces
 # `python -m levy build`, which wrote 24 MB into the installed package.
@@ -79,7 +83,7 @@ include = ["levy*"]
 namespaces = false
 
 [tool.setuptools.package-data]
-levy = ["data/*.npz", "data/manifest.json"]
+levy = ["data/*.npz", "data/manifest.json", "py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -129,3 +133,38 @@ checks = ["all", "GL01", "ES01", "SA01", "EX01"]
 # __init__'s parameters are documented in the class docstring, per the numpydoc
 # style guide itself.
 exclude = ['\.__init__$']
+
+# The numerical core predates type annotations and is checked by tests, not by
+# mypy. The typed surface is checked strictly -- that is the part downstream
+# users' type checkers will see through py.typed.
+[tool.mypy]
+# Deliberately no `python_version`: mypy 1.19 refuses to target 3.9 while
+# running on a newer interpreter, and the NumPy stubs fail to parse when it
+# tries. The annotations here are 3.9-safe by construction -- PEP 585 builtin
+# generics only, no `X | Y` -- and the 3.9 test leg is what proves it at run
+# time.
+files = ["src/levy/api.py", "src/levy/_typing.py"]
+mypy_path = "src"
+strict = true
+
+# The core is not analysed at all: its symbols become `Any` here, which is
+# honest -- it has no annotations to trust. api.py is still checked strictly,
+# and converts everything it gets back to a declared type at the boundary, so
+# nothing untyped escapes into a user's type checker.
+[[tool.mypy.overrides]]
+module = [
+    "levy",
+    "levy.constants",
+    "levy.distribution",
+    "levy.fitting",
+    "levy.interpolation",
+    "levy.parametrization",
+    "levy.sampling",
+    "levy.tables",
+    "levy._build",
+    "levy._build.*",
+    "levy._logging",
+    "scipy.*",
+]
+ignore_missing_imports = true
+follow_imports = "skip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,11 @@ classifiers = [
 # scipy 1.1.0 (2018), neither of which installs on any currently supported
 # Python -- and setup.py never read that file anyway, so the pins were not even
 # enforced at install time. Exact pins belong in an application, not a library.
-dependencies = ["numpy>=1.20", "scipy>=1.5"]
+# pydantic is used only at the API boundary, never inside a likelihood
+# evaluation -- tests/test_hot_loop.py enforces that. It buys the error a user
+# actually wants ("alpha must be >= 0.5", pointing at their call) instead of a
+# wrong number from a clamped table index.
+dependencies = ["numpy>=1.20", "scipy>=1.5", "pydantic>=2.0"]
 
 dynamic = ["version"]
 
@@ -48,7 +52,7 @@ dynamic = ["version"]
 dev = ["pytest>=7", "build", "twine"]
 # Pinned to a minor series: ruff adds rules in every release, so an unpinned
 # floor turns a green branch red on somebody else's schedule.
-lint = ["ruff>=0.16,<0.17", "numpydoc>=1.6"]
+lint = ["ruff>=0.16,<0.17", "numpydoc>=1.6", "mypy>=1.8"]
 
 # Regenerates the lookup tables into a user cache directory. Replaces
 # `python -m levy build`, which wrote 24 MB into the installed package.
@@ -79,7 +83,7 @@ include = ["levy*"]
 namespaces = false
 
 [tool.setuptools.package-data]
-levy = ["data/*.npz", "data/manifest.json"]
+levy = ["data/*.npz", "data/manifest.json", "py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -137,3 +141,38 @@ checks = ["all", "GL01", "ES01", "SA01", "EX01"]
 # __init__'s parameters are documented in the class docstring, per the numpydoc
 # style guide itself.
 exclude = ['\.__init__$']
+
+# The numerical core predates type annotations and is checked by tests, not by
+# mypy. The typed surface is checked strictly -- that is the part downstream
+# users' type checkers will see through py.typed.
+[tool.mypy]
+# Deliberately no `python_version`: mypy 1.19 refuses to target 3.9 while
+# running on a newer interpreter, and the NumPy stubs fail to parse when it
+# tries. The annotations here are 3.9-safe by construction -- PEP 585 builtin
+# generics only, no `X | Y` -- and the 3.9 test leg is what proves it at run
+# time.
+files = ["src/levy/api.py", "src/levy/_typing.py"]
+mypy_path = "src"
+strict = true
+
+# The core is not analysed at all: its symbols become `Any` here, which is
+# honest -- it has no annotations to trust. api.py is still checked strictly,
+# and converts everything it gets back to a declared type at the boundary, so
+# nothing untyped escapes into a user's type checker.
+[[tool.mypy.overrides]]
+module = [
+    "levy",
+    "levy.constants",
+    "levy.distribution",
+    "levy.fitting",
+    "levy.interpolation",
+    "levy.parametrization",
+    "levy.sampling",
+    "levy.tables",
+    "levy._build",
+    "levy._build.*",
+    "levy._logging",
+    "scipy.*",
+]
+ignore_missing_imports = true
+follow_imports = "skip"

--- a/src/levy/__init__.py
+++ b/src/levy/__init__.py
@@ -51,6 +51,7 @@ whole public surface, so ``import levy`` behaves exactly as before:
 ``distribution``      ``levy`` and ``neglog_levy``
 ``fitting``           ``fit_levy``
 ``sampling``          ``random``
+``api``               the typed, validated API: ``pdf``/``cdf``/``rvs``/``fit``
 ``_build``            offline table generation (only the CLI imports it)
 ===================== =========================================================
 
@@ -154,10 +155,11 @@ _MOVED_TO_BUILD = {
 
 
 def __getattr__(name):
-    """Resolve the table-generation helpers that moved into ``levy._build``.
+    """Resolve `levy.api`, and the helpers that moved into ``levy._build``.
 
     PEP 562 module-level lookup, so ``levy._calculate_levy`` still works
-    without ``import levy`` pulling in ``scipy.integrate``.
+    without ``import levy`` pulling in ``scipy.integrate``, and ``levy.api``
+    resolves without it pulling in pydantic.
 
     Parameters
     ----------
@@ -174,6 +176,9 @@ def __getattr__(name):
     AttributeError
         For any other name, as a module lookup normally would.
     """
+    if name == 'api':
+        import levy.api as api_module
+        return api_module
     if name in _MOVED_TO_BUILD:
         from levy import _build
         return getattr(_build, _MOVED_TO_BUILD[name])

--- a/src/levy/__init__.py
+++ b/src/levy/__init__.py
@@ -51,6 +51,7 @@ whole public surface, so ``import levy`` behaves exactly as before:
 ``distribution``      ``levy`` and ``neglog_levy``
 ``fitting``           ``fit_levy``
 ``sampling``          ``random``
+``api``               the typed API: ``pdf``/``cdf``/``logpdf``/``rvs``/``fit``
 ``_build``            offline table generation (only the CLI imports it)
 ===================== =========================================================
 
@@ -155,10 +156,11 @@ _MOVED_TO_BUILD = {
 
 
 def __getattr__(name):
-    """Resolve the table-generation helpers that moved into ``levy._build``.
+    """Resolve `levy.api`, and the helpers that moved into ``levy._build``.
 
     PEP 562 module-level lookup, so ``levy._calculate_levy`` still works
-    without ``import levy`` pulling in ``scipy.integrate``.
+    without ``import levy`` pulling in ``scipy.integrate``, and ``levy.api``
+    resolves without it pulling in pydantic.
 
     Parameters
     ----------
@@ -175,6 +177,9 @@ def __getattr__(name):
     AttributeError
         For any other name, as a module lookup normally would.
     """
+    if name == 'api':
+        import levy.api as api_module
+        return api_module
     if name in _MOVED_TO_BUILD:
         from levy import _build
         return getattr(_build, _MOVED_TO_BUILD[name])

--- a/src/levy/_typing.py
+++ b/src/levy/_typing.py
@@ -1,0 +1,66 @@
+#    Copyright (C) 2017 José M. Miotto
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""Type aliases shared by the typed API.
+
+Kept in a module of their own so that :mod:`levy.api` can be checked with
+``mypy --strict`` without dragging the untyped numerical core along with it.
+
+Attributes
+----------
+Parametrization : type alias
+    The five parametrization tags, as a ``Literal``. Spelling these out is what
+    turns a mistyped ``par='b'`` into an error your editor shows you, rather
+    than a ``KeyError`` from inside a dict lookup at runtime.
+ArrayLike : type alias
+    Anything :func:`numpy.asarray` accepts.
+FloatArray : type alias
+    A NumPy array of ``float64``.
+Size : type alias
+    The shape argument of :func:`levy.api.rvs`.
+
+Notes
+-----
+``FloatArray`` and ``ArrayLike`` resolve to the precise ``numpy.typing`` forms
+under a type checker and to plain ``numpy.ndarray`` at run time. That is
+deliberate: ``numpy.typing.NDArray`` only appeared in NumPy 1.21, and the
+package supports 1.20. A type checker always has a modern NumPy; an installed
+copy may not.
+"""
+
+from typing import TYPE_CHECKING, Literal, Optional, Union
+
+import numpy as np
+
+__all__ = ['ArrayLike', 'FloatArray', 'Parametrization', 'Size']
+
+Parametrization = Literal['0', '1', 'M', 'A', 'B']
+
+Size = Union[int, tuple[int, ...], None]
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    ArrayLike = npt.ArrayLike
+    FloatArray = npt.NDArray[np.float64]
+else:
+    ArrayLike = object
+    FloatArray = np.ndarray
+
+#: Result of a scalar-or-array evaluation: a Python float for scalar input.
+ScalarOrArray = Union[float, "FloatArray"]
+
+#: A seed for the legacy global NumPy stream, or nothing.
+Seed = Optional[int]

--- a/src/levy/_typing.py
+++ b/src/levy/_typing.py
@@ -1,0 +1,69 @@
+#    Copyright (C) 2017 José M. Miotto
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""Type aliases shared by the typed API.
+
+Kept in a module of their own so that :mod:`levy.api` can be checked with
+``mypy --strict`` without dragging the untyped numerical core along with it.
+
+Attributes
+----------
+Parametrization : type alias
+    The five parametrization tags, as a ``Literal``. Spelling these out is what
+    turns a mistyped ``par='b'`` into an error your editor shows you, rather
+    than a ``KeyError`` from inside a dict lookup at runtime.
+ArrayLike : type alias
+    Anything :func:`numpy.asarray` accepts.
+FloatArray : type alias
+    A NumPy array of ``float64``.
+Size : type alias
+    The shape argument of :func:`levy.api.rvs`.
+
+Notes
+-----
+``FloatArray`` and ``ArrayLike`` resolve to the precise ``numpy.typing`` forms
+under a type checker and to plain ``numpy.ndarray`` at run time. That is
+deliberate: ``numpy.typing.NDArray`` only appeared in NumPy 1.21, and the
+package supports 1.20. A type checker always has a modern NumPy; an installed
+copy may not.
+"""
+
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+
+import numpy as np
+
+__all__ = ['ArrayLike', 'FloatArray', 'Parametrization', 'ScalarOrArray', 'Seed', 'Size']
+
+Parametrization = Literal['0', '1', 'M', 'A', 'B']
+
+# NumPy integer scalars are accepted alongside built-in ints: `np.int64` is
+# not an `int` subclass, and rvs() explicitly handles it, so the alias has to
+# say so or a checker rejects a call the runtime advertises as supported.
+Size = Union[int, "np.integer[Any]", tuple[Union[int, "np.integer[Any]"], ...], None]
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    ArrayLike = npt.ArrayLike
+    FloatArray = npt.NDArray[np.float64]
+else:
+    ArrayLike = object
+    FloatArray = np.ndarray
+
+#: Result of a scalar-or-array evaluation: a Python float for scalar input.
+ScalarOrArray = Union[float, "FloatArray"]
+
+#: A seed for the legacy global NumPy stream, or nothing.
+Seed = Optional[int]

--- a/src/levy/api.py
+++ b/src/levy/api.py
@@ -1,0 +1,606 @@
+#    Copyright (C) 2017 José M. Miotto
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""The typed, validated public API.
+
+Five keyword-only functions -- :func:`pdf`, :func:`cdf`, :func:`logpdf`,
+:func:`rvs` and :func:`fit` -- with the names a reader coming from
+``scipy.stats`` already knows, and a frozen :class:`StableParams` carrying
+validated parameters between them.
+
+The numerical core is untouched; every function here converts, validates once,
+and delegates. That is the whole design rule:
+
+**Pydantic sits at the boundary and never enters the hot loop.** A
+:class:`StableParams` is built when a call arrives and when a fit returns, and
+at no other time. :func:`fit` runs thousands of likelihood evaluations, and not
+one of them constructs a model -- ``tests/test_hot_loop.py`` counts the
+constructions during a 1000-point fit and fails if the number grows with the
+data.
+
+Examples
+--------
+>>> import numpy as np
+>>> from levy import api
+>>> np.round(api.cdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
+array([0.756342, 0.89496 ])
+
+Parameters can be carried around as a validated object instead of four loose
+floats:
+
+>>> params = api.StableParams(alpha=1.5, beta=0.0)
+>>> params
+StableParams(alpha=1.5, beta=0.0, mu=0.0, sigma=1.0)
+>>> np.round(api.pdf(np.array([1.0]), **params.as_kwargs()), 6)
+array([0.202038])
+
+Out-of-range values are rejected where they are given, not deep inside an
+interpolation:
+
+>>> try:
+...     api.StableParams(alpha=0.2, beta=0.0)
+... except Exception as error:
+...     print(type(error).__name__)
+ValidationError
+"""
+
+from typing import Any, cast
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict, Field
+
+from levy._typing import ArrayLike, FloatArray, Parametrization, ScalarOrArray, Seed, Size
+from levy.distribution import levy as _levy
+from levy.fitting import fit_levy as _fit_levy
+from levy.parametrization import Parameters
+from levy.sampling import random as _random
+
+__all__ = ['FitResult', 'StableParams', 'cdf', 'fit', 'logpdf', 'pdf', 'rvs']
+
+
+class StableParams(BaseModel):
+    """Validated parameters of a stable distribution, in parametrization 0.
+
+    Frozen and hashable, so an instance can be reused, cached or used as a
+    dictionary key without any risk of a later mutation invalidating the
+    validation it passed.
+
+    Attributes
+    ----------
+    alpha : float
+        Index of stability, in ``[0.5, 2]``. The lower bound is where the
+        lookup tables stop, not where the distribution family does.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location, ``delta_0`` in Nolan's notation.
+    sigma : float, default 1.0
+        Scale, strictly positive. ``gamma`` in Nolan's notation; note that it
+        corresponds to ``sqrt(2) * sigma`` of the Normal distribution.
+
+    See Also
+    --------
+    levy.parametrization.Parameters : The fitting-time wrapper, which also
+        tracks which components are held fixed.
+
+    Examples
+    --------
+    >>> StableParams(alpha=1.5, beta=-0.5, mu=1.0, sigma=2.0)
+    StableParams(alpha=1.5, beta=-0.5, mu=1.0, sigma=2.0)
+
+    Values from another parametrization are converted on the way in:
+
+    >>> p = StableParams.from_par(1.6, 0.5, 0.3, 1.2, par='1')
+    >>> round(p.mu, 6)
+    -0.135926
+    """
+
+    model_config = ConfigDict(frozen=True, extra='forbid')
+
+    alpha: float = Field(ge=0.5, le=2.0)
+    beta: float = Field(ge=-1.0, le=1.0)
+    mu: float = 0.0
+    sigma: float = Field(default=1.0, gt=0.0)
+
+    @classmethod
+    def from_par(
+        cls,
+        alpha: float,
+        beta: float,
+        loc: float,
+        scale: float,
+        par: Parametrization = '0',
+    ) -> "StableParams":
+        """Build from values written in any of the five parametrizations.
+
+        Parameters
+        ----------
+        alpha : float
+            First parameter, the index of stability in every parametrization.
+        beta : float
+            Second parameter: the skewness in 0, 1, M and A; ``beta_B`` in B.
+        loc : float
+            Third parameter: ``mu`` in 0 and 1, ``gamma`` in M, A and B.
+        scale : float
+            Fourth parameter: ``sigma`` in 0 and 1, ``lambda`` in M, A and B.
+        par : {'0', '1', 'M', 'A', 'B'}, default '0'
+            Which parametrization the four values are written in.
+
+        Returns
+        -------
+        StableParams
+            The same distribution, in parametrization 0.
+
+        Notes
+        -----
+        Validation happens *after* the conversion, because parametrization 0 is
+        what the lookup tables cover. A ``beta_B`` that is perfectly legal in B
+        can convert to a ``beta_0`` outside ``[-1, 1]``; catching that here is
+        the point.
+        """
+        values = np.asarray([alpha, beta, loc, scale], dtype='d')
+        if par != '0':
+            values = Parameters.convert(values, par, '0')
+        return cls(
+            alpha=float(values[0]),
+            beta=float(values[1]),
+            mu=float(values[2]),
+            sigma=float(values[3]),
+        )
+
+    def to_par(self, par: Parametrization) -> tuple[float, float, float, float]:
+        """Write these parameters in another parametrization.
+
+        Parameters
+        ----------
+        par : {'0', '1', 'M', 'A', 'B'}
+            Parametrization to convert to.
+
+        Returns
+        -------
+        tuple of float
+            The four values, in that parametrization's own order and meaning.
+
+        Examples
+        --------
+        >>> p = StableParams(alpha=1.5, beta=0.5, mu=0.0, sigma=1.2)
+        >>> tuple(round(v, 6) for v in p.to_par('1'))
+        (1.5, 0.5, 0.6, 1.2)
+        """
+        values = np.asarray(self.as_tuple(), dtype='d')
+        if par == '0':
+            return self.as_tuple()
+        converted = Parameters.convert(values, '0', par)
+        return (
+            float(converted[0]), float(converted[1]),
+            float(converted[2]), float(converted[3]),
+        )
+
+    def as_tuple(self) -> tuple[float, float, float, float]:
+        """Return the four parameters positionally.
+
+        Returns
+        -------
+        tuple of float
+            ``(alpha, beta, mu, sigma)``.
+        """
+        return (self.alpha, self.beta, self.mu, self.sigma)
+
+    def as_kwargs(self) -> dict[str, float]:
+        """Return the four parameters as keyword arguments for this module.
+
+        Returns
+        -------
+        dict
+            ``{'alpha': ..., 'beta': ..., 'mu': ..., 'sigma': ...}``, ready to
+            splat into :func:`pdf`, :func:`cdf`, :func:`logpdf` or :func:`rvs`.
+        """
+        return {'alpha': self.alpha, 'beta': self.beta,
+                'mu': self.mu, 'sigma': self.sigma}
+
+
+class FitResult(BaseModel):
+    """Outcome of a maximum-likelihood fit.
+
+    Attributes
+    ----------
+    params : StableParams
+        The fitted parameters, always in parametrization 0.
+    negative_log_likelihood : float
+        Value of the objective at the optimum. Lower is a better fit.
+    parametrization : {'0', '1', 'M', 'A', 'B'}
+        The parametrization the search was carried out in. It changes the
+        feasible region and the starting point, so it is worth recording.
+
+    Examples
+    --------
+    >>> x = rvs(alpha=1.5, beta=0.0, size=200, random_state=0)
+    >>> result = fit(x)
+    >>> tuple(round(v, 2) for v in result.params.as_tuple())
+    (1.52, -0.08, 0.05, 0.99)
+    >>> round(result.negative_log_likelihood, 3)
+    402.372
+    """
+
+    model_config = ConfigDict(frozen=True, extra='forbid')
+
+    params: StableParams
+    negative_log_likelihood: float
+    parametrization: Parametrization = '0'
+
+    def as_par(self, par: Parametrization) -> tuple[float, float, float, float]:
+        """Write the fitted parameters in another parametrization.
+
+        Parameters
+        ----------
+        par : {'0', '1', 'M', 'A', 'B'}
+            Parametrization to convert to.
+
+        Returns
+        -------
+        tuple of float
+            The four fitted values in that parametrization.
+        """
+        return self.params.to_par(par)
+
+
+def _narrow(value: Any) -> ScalarOrArray:
+    """Give the untyped core's return value a declared type.
+
+    Parameters
+    ----------
+    value : object
+        Whatever :mod:`levy.distribution` or :mod:`levy.sampling` returned.
+
+    Returns
+    -------
+    float or ndarray
+        `value` itself if it is an array, otherwise a Python float.
+
+    Notes
+    -----
+    The numerical core carries no annotations, so mypy sees ``Any`` coming back
+    from it. Rather than asserting a type with a bare ``cast``, this checks
+    one -- the cost is a single ``isinstance`` per call, not per element, and
+    it means the declared return type of every public function is something
+    that was actually verified.
+    """
+    if isinstance(value, np.ndarray):
+        return cast(FloatArray, value)
+    return float(value)
+
+
+def _validated(
+    alpha: float, beta: float, mu: float, sigma: float, par: Parametrization
+) -> StableParams:
+    """Validate one set of parameters at the API boundary.
+
+    Parameters
+    ----------
+    alpha, beta, mu, sigma : float
+        The four parameters, in `par`.
+    par : {'0', '1', 'M', 'A', 'B'}
+        Parametrization they are written in.
+
+    Returns
+    -------
+    StableParams
+        The validated parameters, in parametrization 0.
+    """
+    if par == '0':
+        return StableParams(alpha=alpha, beta=beta, mu=mu, sigma=sigma)
+    return StableParams.from_par(alpha, beta, mu, sigma, par=par)
+
+
+def pdf(
+    x: ArrayLike,
+    *,
+    alpha: float,
+    beta: float,
+    mu: float = 0.0,
+    sigma: float = 1.0,
+    par: Parametrization = '0',
+) -> ScalarOrArray:
+    """Evaluate the probability density function.
+
+    Parameters
+    ----------
+    x : array_like
+        Points to evaluate at. A scalar in gives a float out.
+    alpha : float
+        Index of stability, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location.
+    sigma : float, default 1.0
+        Scale, strictly positive.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the four parameters are written in.
+
+    Returns
+    -------
+    float or ndarray
+        The density at `x`.
+
+    Raises
+    ------
+    pydantic.ValidationError
+        If the parameters, once converted to parametrization 0, fall outside
+        what the lookup tables cover.
+
+    See Also
+    --------
+    cdf : The distribution function.
+    logpdf : The log density, which is what fitting actually uses.
+
+    Examples
+    --------
+    >>> np.round(pdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
+    array([0.202038, 0.084539])
+    """
+    p = _validated(alpha, beta, mu, sigma, par)
+    return _narrow(_levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=False))
+
+
+def cdf(
+    x: ArrayLike,
+    *,
+    alpha: float,
+    beta: float,
+    mu: float = 0.0,
+    sigma: float = 1.0,
+    par: Parametrization = '0',
+) -> ScalarOrArray:
+    """Evaluate the cumulative distribution function.
+
+    Parameters
+    ----------
+    x : array_like
+        Points to evaluate at. A scalar in gives a float out.
+    alpha : float
+        Index of stability, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location.
+    sigma : float, default 1.0
+        Scale, strictly positive.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the four parameters are written in.
+
+    Returns
+    -------
+    float or ndarray
+        The distribution function at `x`.
+
+    Raises
+    ------
+    pydantic.ValidationError
+        If the parameters, once converted to parametrization 0, fall outside
+        what the lookup tables cover.
+
+    See Also
+    --------
+    pdf : The density.
+
+    Examples
+    --------
+    >>> np.round(cdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
+    array([0.756342, 0.89496 ])
+    """
+    p = _validated(alpha, beta, mu, sigma, par)
+    return _narrow(_levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=True))
+
+
+def logpdf(
+    x: ArrayLike,
+    *,
+    alpha: float,
+    beta: float,
+    mu: float = 0.0,
+    sigma: float = 1.0,
+    par: Parametrization = '0',
+) -> ScalarOrArray:
+    """Evaluate the log of the probability density function.
+
+    Parameters
+    ----------
+    x : array_like
+        Points to evaluate at.
+    alpha : float
+        Index of stability, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location.
+    sigma : float, default 1.0
+        Scale, strictly positive.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the four parameters are written in.
+
+    Returns
+    -------
+    float or ndarray
+        ``log(pdf(x))``.
+
+    See Also
+    --------
+    levy.distribution.neglog_levy : The same quantity negated, as the fit uses
+        it.
+
+    Notes
+    -----
+    Note the sign. This returns the log density, following ``scipy.stats``;
+    the 1.x function ``levy.neglog_levy`` returns its negative, and both remain
+    available. Densities are floored at 1e-100 before the logarithm, so the
+    result is bounded below by about -230 rather than being ``-inf``.
+
+    Examples
+    --------
+    >>> np.round(logpdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
+    array([-1.599299, -2.470541])
+    """
+    p = _validated(alpha, beta, mu, sigma, par)
+    values = _levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=False)
+    return _narrow(np.log(np.maximum(1e-100, values)))
+
+
+def rvs(
+    *,
+    alpha: float,
+    beta: float,
+    mu: float = 0.0,
+    sigma: float = 1.0,
+    par: Parametrization = '0',
+    size: Size = None,
+    random_state: Seed = None,
+) -> ScalarOrArray:
+    """Draw random variates.
+
+    Parameters
+    ----------
+    alpha : float
+        Index of stability, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location.
+    sigma : float, default 1.0
+        Scale, strictly positive.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the four parameters are written in.
+    size : int or tuple of int, optional
+        Shape of the result. The default draws a single scalar.
+    random_state : int, optional
+        Seed for the draw. The global ``numpy.random`` stream is used either
+        way; this seeds it, then restores whatever state it had, so calling
+        with a seed does not disturb a surrounding sequence.
+
+    Returns
+    -------
+    float or ndarray
+        The variates.
+
+    See Also
+    --------
+    levy.sampling.random : The 1.x spelling, taking ``shape`` instead of
+        ``size``.
+
+    Notes
+    -----
+    Sampling still runs on the legacy global ``numpy.random`` stream rather
+    than a ``Generator``, so that seeded results match 1.x exactly.
+    ``random_state`` therefore takes a seed, not a ``Generator``; accepting one
+    would mean reimplementing the sampler and changing every seeded number.
+
+    Examples
+    --------
+    >>> np.round(rvs(alpha=1.5, beta=0.0, size=4, random_state=0), 6)
+    array([0.218654, 0.775259, 0.454604, 0.10272 ])
+
+    The surrounding stream is left where it was:
+
+    >>> np.random.seed(7)
+    >>> before = np.random.random()
+    >>> np.random.seed(7)
+    >>> _ = rvs(alpha=1.5, beta=0.0, size=3, random_state=0)
+    >>> bool(np.random.random() == before)
+    True
+    """
+    p = _validated(alpha, beta, mu, sigma, par)
+    shape: tuple[int, ...] = () if size is None else (
+        (size,) if isinstance(size, int) else tuple(size))
+
+    if random_state is None:
+        return _narrow(_random(p.alpha, p.beta, p.mu, p.sigma, shape=shape))
+
+    state = np.random.get_state()
+    try:
+        np.random.seed(random_state)
+        return _narrow(_random(p.alpha, p.beta, p.mu, p.sigma, shape=shape))
+    finally:
+        np.random.set_state(state)
+
+
+def fit(
+    x: ArrayLike,
+    *,
+    par: Parametrization = '0',
+    **fixed: float,
+) -> FitResult:
+    """Fit a stable distribution to data by maximum likelihood.
+
+    Parameters
+    ----------
+    x : array_like
+        The sample.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization to search in. It sets the feasible region and the
+        starting point, so different choices can reach different optima.
+    **fixed
+        Any of the names in ``levy.par_names[par]``, pinned to a value instead
+        of being estimated.
+
+    Returns
+    -------
+    FitResult
+        The fitted parameters, in parametrization 0, and the negative log
+        likelihood at the optimum.
+
+    Raises
+    ------
+    TypeError
+        If a keyword is not a parameter name of `par`. The 1.x
+        :func:`levy.fitting.fit_levy` silently ignored such a keyword, so a
+        typo cost you an unconstrained fit and no warning.
+
+    See Also
+    --------
+    levy.fitting.fit_levy : The 1.x spelling, returning a ``Parameters`` object.
+
+    Notes
+    -----
+    A :class:`StableParams` is constructed twice per call -- never inside the
+    optimizer's loop. See the module docstring.
+
+    Examples
+    --------
+    >>> x = rvs(alpha=1.5, beta=0.0, size=200, random_state=0)
+    >>> tuple(round(v, 2) for v in fit(x).params.as_tuple())
+    (1.52, -0.08, 0.05, 0.99)
+
+    Pinning a parameter restricts the search:
+
+    >>> tuple(round(v, 2) for v in fit(x, beta=0.0).params.as_tuple())
+    (1.53, 0.0, 0.03, 0.99)
+    """
+    from levy.constants import par_names
+
+    unknown = set(fixed) - set(par_names[par])
+    if unknown:
+        raise TypeError(
+            f'fit() got unexpected keyword argument(s) '
+            f'{", ".join(sorted(unknown))}; parametrization {par!r} takes '
+            f'{", ".join(par_names[par])}'
+        )
+
+    parameters, nll = _fit_levy(np.asarray(x, dtype='d'), par=par, **fixed)
+    alpha, beta, mu, sigma = (float(v) for v in parameters.get('0'))
+    return FitResult(
+        params=StableParams(alpha=alpha, beta=beta, mu=mu, sigma=sigma),
+        negative_log_likelihood=float(nll),
+        parametrization=par,
+    )

--- a/src/levy/api.py
+++ b/src/levy/api.py
@@ -1,0 +1,692 @@
+#    Copyright (C) 2017 José M. Miotto
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""The typed, validated public API.
+
+Five keyword-only functions -- :func:`pdf`, :func:`cdf`, :func:`logpdf`,
+:func:`rvs` and :func:`fit` -- with the names a reader coming from
+``scipy.stats`` already knows, and a frozen :class:`StableParams` carrying
+validated parameters between them.
+
+The numerical core is untouched; every function here converts, validates once,
+and delegates. That is the whole design rule:
+
+**Pydantic sits at the boundary and never enters the hot loop.** A
+:class:`StableParams` is built when a call arrives, and once more when
+:func:`fit` returns -- one construction per fit, whatever the sample size.
+:func:`fit` runs thousands of likelihood evaluations, and not one of them
+constructs a model; ``tests/test_hot_loop.py`` counts the constructions during
+a 1000-point fit and fails if the number grows with the data.
+
+Examples
+--------
+>>> import numpy as np
+>>> from levy import api
+>>> np.round(api.cdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
+array([0.756342, 0.89496 ])
+
+Parameters can be carried around as a validated object instead of four loose
+floats:
+
+>>> params = api.StableParams(alpha=1.5, beta=0.0)
+>>> params
+StableParams(alpha=1.5, beta=0.0, mu=0.0, sigma=1.0)
+>>> np.round(api.pdf(np.array([1.0]), **params.as_kwargs()), 6)
+array([0.202038])
+
+Out-of-range values are rejected where they are given, not deep inside an
+interpolation:
+
+>>> try:
+...     api.StableParams(alpha=0.2, beta=0.0)
+... except Exception as error:
+...     print(type(error).__name__)
+ValidationError
+"""
+
+import operator
+from typing import Any, cast
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict, Field
+
+from levy._typing import ArrayLike, FloatArray, Parametrization, ScalarOrArray, Seed, Size
+from levy.constants import par_names
+from levy.distribution import levy as _levy
+from levy.fitting import fit_levy as _fit_levy
+from levy.parametrization import Parameters
+from levy.sampling import random as _random
+
+__all__ = ['FitResult', 'StableParams', 'cdf', 'fit', 'logpdf', 'pdf', 'rvs']
+
+
+def _check_par(par: Any) -> None:
+    """Reject a parametrization name the package does not know.
+
+    Parameters
+    ----------
+    par : object
+        The value given for ``par``.
+
+    Raises
+    ------
+    ValueError
+        If `par` is not one of the five names, listing them. Without this an
+        unknown name surfaced as a ``KeyError`` from a conversion table
+        several frames down, naming neither the argument nor the choices.
+    """
+    if par not in par_names:
+        raise ValueError(
+            f'par must be one of {", ".join(repr(name) for name in par_names)}, got {par!r}')
+
+
+class StableParams(BaseModel):
+    """Validated parameters of a stable distribution, in parametrization 0.
+
+    Frozen and hashable, so an instance can be reused, cached or used as a
+    dictionary key without any risk of a later mutation invalidating the
+    validation it passed.
+
+    Attributes
+    ----------
+    alpha : float
+        Index of stability, in ``[0.5, 2]``. The lower bound is where the
+        lookup tables stop, not where the distribution family does.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location, ``delta_0`` in Nolan's notation.
+    sigma : float, default 1.0
+        Scale, strictly positive. ``gamma`` in Nolan's notation; note that it
+        corresponds to ``sqrt(2) * sigma`` of the Normal distribution.
+
+    See Also
+    --------
+    levy.parametrization.Parameters : The fitting-time wrapper, which also
+        tracks which components are held fixed.
+
+    Examples
+    --------
+    >>> StableParams(alpha=1.5, beta=-0.5, mu=1.0, sigma=2.0)
+    StableParams(alpha=1.5, beta=-0.5, mu=1.0, sigma=2.0)
+
+    Values from another parametrization are converted on the way in:
+
+    >>> p = StableParams.from_par(1.6, 0.5, 0.3, 1.2, par='1')
+    >>> round(p.mu, 6)
+    -0.135926
+    """
+
+    # allow_inf_nan=False: sigma=inf satisfies gt=0 and then divides the
+    # density into zeros; an infinite or NaN parameter is not a distribution.
+    model_config = ConfigDict(frozen=True, extra='forbid', allow_inf_nan=False)
+
+    alpha: float = Field(ge=0.5, le=2.0)
+    beta: float = Field(ge=-1.0, le=1.0)
+    mu: float = 0.0
+    sigma: float = Field(default=1.0, gt=0.0)
+
+    @classmethod
+    def from_par(
+        cls,
+        alpha: float,
+        beta: float,
+        loc: float,
+        scale: float,
+        par: Parametrization = '0',
+    ) -> "StableParams":
+        """Build from values written in any of the five parametrizations.
+
+        Parameters
+        ----------
+        alpha : float
+            First parameter, the index of stability in every parametrization.
+        beta : float
+            Second parameter: the skewness in 0, 1, M and A; ``beta_B`` in B.
+        loc : float
+            Third parameter: ``mu`` in 0 and 1, ``gamma`` in M, A and B.
+        scale : float
+            Fourth parameter: ``sigma`` in 0 and 1, ``lambda`` in M, A and B.
+        par : {'0', '1', 'M', 'A', 'B'}, default '0'
+            Which parametrization the four values are written in.
+
+        Returns
+        -------
+        StableParams
+            The same distribution, in parametrization 0.
+
+        Notes
+        -----
+        Validation happens *after* the conversion, because parametrization 0 is
+        what the lookup tables cover. A ``beta_B`` that is perfectly legal in B
+        can convert to a ``beta_0`` outside ``[-1, 1]``; catching that here is
+        the point.
+        """
+        _check_par(par)
+        values = np.asarray([alpha, beta, loc, scale], dtype='d')
+        if par != '0':
+            values = Parameters.convert(values, par, '0')
+        return cls(
+            alpha=float(values[0]),
+            beta=float(values[1]),
+            mu=float(values[2]),
+            sigma=float(values[3]),
+        )
+
+    def to_par(self, par: Parametrization) -> tuple[float, float, float, float]:
+        """Write these parameters in another parametrization.
+
+        Parameters
+        ----------
+        par : {'0', '1', 'M', 'A', 'B'}
+            Parametrization to convert to.
+
+        Returns
+        -------
+        tuple of float
+            The four values, in that parametrization's own order and meaning.
+
+        Raises
+        ------
+        ValueError
+            If the conversion is singular for these values -- B at
+            ``alpha = 1`` -- and would return a non-finite parameter.
+
+        Examples
+        --------
+        >>> p = StableParams(alpha=1.5, beta=0.5, mu=0.0, sigma=1.2)
+        >>> tuple(round(v, 6) for v in p.to_par('1'))
+        (1.5, 0.5, 0.6, 1.2)
+        """
+        _check_par(par)
+        values = np.asarray(self.as_tuple(), dtype='d')
+        if par == '0':
+            return self.as_tuple()
+        # errstate: the singular case below divides 0/0 and x/0 on purpose,
+        # and the ValueError is the report -- not a RuntimeWarning as well.
+        with np.errstate(divide='ignore', invalid='ignore'):
+            converted = Parameters.convert(values, '0', par)
+        if not np.all(np.isfinite(converted)):
+            # Zolotarev's B is singular at alpha = 1: beta_B is
+            # arctan(beta_0 * tan(pi*alpha/2)) / psi(alpha) with both parts
+            # degenerate there, so the result is nan or inf. Returning that
+            # would hand back a tuple from_par cannot accept.
+            raise ValueError(
+                f'parametrization {par!r} is singular at alpha={self.alpha}: '
+                f'the conversion gives {tuple(converted)}. Use another '
+                f'parametrization there, or move alpha off the singular value.'
+            )
+        return (
+            float(converted[0]), float(converted[1]),
+            float(converted[2]), float(converted[3]),
+        )
+
+    def as_tuple(self) -> tuple[float, float, float, float]:
+        """Return the four parameters positionally.
+
+        Returns
+        -------
+        tuple of float
+            ``(alpha, beta, mu, sigma)``.
+        """
+        return (self.alpha, self.beta, self.mu, self.sigma)
+
+    def as_kwargs(self) -> dict[str, float]:
+        """Return the four parameters as keyword arguments for this module.
+
+        Returns
+        -------
+        dict
+            ``{'alpha': ..., 'beta': ..., 'mu': ..., 'sigma': ...}``, ready to
+            splat into :func:`pdf`, :func:`cdf`, :func:`logpdf` or :func:`rvs`.
+        """
+        return {'alpha': self.alpha, 'beta': self.beta,
+                'mu': self.mu, 'sigma': self.sigma}
+
+
+class FitResult(BaseModel):
+    """Outcome of a maximum-likelihood fit.
+
+    Attributes
+    ----------
+    params : StableParams
+        The fitted parameters, always in parametrization 0.
+    negative_log_likelihood : float
+        Value of the objective at the optimum. Lower is a better fit.
+    parametrization : {'0', '1', 'M', 'A', 'B'}
+        The parametrization the search was carried out in. It changes the
+        feasible region and the starting point, so it is worth recording.
+
+    Examples
+    --------
+    >>> x = rvs(alpha=1.5, beta=0.0, size=200, random_state=0)
+    >>> result = fit(x)
+    >>> tuple(round(v, 2) for v in result.params.as_tuple())
+    (1.52, -0.08, 0.05, 0.99)
+    >>> round(result.negative_log_likelihood, 3)
+    402.372
+    """
+
+    model_config = ConfigDict(frozen=True, extra='forbid')
+
+    params: StableParams
+    negative_log_likelihood: float
+    parametrization: Parametrization = '0'
+
+    def as_par(self, par: Parametrization) -> tuple[float, float, float, float]:
+        """Write the fitted parameters in another parametrization.
+
+        Parameters
+        ----------
+        par : {'0', '1', 'M', 'A', 'B'}
+            Parametrization to convert to.
+
+        Returns
+        -------
+        tuple of float
+            The four fitted values in that parametrization.
+        """
+        return self.params.to_par(par)
+
+
+def _narrow(value: Any) -> ScalarOrArray:
+    """Give the untyped core's return value a declared type.
+
+    Parameters
+    ----------
+    value : object
+        Whatever :mod:`levy.distribution` or :mod:`levy.sampling` returned.
+
+    Returns
+    -------
+    float or ndarray
+        `value` itself if it is an array, otherwise a Python float.
+
+    Notes
+    -----
+    The numerical core carries no annotations, so mypy sees ``Any`` coming back
+    from it. Rather than asserting a type with a bare ``cast``, this checks
+    one -- the cost is a single ``isinstance`` per call, not per element, and
+    it means the declared return type of every public function is something
+    that was actually verified.
+    """
+    if isinstance(value, np.ndarray):
+        return cast(FloatArray, value)
+    return float(value)
+
+
+def _validated(
+    alpha: float, beta: float, mu: float, sigma: float, par: Parametrization
+) -> StableParams:
+    """Validate one set of parameters at the API boundary.
+
+    Parameters
+    ----------
+    alpha, beta, mu, sigma : float
+        The four parameters, in `par`.
+    par : {'0', '1', 'M', 'A', 'B'}
+        Parametrization they are written in.
+
+    Returns
+    -------
+    StableParams
+        The validated parameters, in parametrization 0.
+    """
+    if par == '0':
+        return StableParams(alpha=alpha, beta=beta, mu=mu, sigma=sigma)
+    return StableParams.from_par(alpha, beta, mu, sigma, par=par)
+
+
+def pdf(
+    x: ArrayLike,
+    *,
+    alpha: float,
+    beta: float,
+    mu: float = 0.0,
+    sigma: float = 1.0,
+    par: Parametrization = '0',
+) -> ScalarOrArray:
+    """Evaluate the probability density function.
+
+    Parameters
+    ----------
+    x : array_like
+        Points to evaluate at. A scalar input gives a float result.
+    alpha : float
+        Index of stability, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location.
+    sigma : float, default 1.0
+        Scale, strictly positive.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the four parameters are written in.
+
+    Returns
+    -------
+    float or ndarray
+        The density at `x`.
+
+    Raises
+    ------
+    pydantic.ValidationError
+        If the parameters, once converted to parametrization 0, fall outside
+        what the lookup tables cover.
+
+    See Also
+    --------
+    cdf : The distribution function.
+    logpdf : The log density, which is what fitting actually uses.
+
+    Examples
+    --------
+    >>> np.round(pdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
+    array([0.202038, 0.084539])
+    """
+    p = _validated(alpha, beta, mu, sigma, par)
+    return _narrow(_levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=False))
+
+
+def cdf(
+    x: ArrayLike,
+    *,
+    alpha: float,
+    beta: float,
+    mu: float = 0.0,
+    sigma: float = 1.0,
+    par: Parametrization = '0',
+) -> ScalarOrArray:
+    """Evaluate the cumulative distribution function.
+
+    Parameters
+    ----------
+    x : array_like
+        Points to evaluate at. A scalar input gives a float result.
+    alpha : float
+        Index of stability, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location.
+    sigma : float, default 1.0
+        Scale, strictly positive.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the four parameters are written in.
+
+    Returns
+    -------
+    float or ndarray
+        The distribution function at `x`.
+
+    Raises
+    ------
+    pydantic.ValidationError
+        If the parameters, once converted to parametrization 0, fall outside
+        what the lookup tables cover.
+
+    See Also
+    --------
+    pdf : The density.
+
+    Examples
+    --------
+    >>> np.round(cdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
+    array([0.756342, 0.89496 ])
+    """
+    p = _validated(alpha, beta, mu, sigma, par)
+    return _narrow(_levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=True))
+
+
+def logpdf(
+    x: ArrayLike,
+    *,
+    alpha: float,
+    beta: float,
+    mu: float = 0.0,
+    sigma: float = 1.0,
+    par: Parametrization = '0',
+) -> ScalarOrArray:
+    """Evaluate the log of the probability density function.
+
+    Parameters
+    ----------
+    x : array_like
+        Points to evaluate at.
+    alpha : float
+        Index of stability, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location.
+    sigma : float, default 1.0
+        Scale, strictly positive.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the four parameters are written in.
+
+    Returns
+    -------
+    float or ndarray
+        ``log(pdf(x))``.
+
+    See Also
+    --------
+    levy.distribution.neglog_levy : The same quantity negated, as the fit uses
+        it.
+
+    Notes
+    -----
+    Note the sign. This returns the log density, following ``scipy.stats``;
+    the 1.x function ``levy.neglog_levy`` returns its negative, and both remain
+    available. Densities are floored at 1e-100 before the logarithm, so the
+    result is bounded below by about -230 rather than being ``-inf``.
+
+    Examples
+    --------
+    >>> np.round(logpdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
+    array([-1.599299, -2.470541])
+    """
+    p = _validated(alpha, beta, mu, sigma, par)
+    values = _levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=False)
+    return _narrow(np.log(np.maximum(1e-100, values)))
+
+
+def rvs(
+    *,
+    alpha: float,
+    beta: float,
+    mu: float = 0.0,
+    sigma: float = 1.0,
+    par: Parametrization = '0',
+    size: Size = None,
+    random_state: Seed = None,
+) -> ScalarOrArray:
+    """Draw random variates.
+
+    Parameters
+    ----------
+    alpha : float
+        Index of stability, in ``[0.5, 2]``.
+    beta : float
+        Skewness, in ``[-1, 1]``.
+    mu : float, default 0.0
+        Location.
+    sigma : float, default 1.0
+        Scale, strictly positive.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization the four parameters are written in.
+    size : int or tuple of int, optional
+        Shape of the result. The default draws a single scalar.
+    random_state : int, optional
+        Seed for the draw. The global ``numpy.random`` stream is used either
+        way; this seeds it, then restores whatever state it had, so calling
+        with a seed does not disturb a surrounding sequence.
+
+    Returns
+    -------
+    float or ndarray
+        The variates.
+
+    See Also
+    --------
+    levy.sampling.random : The 1.x spelling, taking ``shape`` instead of
+        ``size``.
+
+    Notes
+    -----
+    Sampling still runs on the legacy global ``numpy.random`` stream rather
+    than a ``Generator``, so that seeded results match 1.x exactly.
+    ``random_state`` therefore takes a seed, not a ``Generator``; accepting one
+    would mean reimplementing the sampler and changing every seeded number.
+
+    For the same reason a seeded call saves the global stream's state, seeds,
+    draws and restores it. That sequence is not synchronised: two threads
+    making seeded calls at once can restore each other's stale state, and
+    the guarantee that the surrounding stream is left where it was then
+    fails. Seeded calls are single-threaded by contract; unseeded ones are
+    as thread-safe as ``numpy.random`` itself.
+
+    Examples
+    --------
+    >>> np.round(rvs(alpha=1.5, beta=0.0, size=4, random_state=0), 6)
+    array([0.218654, 0.775259, 0.454604, 0.10272 ])
+
+    The surrounding stream is left where it was:
+
+    >>> np.random.seed(7)
+    >>> before = np.random.random()
+    >>> np.random.seed(7)
+    >>> _ = rvs(alpha=1.5, beta=0.0, size=3, random_state=0)
+    >>> bool(np.random.random() == before)
+    True
+    """
+    p = _validated(alpha, beta, mu, sigma, par)
+    # np.integer, not just int: a NumPy integer scalar is neither an int
+    # subclass nor iterable, so it used to fall through to tuple(size) and
+    # raise. `rvs(size=np.int64(10))` is an ordinary thing to write.
+    # operator.index, not int(): int(2.5) is 2, so a float shape would be
+    # silently truncated, whereas __index__ is defined only by integers --
+    # built-in and NumPy alike -- and raises TypeError for anything else.
+    shape: tuple[int, ...] = () if size is None else (
+        (operator.index(size),) if isinstance(size, (int, np.integer))
+        else tuple(operator.index(item) for item in size))
+
+    if random_state is None:
+        return _narrow(_random(p.alpha, p.beta, p.mu, p.sigma, shape=shape))
+
+    state = np.random.get_state()
+    try:
+        np.random.seed(random_state)
+        return _narrow(_random(p.alpha, p.beta, p.mu, p.sigma, shape=shape))
+    finally:
+        np.random.set_state(state)
+
+
+def fit(
+    x: ArrayLike,
+    *,
+    par: Parametrization = '0',
+    **fixed: float,
+) -> FitResult:
+    """Fit a stable distribution to data by maximum likelihood.
+
+    Parameters
+    ----------
+    x : array_like
+        The sample.
+    par : {'0', '1', 'M', 'A', 'B'}, default '0'
+        Parametrization to search in. It sets the feasible region and the
+        starting point, so different choices can reach different optima.
+    **fixed
+        Any of the names in ``levy.par_names[par]``, pinned to a value instead
+        of being estimated.
+
+    Returns
+    -------
+    FitResult
+        The fitted parameters, in parametrization 0, and the negative log
+        likelihood at the optimum.
+
+    Raises
+    ------
+    TypeError
+        If a keyword is not a parameter name of `par`. The 1.x
+        :func:`levy.fitting.fit_levy` silently ignored such a keyword, so a
+        typo cost you an unconstrained fit and no warning.
+
+    See Also
+    --------
+    levy.fitting.fit_levy : The 1.x spelling, returning a ``Parameters`` object.
+
+    Notes
+    -----
+    A :class:`StableParams` is constructed twice per call -- never inside the
+    optimizer's loop. See the module docstring.
+
+    Examples
+    --------
+    >>> x = rvs(alpha=1.5, beta=0.0, size=200, random_state=0)
+    >>> tuple(round(v, 2) for v in fit(x).params.as_tuple())
+    (1.52, -0.08, 0.05, 0.99)
+
+    Pinning a parameter restricts the search:
+
+    >>> tuple(round(v, 2) for v in fit(x, beta=0.0).params.as_tuple())
+    (1.53, 0.0, 0.03, 0.99)
+    """
+    _check_par(par)
+    unknown = set(fixed) - set(par_names[par])
+    if unknown:
+        raise TypeError(
+            f'fit() got unexpected keyword argument(s) '
+            f'{", ".join(sorted(unknown))}; parametrization {par!r} takes '
+            f'{", ".join(par_names[par])}'
+        )
+
+    # The names were checked; the values were not. A pinned scale of 0 reaches
+    # the optimizer and divides by zero inside levy(), and an out-of-range
+    # alpha indexes the lookup tables from the wrong end. These are the same
+    # bounds StableParams enforces on the evaluation side; the third name is
+    # a location and is unbounded, the fourth is a scale in every
+    # parametrization.
+    names = par_names[par]
+    # Normalised once, and the normalised values are what the fitter gets:
+    # checking float(value) and then passing `value` through would let a
+    # string or a 0-d array that happens to convert reach the optimizer as
+    # it came.
+    pinned = {name: float(value) for name, value in fixed.items()}
+    # Finite first: inf satisfies `> 0` and nan satisfies nothing, and either
+    # would otherwise reach the optimizer, where StableParams would have
+    # refused it on the evaluation side.
+    for name, value in pinned.items():
+        if not np.isfinite(value):
+            raise ValueError(f'{name} must be finite, got {fixed[name]!r}')
+    for name, low, high in ((names[0], 0.5, 2.0), (names[1], -1.0, 1.0)):
+        if name in pinned and not low <= pinned[name] <= high:
+            raise ValueError(
+                f'{name} must lie in [{low}, {high}], got {fixed[name]!r}'
+            )
+    if names[3] in pinned and not pinned[names[3]] > 0.0:
+        raise ValueError(
+            f'{names[3]} must be strictly positive, got {fixed[names[3]]!r}'
+        )
+
+    parameters, nll = _fit_levy(np.asarray(x, dtype='d'), par=par, **pinned)
+    alpha, beta, mu, sigma = (float(v) for v in parameters.get('0'))
+    return FitResult(
+        params=StableParams(alpha=alpha, beta=beta, mu=mu, sigma=sigma),
+        negative_log_likelihood=float(nll),
+        parametrization=par,
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,300 @@
+"""The typed API: parity with 1.x, validation, and the shapes of the results.
+
+The point of every parity test here is that `api` adds a boundary and changes
+no numbers. Where a 1.x call and an `api` call describe the same thing, the
+floats must be bit-identical, not merely close.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import levy
+
+pytest.importorskip("pydantic")
+
+from pydantic import ValidationError  # noqa: E402
+
+from levy import api  # noqa: E402
+
+PARAMETRIZATIONS = ["0", "1", "M", "A", "B"]
+
+GRID = [
+    (0.7, -0.5, 0.0, 1.0),
+    (1.0, 0.0, 0.0, 1.0),
+    (1.3, 0.9, -2.0, 0.5),
+    (1.5, 0.0, 0.0, 1.0),
+    (1.9, -1.0, 3.0, 2.0),
+    (2.0, 0.0, 0.0, 1.0),
+]
+
+XS = np.concatenate([
+    np.linspace(-40.0, 40.0, 161),
+    np.linspace(-2.0, 2.0, 41),
+])
+
+
+# --------------------------------------------------------------------------
+# parity with the 1.x functions
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), GRID)
+def test_pdf_is_bit_identical_to_levy(alpha, beta, mu, sigma):
+    expected = levy.levy(XS, alpha, beta, mu, sigma, cdf=False)
+    got = api.pdf(XS, alpha=alpha, beta=beta, mu=mu, sigma=sigma)
+    assert np.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), GRID)
+def test_cdf_is_bit_identical_to_levy(alpha, beta, mu, sigma):
+    expected = levy.levy(XS, alpha, beta, mu, sigma, cdf=True)
+    got = api.cdf(XS, alpha=alpha, beta=beta, mu=mu, sigma=sigma)
+    assert np.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), GRID)
+def test_logpdf_is_the_negation_of_neglog_levy(alpha, beta, mu, sigma):
+    # Note the sign: neglog_levy returns -log(pdf), logpdf returns +log(pdf).
+    expected = -levy.neglog_levy(XS, alpha, beta, mu, sigma)
+    got = api.logpdf(XS, alpha=alpha, beta=beta, mu=mu, sigma=sigma)
+    assert np.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), GRID)
+def test_rvs_is_bit_identical_to_random(alpha, beta, mu, sigma):
+    np.random.seed(4242)
+    expected = levy.random(alpha, beta, mu, sigma, shape=(500,))
+    got = api.rvs(alpha=alpha, beta=beta, mu=mu, sigma=sigma,
+                  size=500, random_state=4242)
+    assert np.array_equal(got, expected)
+
+
+@pytest.mark.parametrize("par", PARAMETRIZATIONS)
+def test_fit_agrees_with_fit_levy(par):
+    np.random.seed(11)
+    sample = levy.random(1.5, 0.0, 0.0, 1.0, shape=(300,))
+
+    expected, expected_nll = levy.fit_levy(sample, par=par)
+    result = api.fit(sample, par=par)
+
+    assert np.array_equal(np.asarray(result.params.as_tuple()), expected.get("0"))
+    assert result.negative_log_likelihood == expected_nll
+    assert result.parametrization == par
+
+
+# --------------------------------------------------------------------------
+# validation at the boundary
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("field", "value"), [
+    ("alpha", 0.4),      # below the tabulated range
+    ("alpha", 2.1),      # above it
+    ("beta", -1.5),
+    ("beta", 1.5),
+    ("sigma", 0.0),      # a zero scale divides by zero downstream
+    ("sigma", -1.0),
+])
+def test_out_of_range_parameters_are_rejected(field, value):
+    kwargs = {"alpha": 1.5, "beta": 0.0, "mu": 0.0, "sigma": 1.0}
+    kwargs[field] = value
+    with pytest.raises(ValidationError):
+        api.StableParams(**kwargs)
+
+
+def test_validation_error_names_the_offending_field():
+    with pytest.raises(ValidationError, match="alpha"):
+        api.StableParams(alpha=0.4, beta=0.0)
+
+
+@pytest.mark.parametrize("function", [api.pdf, api.cdf, api.logpdf])
+def test_functions_validate_before_touching_the_tables(function):
+    with pytest.raises(ValidationError):
+        function(np.array([1.0]), alpha=0.4, beta=0.0)
+
+
+def test_rvs_validates_too():
+    with pytest.raises(ValidationError):
+        api.rvs(alpha=0.4, beta=0.0, size=3)
+
+
+def test_params_are_frozen():
+    params = api.StableParams(alpha=1.5, beta=0.0)
+    with pytest.raises(ValidationError):
+        params.alpha = 1.6
+
+
+def test_params_are_hashable():
+    a = api.StableParams(alpha=1.5, beta=0.0)
+    b = api.StableParams(alpha=1.5, beta=0.0)
+    assert hash(a) == hash(b)
+    assert len({a, b}) == 1
+
+
+def test_unknown_field_is_rejected():
+    with pytest.raises(ValidationError):
+        api.StableParams(alpha=1.5, beta=0.0, skew=0.3)
+
+
+def test_fit_rejects_a_misspelt_parameter_name():
+    # fit_levy takes **kwargs and quietly ignores anything it does not know,
+    # so `fit_levy(x, beta_=0)` silently fits beta instead of pinning it.
+    np.random.seed(3)
+    sample = levy.random(1.5, 0.0, shape=(50,))
+    with pytest.raises(TypeError, match="beta_"):
+        api.fit(sample, beta_=0.0)
+
+
+def test_fit_levy_still_ignores_it__documenting_the_difference():
+    np.random.seed(3)
+    sample = levy.random(1.5, 0.0, shape=(50,))
+    free, _ = levy.fit_levy(sample)
+    typoed, _ = levy.fit_levy(sample, beta_=0.0)
+    assert np.array_equal(typoed.get("0"), free.get("0"))
+
+
+# --------------------------------------------------------------------------
+# parametrization handling
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("par", PARAMETRIZATIONS)
+def test_from_par_and_to_par_round_trip(par):
+    original = api.StableParams(alpha=1.6, beta=0.4, mu=0.3, sigma=1.2)
+    written = original.to_par(par)
+    back = api.StableParams.from_par(*written, par=par)
+    np.testing.assert_allclose(back.as_tuple(), original.as_tuple(), rtol=1e-12)
+
+
+@pytest.mark.parametrize("par", PARAMETRIZATIONS)
+def test_from_par_matches_parameters_convert(par):
+    values = np.array([1.6, 0.4, 0.3, 1.2])
+    expected = levy.Parameters.convert(values, par, "0")
+    got = api.StableParams.from_par(*values, par=par)
+    assert np.array_equal(np.asarray(got.as_tuple()), np.asarray(expected, dtype="d"))
+
+
+@pytest.mark.parametrize("par", PARAMETRIZATIONS)
+def test_pdf_accepts_parameters_in_any_parametrization(par):
+    reference = api.StableParams(alpha=1.6, beta=0.4, mu=0.3, sigma=1.2)
+    written = reference.to_par(par)
+    got = api.pdf(XS, alpha=written[0], beta=written[1],
+                  mu=written[2], sigma=written[3], par=par)
+    expected = api.pdf(XS, **reference.as_kwargs())
+    np.testing.assert_allclose(got, expected, rtol=1e-10)
+
+
+def test_conversion_out_of_range_is_caught_at_the_boundary():
+    # A beta_B near the edge converts to a beta_0 outside [-1, 1]; 1.x would
+    # hand that straight to _interpolate, which clamps the grid index and
+    # returns a number that looks fine.
+    with pytest.raises(ValidationError):
+        api.StableParams.from_par(1.9, 3.0, 0.0, 1.0, par="B")
+
+
+# --------------------------------------------------------------------------
+# shapes, dtypes and the seeding contract
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("size", "expected"), [
+    (None, ()),
+    (5, (5,)),
+    ((3,), (3,)),
+    ((2, 3), (2, 3)),
+])
+def test_rvs_size_maps_onto_shape(size, expected):
+    drawn = api.rvs(alpha=1.5, beta=0.0, size=size, random_state=1)
+    assert np.shape(drawn) == expected
+
+
+def test_rvs_with_a_seed_leaves_the_global_stream_untouched():
+    np.random.seed(99)
+    before = np.random.random(3)
+
+    np.random.seed(99)
+    api.rvs(alpha=1.5, beta=0.0, size=100, random_state=0)
+    after = np.random.random(3)
+
+    assert np.array_equal(before, after)
+
+
+def test_rvs_without_a_seed_advances_the_global_stream():
+    np.random.seed(5)
+    first = api.rvs(alpha=1.5, beta=0.0, size=3)
+    second = api.rvs(alpha=1.5, beta=0.0, size=3)
+    assert not np.array_equal(first, second)
+
+
+def test_scalar_input_gives_a_python_float():
+    value = api.pdf(1.0, alpha=1.5, beta=0.0)
+    assert isinstance(value, float)
+    assert not isinstance(value, np.ndarray)
+
+
+def test_array_input_gives_an_array():
+    values = api.pdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0)
+    assert isinstance(values, np.ndarray)
+    assert values.shape == (2,)
+
+
+def test_functions_are_keyword_only():
+    with pytest.raises(TypeError):
+        api.pdf(np.array([1.0]), 1.5, 0.0)
+
+
+# --------------------------------------------------------------------------
+# results
+# --------------------------------------------------------------------------
+
+def test_fit_result_carries_the_parametrization_and_converts_back():
+    np.random.seed(7)
+    sample = levy.random(1.5, 0.2, 0.0, 1.0, shape=(400,))
+    result = api.fit(sample, par="1")
+
+    assert result.parametrization == "1"
+    np.testing.assert_allclose(
+        result.as_par("1"), result.params.to_par("1"), rtol=0, atol=0)
+
+
+def test_fit_recovers_parameters_it_generated_from():
+    np.random.seed(2024)
+    sample = levy.random(1.5, 0.0, 0.0, 1.0, shape=(4000,))
+    fitted = api.fit(sample).params
+    assert abs(fitted.alpha - 1.5) < 0.15
+    assert abs(fitted.beta) < 0.25
+    assert abs(fitted.sigma - 1.0) < 0.15
+
+
+def test_fit_result_is_frozen():
+    np.random.seed(1)
+    sample = levy.random(1.5, 0.0, shape=(50,))
+    result = api.fit(sample)
+    with pytest.raises(ValidationError):
+        result.negative_log_likelihood = 0.0
+
+
+def test_the_new_api_emits_no_deprecation_warnings():
+    # The 2.0 shims land in a later PR and will make the 1.x names warn. This
+    # is what keeps the new spelling silent when they do.
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        api.pdf(np.array([1.0]), alpha=1.5, beta=0.0)
+        api.cdf(np.array([1.0]), alpha=1.5, beta=0.0)
+        api.logpdf(np.array([1.0]), alpha=1.5, beta=0.0)
+        api.rvs(alpha=1.5, beta=0.0, size=2, random_state=0)
+        api.fit(np.array([0.1, -0.4, 1.2, 0.3, -1.1]))
+
+
+def test_package_ships_py_typed():
+    import pathlib
+
+    marker = pathlib.Path(levy.__file__).with_name("py.typed")
+    assert marker.exists(), "py.typed is what makes the annotations visible downstream"
+
+
+def test_api_is_reachable_from_the_package_root():
+    import importlib
+
+    module = importlib.import_module("levy")
+    assert module.api is api

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,424 @@
+"""The typed API: parity with 1.x, validation, and the shapes of the results.
+
+The point of every parity test here is that `api` adds a boundary and changes
+no numbers. Where a 1.x call and an `api` call describe the same thing, the
+floats must be bit-identical, not merely close.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+import levy
+from levy import api
+
+PARAMETRIZATIONS = ["0", "1", "M", "A", "B"]
+
+GRID = [
+    (0.7, -0.5, 0.0, 1.0),
+    (1.0, 0.0, 0.0, 1.0),
+    (1.3, 0.9, -2.0, 0.5),
+    (1.5, 0.0, 0.0, 1.0),
+    (1.9, -1.0, 3.0, 2.0),
+    (2.0, 0.0, 0.0, 1.0),
+]
+
+XS = np.concatenate([
+    np.linspace(-40.0, 40.0, 161),
+    np.linspace(-2.0, 2.0, 41),
+])
+
+
+# --------------------------------------------------------------------------
+# parity with the 1.x functions
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), GRID)
+def test_pdf_is_bit_identical_to_levy(alpha, beta, mu, sigma):
+    expected = levy.levy(XS, alpha, beta, mu, sigma, cdf=False)
+    got = api.pdf(XS, alpha=alpha, beta=beta, mu=mu, sigma=sigma)
+    assert np.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), GRID)
+def test_cdf_is_bit_identical_to_levy(alpha, beta, mu, sigma):
+    expected = levy.levy(XS, alpha, beta, mu, sigma, cdf=True)
+    got = api.cdf(XS, alpha=alpha, beta=beta, mu=mu, sigma=sigma)
+    assert np.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), GRID)
+def test_logpdf_is_the_negation_of_neglog_levy(alpha, beta, mu, sigma):
+    # Note the sign: neglog_levy returns -log(pdf), logpdf returns +log(pdf).
+    expected = -levy.neglog_levy(XS, alpha, beta, mu, sigma)
+    got = api.logpdf(XS, alpha=alpha, beta=beta, mu=mu, sigma=sigma)
+    assert np.array_equal(got, expected)
+
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), GRID)
+def test_rvs_is_bit_identical_to_random(alpha, beta, mu, sigma):
+    np.random.seed(4242)
+    expected = levy.random(alpha, beta, mu, sigma, shape=(500,))
+    got = api.rvs(alpha=alpha, beta=beta, mu=mu, sigma=sigma,
+                  size=500, random_state=4242)
+    assert np.array_equal(got, expected)
+
+
+@pytest.mark.parametrize("par", PARAMETRIZATIONS)
+def test_fit_agrees_with_fit_levy(par):
+    np.random.seed(11)
+    sample = levy.random(1.5, 0.0, 0.0, 1.0, shape=(300,))
+
+    expected, expected_nll = levy.fit_levy(sample, par=par)
+    result = api.fit(sample, par=par)
+
+    assert np.array_equal(np.asarray(result.params.as_tuple()), expected.get("0"))
+    assert result.negative_log_likelihood == expected_nll
+    assert result.parametrization == par
+
+
+# --------------------------------------------------------------------------
+# validation at the boundary
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("field", "value"), [
+    ("alpha", 0.4),      # below the tabulated range
+    ("alpha", 2.1),      # above it
+    ("beta", -1.5),
+    ("beta", 1.5),
+    ("sigma", 0.0),      # a zero scale divides by zero downstream
+    ("sigma", -1.0),
+])
+def test_out_of_range_parameters_are_rejected(field, value):
+    kwargs = {"alpha": 1.5, "beta": 0.0, "mu": 0.0, "sigma": 1.0}
+    kwargs[field] = value
+    with pytest.raises(ValidationError):
+        api.StableParams(**kwargs)
+
+
+def test_validation_error_names_the_offending_field():
+    with pytest.raises(ValidationError, match="alpha"):
+        api.StableParams(alpha=0.4, beta=0.0)
+
+
+@pytest.mark.parametrize("function", [api.pdf, api.cdf, api.logpdf])
+def test_functions_validate_before_touching_the_tables(function):
+    with pytest.raises(ValidationError):
+        function(np.array([1.0]), alpha=0.4, beta=0.0)
+
+
+def test_rvs_validates_too():
+    with pytest.raises(ValidationError):
+        api.rvs(alpha=0.4, beta=0.0, size=3)
+
+
+def test_params_are_frozen():
+    params = api.StableParams(alpha=1.5, beta=0.0)
+    with pytest.raises(ValidationError):
+        params.alpha = 1.6
+
+
+def test_params_are_hashable():
+    a = api.StableParams(alpha=1.5, beta=0.0)
+    b = api.StableParams(alpha=1.5, beta=0.0)
+    assert hash(a) == hash(b)
+    assert len({a, b}) == 1
+
+
+def test_unknown_field_is_rejected():
+    with pytest.raises(ValidationError):
+        api.StableParams(alpha=1.5, beta=0.0, skew=0.3)
+
+
+def test_fit_rejects_a_misspelt_parameter_name():
+    # fit_levy takes **kwargs and quietly ignores anything it does not know,
+    # so `fit_levy(x, beta_=0)` silently fits beta instead of pinning it.
+    np.random.seed(3)
+    sample = levy.random(1.5, 0.0, shape=(50,))
+    with pytest.raises(TypeError, match="beta_"):
+        api.fit(sample, beta_=0.0)
+
+
+def test_fit_levy_still_ignores_it__documenting_the_difference():
+    np.random.seed(3)
+    sample = levy.random(1.5, 0.0, shape=(50,))
+    free, _ = levy.fit_levy(sample)
+    typoed, _ = levy.fit_levy(sample, beta_=0.0)
+    assert np.array_equal(typoed.get("0"), free.get("0"))
+
+
+# --------------------------------------------------------------------------
+# parametrization handling
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("par", PARAMETRIZATIONS)
+def test_from_par_and_to_par_round_trip(par):
+    original = api.StableParams(alpha=1.6, beta=0.4, mu=0.3, sigma=1.2)
+    written = original.to_par(par)
+    back = api.StableParams.from_par(*written, par=par)
+    np.testing.assert_allclose(back.as_tuple(), original.as_tuple(), rtol=1e-12)
+
+
+@pytest.mark.parametrize("par", PARAMETRIZATIONS)
+def test_from_par_matches_parameters_convert(par):
+    values = np.array([1.6, 0.4, 0.3, 1.2])
+    expected = levy.Parameters.convert(values, par, "0")
+    got = api.StableParams.from_par(*values, par=par)
+    assert np.array_equal(np.asarray(got.as_tuple()), np.asarray(expected, dtype="d"))
+
+
+@pytest.mark.parametrize("par", PARAMETRIZATIONS)
+def test_pdf_accepts_parameters_in_any_parametrization(par):
+    reference = api.StableParams(alpha=1.6, beta=0.4, mu=0.3, sigma=1.2)
+    written = reference.to_par(par)
+    got = api.pdf(XS, alpha=written[0], beta=written[1],
+                  mu=written[2], sigma=written[3], par=par)
+    expected = api.pdf(XS, **reference.as_kwargs())
+    np.testing.assert_allclose(got, expected, rtol=1e-10)
+
+
+def test_conversion_out_of_range_is_caught_at_the_boundary():
+    # A beta_B near the edge converts to a beta_0 outside [-1, 1]; 1.x would
+    # hand that straight to _interpolate, which clamps the grid index and
+    # returns a number that looks fine.
+    with pytest.raises(ValidationError):
+        api.StableParams.from_par(1.9, 3.0, 0.0, 1.0, par="B")
+
+
+# --------------------------------------------------------------------------
+# shapes, dtypes and the seeding contract
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("size", "expected"), [
+    (None, ()),
+    (5, (5,)),
+    ((3,), (3,)),
+    ((2, 3), (2, 3)),
+])
+def test_rvs_size_maps_onto_shape(size, expected):
+    drawn = api.rvs(alpha=1.5, beta=0.0, size=size, random_state=1)
+    assert np.shape(drawn) == expected
+
+
+def test_rvs_with_a_seed_leaves_the_global_stream_untouched():
+    np.random.seed(99)
+    before = np.random.random(3)
+
+    np.random.seed(99)
+    api.rvs(alpha=1.5, beta=0.0, size=100, random_state=0)
+    after = np.random.random(3)
+
+    assert np.array_equal(before, after)
+
+
+def test_rvs_without_a_seed_advances_the_global_stream():
+    np.random.seed(5)
+    first = api.rvs(alpha=1.5, beta=0.0, size=3)
+    second = api.rvs(alpha=1.5, beta=0.0, size=3)
+    assert not np.array_equal(first, second)
+
+
+def test_scalar_input_gives_a_python_float():
+    value = api.pdf(1.0, alpha=1.5, beta=0.0)
+    assert isinstance(value, float)
+    assert not isinstance(value, np.ndarray)
+
+
+def test_array_input_gives_an_array():
+    values = api.pdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0)
+    assert isinstance(values, np.ndarray)
+    assert values.shape == (2,)
+
+
+def test_functions_are_keyword_only():
+    with pytest.raises(TypeError):
+        api.pdf(np.array([1.0]), 1.5, 0.0)
+
+
+# --------------------------------------------------------------------------
+# results
+# --------------------------------------------------------------------------
+
+def test_fit_result_carries_the_parametrization_and_converts_back():
+    np.random.seed(7)
+    sample = levy.random(1.5, 0.2, 0.0, 1.0, shape=(400,))
+    result = api.fit(sample, par="1")
+
+    assert result.parametrization == "1"
+    np.testing.assert_allclose(
+        result.as_par("1"), result.params.to_par("1"), rtol=0, atol=0)
+
+
+def test_fit_recovers_parameters_it_generated_from():
+    np.random.seed(2024)
+    sample = levy.random(1.5, 0.0, 0.0, 1.0, shape=(4000,))
+    fitted = api.fit(sample).params
+    assert abs(fitted.alpha - 1.5) < 0.15
+    assert abs(fitted.beta) < 0.25
+    assert abs(fitted.sigma - 1.0) < 0.15
+
+
+def test_fit_result_is_frozen():
+    np.random.seed(1)
+    sample = levy.random(1.5, 0.0, shape=(50,))
+    result = api.fit(sample)
+    with pytest.raises(ValidationError):
+        result.negative_log_likelihood = 0.0
+
+
+def test_the_new_api_emits_no_deprecation_warnings():
+    # The 2.0 shims land in a later PR and will make the 1.x names warn. This
+    # is what keeps the new spelling silent when they do.
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        api.pdf(np.array([1.0]), alpha=1.5, beta=0.0)
+        api.cdf(np.array([1.0]), alpha=1.5, beta=0.0)
+        api.logpdf(np.array([1.0]), alpha=1.5, beta=0.0)
+        api.rvs(alpha=1.5, beta=0.0, size=2, random_state=0)
+        api.fit(np.array([0.1, -0.4, 1.2, 0.3, -1.1]))
+
+
+def test_package_ships_py_typed():
+    import pathlib
+
+    marker = pathlib.Path(levy.__file__).with_name("py.typed")
+    assert marker.exists(), "py.typed is what makes the annotations visible downstream"
+
+
+def test_api_is_reachable_from_the_package_root():
+    import importlib
+
+    module = importlib.import_module("levy")
+    assert module.api is api
+
+
+# --------------------------------------------------------------------------
+# Argument handling that used to fail late, or not at all
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("size", [np.int64(5), np.int32(5), 5])
+def test_rvs_accepts_numpy_integer_sizes(size):
+    """np.int64 is neither an int subclass nor iterable, so `tuple(size)`
+    raised TypeError for a perfectly ordinary call.
+    """
+    assert np.shape(api.rvs(alpha=1.5, beta=0.0, size=size, random_state=0)) == (5,)
+
+
+def test_rvs_still_accepts_tuple_sizes():
+    assert np.shape(
+        api.rvs(alpha=1.5, beta=0.0, size=(2, 3), random_state=0)
+    ) == (2, 3)
+
+
+@pytest.mark.parametrize(
+    "fixed,message",
+    [
+        ({"sigma": 0.0}, "strictly positive"),
+        ({"sigma": -1.0}, "strictly positive"),
+        ({"alpha": 0.2}, "must lie in"),
+        ({"alpha": 2.5}, "must lie in"),
+        ({"beta": 2.0}, "must lie in"),
+        ({"sigma": float("inf")}, "sigma must be finite"),
+        ({"mu": float("nan")}, "mu must be finite"),
+        ({"alpha": float("nan")}, "alpha must be finite"),
+    ],
+)
+def test_fit_rejects_out_of_range_fixed_values(fixed, message):
+    """The names were validated but the values were not, so `fit(x, sigma=0)`
+    reached the optimizer and divided by zero inside levy(). sigma=inf and
+    mu=nan slipped past the range checks the same way -- inf is > 0 and nan
+    compares as nothing -- so finiteness is checked first.
+    """
+    x = api.rvs(alpha=1.5, beta=0.0, size=200, random_state=0)
+    with pytest.raises(ValueError, match=message):
+        api.fit(x, **fixed)
+
+
+def test_fit_still_accepts_a_valid_fixed_value():
+    x = api.rvs(alpha=1.5, beta=0.0, size=200, random_state=0)
+    assert api.fit(x, beta=0.0).params.beta == 0.0
+
+
+# --------------------------------------------------------------------------
+# an unknown parametrization
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("call", [
+    lambda: api.pdf(np.array([1.0]), alpha=1.5, beta=0.0, par="Z"),
+    lambda: api.rvs(alpha=1.5, beta=0.0, size=3, par="Z"),
+    lambda: api.fit(np.array([0.1, -0.4, 2.0, 0.7, -1.1, 0.3]), par="Z"),
+    lambda: api.StableParams(alpha=1.5, beta=0.0).to_par("Z"),
+    lambda: api.StableParams.from_par(1.5, 0.0, 0.0, 1.0, par="Z"),
+])
+def test_an_unknown_parametrization_is_a_value_error_naming_the_choices(call):
+    """Used to be a KeyError from a conversion table several frames down,
+    naming neither the argument nor what it accepts.
+    """
+    with pytest.raises(ValueError, match="'0', '1', 'M', 'A', 'B'"):
+        call()
+
+
+# --------------------------------------------------------------------------
+# non-finite parameters, and a singular conversion
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field,value", [
+    ("sigma", float("inf")), ("mu", float("nan")), ("mu", float("-inf")),
+])
+def test_non_finite_parameters_are_rejected_at_the_boundary(field, value):
+    """sigma=inf satisfied `gt=0` and went on to divide the density into
+    zeros; a non-finite parameter is not a distribution and is refused with
+    the field named.
+    """
+    kwargs = dict(alpha=1.5, beta=0.0, mu=0.0, sigma=1.0)
+    kwargs[field] = value
+    with pytest.raises(ValidationError, match=field):
+        api.StableParams(**kwargs)
+
+
+def test_to_par_refuses_the_singular_conversion_to_b_at_alpha_1():
+    """Zolotarev's B is singular at alpha = 1: to_par('B') returned nan (or
+    inf) for beta_B, a tuple from_par could not take back.
+    """
+    with pytest.raises(ValueError, match="singular at alpha=1.0"):
+        api.StableParams(alpha=1.0, beta=0.0).to_par("B")
+    with pytest.raises(ValueError, match="singular"):
+        api.StableParams(alpha=1.0, beta=0.5).to_par("B")
+    # The other parametrizations are fine there, and B is fine off it.
+    for par in ("1", "M", "A"):
+        assert all(np.isfinite(api.StableParams(alpha=1.0, beta=0.5).to_par(par)))
+    assert all(np.isfinite(api.StableParams(alpha=1.01, beta=0.5).to_par("B")))
+
+
+def test_rvs_accepts_numpy_integers_inside_a_shape_tuple():
+    sample = api.rvs(alpha=1.5, beta=0.0, size=(np.int64(2), np.int32(3)), random_state=0)
+    assert sample.shape == (2, 3)
+
+
+def test_rvs_rejects_a_non_integer_shape():
+    """`int()` truncated (2.5, 3.9) to a (2, 3) draw. Only values with
+    `__index__` -- built-in and NumPy integers -- are accepted now.
+    """
+    with pytest.raises(TypeError):
+        api.rvs(alpha=1.5, beta=0.0, size=(2.5, 3.9))
+    with pytest.raises(TypeError):
+        api.rvs(alpha=1.5, beta=0.0, size=2.5)
+
+
+def test_fit_passes_the_normalised_pinned_values_to_the_fitter():
+    """The range checks converted each value with float() and then handed
+    the original on, so a 0-d array or a numeric string reached the
+    optimizer as it came. The fitter now receives plain floats.
+    """
+    x = api.rvs(alpha=1.5, beta=0.0, size=300, random_state=3)
+    from_array = api.fit(x, beta=np.array(0.0), mu=np.float32(0.0))
+    from_float = api.fit(x, beta=0.0, mu=0.0)
+    assert from_array.params == from_float.params
+    assert from_array.params.beta == 0.0 and from_array.params.mu == 0.0

--- a/tests/test_hot_loop.py
+++ b/tests/test_hot_loop.py
@@ -1,0 +1,116 @@
+"""Pydantic must stay at the boundary and out of the likelihood loop.
+
+This is the test that makes the new dependency defensible. A stable fit runs
+thousands of density evaluations; if a model were constructed inside that loop,
+`pip install pylevy` would have bought a validation library and paid for it in
+the one place where this package's whole reason to exist is speed.
+
+The invariant is not "few constructions" but "a number that does not grow with
+the data". That is what the scaling test below measures.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import levy
+
+pytest.importorskip("pydantic")
+
+from levy import api  # noqa: E402
+
+
+class ConstructionCounter:
+    """Count StableParams constructions inside a block."""
+
+    def __init__(self, monkeypatch):
+        self.count = 0
+        original = api.StableParams.__init__
+
+        def counting_init(model_self, **data):
+            self.count += 1
+            original(model_self, **data)
+
+        monkeypatch.setattr(api.StableParams, "__init__", counting_init)
+
+
+def _sample(n, seed=0):
+    np.random.seed(seed)
+    return levy.random(1.5, 0.0, 0.0, 1.0, shape=(n,))
+
+
+def test_fit_levy_never_constructs_a_model(monkeypatch):
+    # The 1.x path must not acquire a pydantic cost at all: someone who never
+    # imports levy.api should not pay for it.
+    counter = ConstructionCounter(monkeypatch)
+    levy.fit_levy(_sample(1000))
+    assert counter.count == 0
+
+
+def test_levy_and_neglog_levy_never_construct_a_model(monkeypatch):
+    counter = ConstructionCounter(monkeypatch)
+    x = np.linspace(-10.0, 10.0, 5000)
+    levy.levy(x, 1.5, 0.0)
+    levy.levy(x, 1.5, 0.0, cdf=True)
+    levy.neglog_levy(x, 1.5, 0.0, 0.0, 1.0)
+    assert counter.count == 0
+
+
+def test_api_fit_constructs_a_bounded_number_of_models(monkeypatch):
+    counter = ConstructionCounter(monkeypatch)
+    api.fit(_sample(1000))
+    # One for the result. The FitResult wrapper revalidates nothing, because a
+    # BaseModel instance passed for a BaseModel field is accepted as is.
+    assert counter.count <= 2, (
+        f"{counter.count} constructions for a single fit; pydantic has leaked "
+        "into the optimizer's loop"
+    )
+
+
+@pytest.mark.parametrize("n", [100, 1000, 4000])
+def test_construction_count_does_not_grow_with_the_data(monkeypatch, n):
+    counter = ConstructionCounter(monkeypatch)
+    api.fit(_sample(n))
+    assert counter.count <= 2
+
+
+def test_pdf_constructs_exactly_one_model_per_call(monkeypatch):
+    counter = ConstructionCounter(monkeypatch)
+    api.pdf(np.linspace(-5.0, 5.0, 10000), alpha=1.5, beta=0.0)
+    assert counter.count == 1
+
+
+def test_evaluating_with_preconstructed_params_still_costs_one(monkeypatch):
+    # Splatting a StableParams back in re-validates: cheap, and it keeps the
+    # functions' contract identical whether or not a model was involved.
+    params = api.StableParams(alpha=1.5, beta=0.0)
+    counter = ConstructionCounter(monkeypatch)
+    api.pdf(np.linspace(-5.0, 5.0, 1000), **params.as_kwargs())
+    assert counter.count == 1
+
+
+def test_importing_levy_does_not_import_pydantic():
+    # `levy.api` is resolved lazily through the module __getattr__, so a user
+    # of the 1.x surface never pays pydantic's import time.
+    import os
+    import pathlib
+    import subprocess
+    import sys
+
+    code = (
+        "import sys, numpy, levy; "
+        "levy.levy(numpy.array([1.0]), 1.5, 0.0); "
+        "levy.fit_levy(numpy.array([0.1, -0.4, 1.2, 0.3, -1.1])); "
+        "print('pydantic' in sys.modules)"
+    )
+    env = dict(os.environ)
+    # Works whether the package is installed or only present in src/.
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(pathlib.Path(levy.__file__).parents[1]), env.get("PYTHONPATH", "")]
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, check=True, env=env,
+    )
+    assert result.stdout.strip() == "False", result.stdout

--- a/tests/test_hot_loop.py
+++ b/tests/test_hot_loop.py
@@ -1,0 +1,113 @@
+"""Pydantic must stay at the boundary and out of the likelihood loop.
+
+This is the test that makes the new dependency defensible. A stable fit runs
+thousands of density evaluations; if a model were constructed inside that loop,
+`pip install pylevy` would have bought a validation library and paid for it in
+the one place where this package's whole reason to exist is speed.
+
+The invariant is not "few constructions" but "a number that does not grow with
+the data". That is what the scaling test below measures.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import levy
+from levy import api
+
+
+class ConstructionCounter:
+    """Count StableParams constructions inside a block."""
+
+    def __init__(self, monkeypatch):
+        self.count = 0
+        original = api.StableParams.__init__
+
+        def counting_init(model_self, **data):
+            self.count += 1
+            original(model_self, **data)
+
+        monkeypatch.setattr(api.StableParams, "__init__", counting_init)
+
+
+def _sample(n, seed=0):
+    np.random.seed(seed)
+    return levy.random(1.5, 0.0, 0.0, 1.0, shape=(n,))
+
+
+def test_fit_levy_never_constructs_a_model(monkeypatch):
+    # The 1.x path must not acquire a pydantic cost at all: someone who never
+    # imports levy.api should not pay for it.
+    counter = ConstructionCounter(monkeypatch)
+    levy.fit_levy(_sample(1000))
+    assert counter.count == 0
+
+
+def test_levy_and_neglog_levy_never_construct_a_model(monkeypatch):
+    counter = ConstructionCounter(monkeypatch)
+    x = np.linspace(-10.0, 10.0, 5000)
+    levy.levy(x, 1.5, 0.0)
+    levy.levy(x, 1.5, 0.0, cdf=True)
+    levy.neglog_levy(x, 1.5, 0.0, 0.0, 1.0)
+    assert counter.count == 0
+
+
+def test_api_fit_constructs_a_bounded_number_of_models(monkeypatch):
+    counter = ConstructionCounter(monkeypatch)
+    api.fit(_sample(1000))
+    # One for the result. The FitResult wrapper revalidates nothing, because a
+    # BaseModel instance passed for a BaseModel field is accepted as is.
+    assert counter.count <= 2, (
+        f"{counter.count} constructions for a single fit; pydantic has leaked "
+        "into the optimizer's loop"
+    )
+
+
+@pytest.mark.parametrize("n", [100, 1000, 4000])
+def test_construction_count_does_not_grow_with_the_data(monkeypatch, n):
+    counter = ConstructionCounter(monkeypatch)
+    api.fit(_sample(n))
+    assert counter.count <= 2
+
+
+def test_pdf_constructs_exactly_one_model_per_call(monkeypatch):
+    counter = ConstructionCounter(monkeypatch)
+    api.pdf(np.linspace(-5.0, 5.0, 10000), alpha=1.5, beta=0.0)
+    assert counter.count == 1
+
+
+def test_evaluating_with_preconstructed_params_still_costs_one(monkeypatch):
+    # Splatting a StableParams back in re-validates: cheap, and it keeps the
+    # functions' contract identical whether or not a model was involved.
+    params = api.StableParams(alpha=1.5, beta=0.0)
+    counter = ConstructionCounter(monkeypatch)
+    api.pdf(np.linspace(-5.0, 5.0, 1000), **params.as_kwargs())
+    assert counter.count == 1
+
+
+def test_importing_levy_does_not_import_pydantic():
+    # `levy.api` is resolved lazily through the module __getattr__, so a user
+    # of the 1.x surface never pays pydantic's import time.
+    import os
+    import pathlib
+    import subprocess
+    import sys
+
+    code = (
+        "import sys, numpy, levy; "
+        "levy.levy(numpy.array([1.0]), 1.5, 0.0); "
+        "levy.fit_levy(numpy.array([0.1, -0.4, 1.2, 0.3, -1.1])); "
+        "print('pydantic' in sys.modules)"
+    )
+    env = dict(os.environ)
+    # Works whether the package is installed or only present in src/.
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(pathlib.Path(levy.__file__).parents[1]), env.get("PYTHONPATH", "")]
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, check=True, env=env,
+    )
+    assert result.stdout.strip() == "False", result.stdout


### PR DESCRIPTION
> Part 13 of a 20-commit stack. Stacked on #34 — review that first; the diff here against its base is a single commit.

levy/api.py gives the package the five names a reader coming from scipy.stats
already knows, keyword-only, with a frozen pydantic StableParams carrying
validated parameters between them. levy/_typing.py holds the aliases, and
py.typed makes the annotations visible to a downstream type checker.

The numerical core is untouched. Every function converts, validates once, and
delegates; wheels built from the parent commit and from this one produce all
99,312 values bit for bit identical, and the golden file does not move.

What the boundary buys, concretely:

* `alpha=0.4` is rejected where the user wrote it, naming the field, instead of
  reaching the interpolator.
* Parameters given in B are converted to 0 and *then* validated, which is the
  only place a beta_B that maps outside [-1, 1] can be caught. 1.x handed that
  straight to _interpolate, which clamps the grid index and returns a plausible
  wrong number.
* `fit(x, beta_=0.0)` raises TypeError. `fit_levy` takes **kwargs and silently
  ignores an unknown one, so a typo cost you an unconstrained fit and no
  warning -- there is a test pinning that 1.x behaviour next to the new one.
* StableParams is frozen and hashable, so validated parameters can be cached or
  used as a dict key.

Pydantic never enters the hot loop, and tests/test_hot_loop.py is what makes
that claim checkable rather than aspirational. It counts StableParams
constructions during real work:

    fit_levy(1000 points)          0 constructions
    levy / neglog_levy             0
    api.fit(100 / 1000 / 4000)     <= 2, and constant in n
    api.pdf(10000 points)          1

It also runs a subprocess asserting that `import levy` plus a 1.x call leaves
'pydantic' out of sys.modules entirely -- levy.api is resolved lazily through
the module __getattr__, so nobody on the 1.x surface pays for the dependency.

rvs() takes a seed rather than a Generator, deliberately: sampling stays on the
legacy global numpy.random stream so seeded results match 1.x exactly, and a
seeded call restores whatever state the stream had. Accepting a Generator would
mean reimplementing the sampler and changing every seeded number.

mypy --strict runs in CI over api.py and _typing.py only. The core has no
annotations to trust, so it is excluded rather than papered over; api.py
narrows everything it gets back through a checked isinstance, so nothing typed
Any escapes into a user's type checker.

85 new tests (706 total, from 621). Goldens unchanged.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

