### PR TITLE
Add an optional pandas extra: labels in, labels out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,31 @@ jobs:
       - name: mypy (typed surface)
         run: python -m mypy
 
+  extras:
+    name: optional extras
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The five `test` legs above deliberately run *without* the extras, which
+      # is what proves an install without them works. This one is the other
+      # half: pandas installed, so tests/test_pandas.py actually runs instead of
+      # being skipped.
+      - name: Install package with extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,pandas]"
+
+      - name: Run tests
+        run: python -m pytest tests/ -q -m "not build"
+
+      - name: pandas support is exercised, not skipped
+        run: python -m pytest tests/test_pandas.py -q --no-header -p no:cacheprovider
+
   doctests:
     name: doctests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,57 @@ jobs:
       - name: mypy (typed surface)
         run: python -m mypy
 
+  extras:
+    name: optional extras
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The five `test` legs above deliberately run *without* the extras, which
+      # is what proves an install without them works. This one is the other
+      # half: pandas installed, so tests/test_pandas.py actually runs instead of
+      # being skipped.
+      - name: Install package with extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,pandas]"
+
+      # The extra must be declared in the package metadata, not merely be
+      # importable on this runner: `pip install ".[pandas]"` only *warns* when
+      # an extra does not exist, so a misspelt or dropped extra would otherwise
+      # pass here as long as pandas got installed some other way.
+      - name: The extras are declared in the package metadata
+        run: |
+          python - <<'PY'
+          import tomllib
+          from importlib.metadata import requires
+          with open("pyproject.toml", "rb") as handle:
+              name = tomllib.load(handle)["project"]["name"]
+          declared = requires(name) or []
+          for extra in ("pandas",):
+              assert any(f'extra == "{extra}"' in r for r in declared), (extra, declared)
+          print("extras declared:", sorted(r for r in declared if "extra ==" in r))
+          PY
+
+      # The optional suite is left out here and run exactly once below, where
+      # a skip is made visible and fatal.
+      - name: Run tests
+        run: python -m pytest tests/ -q -m "not build" --ignore=tests/test_pandas.py
+
+      # -rs prints every skip. test_pandas.py skips itself when pandas is
+      # missing, so any SKIPPED line means the extra did not install.
+      - name: pandas support is exercised, not skipped
+        run: |
+          # pipefail: without it the pipeline's status is tee's, and a failing
+          # pytest would pass this step as long as nothing was skipped.
+          set -o pipefail
+          python -m pytest tests/test_pandas.py -q -rs -p no:cacheprovider | tee optional.log
+          ! grep -q "SKIPPED" optional.log
+
   doctests:
     name: doctests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ public name still works and still returns the same floats, bit for bit.
   did: for a package, `-m` requires `__main__.py`.
 - NumPy-style docstrings throughout, enforced by `ruff` (pydocstyle, numpy
   convention) and `numpydoc`, both gated in CI.
+- An optional `pandas` extra. `pdf`, `cdf` and `logpdf` accept a `Series` or a
+  `DataFrame` and return one carrying the same index; `fit` accepts a `Series`
+  or a single-column `DataFrame`, and `FitResult.to_series()` reports the
+  parameters under that parametrization's own names. The core never sees a
+  pandas object, and an install without the extra never imports pandas --
+  support is detected by looking in `sys.modules`, so the fast path is one
+  dictionary lookup. `tests/test_no_pandas.py` runs the whole API in a
+  subprocess with pandas blocked at the import system.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ number, a NaN, or an error -- it returns the same floats, bit for bit.
   did: for a package, `-m` requires `__main__.py`.
 - NumPy-style docstrings throughout, enforced by `ruff` (pydocstyle, numpy
   convention) and `numpydoc`, both gated in CI.
+- An optional `pandas` extra. `pdf`, `cdf` and `logpdf` accept a `Series` or a
+  `DataFrame` and return one carrying the same index; `fit` accepts a `Series`
+  or a single-column `DataFrame`, and `FitResult.to_series()` reports the
+  parameters under that parametrization's own names. The core never sees a
+  pandas object, and an install without the extra never imports pandas --
+  support is detected by looking in `sys.modules`, so the fast path is one
+  dictionary lookup. `tests/test_no_pandas.py` runs the whole API in a
+  subprocess with pandas blocked at the import system.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ params = api.StableParams.from_par(1.6, 0.5, 0.3, 1.2, par='1')
 params.to_par('B')
 ```
 
+## pandas
+
+    pip install ".[pandas]"
+
+`pdf`, `cdf` and `logpdf` accept a `Series` or a `DataFrame` and return one
+with the same index; `fit` accepts a `Series`, and `FitResult.to_series()`
+reports the parameters under their names.
+
+```python
+prices = pd.Series(..., index=dates)
+returns = np.log(prices).diff().dropna()
+
+api.fit(returns).to_series()
+# alpha    1.63
+# beta    -0.07
+# mu       0.00
+# sigma    0.01
+```
+
+Without the extra, pandas is never imported.
+
 ## Regenerating the tables
 
 The shipped tables are enough for normal use. To rebuild them, at the default

--- a/README.md
+++ b/README.md
@@ -52,6 +52,32 @@ params = api.StableParams.from_par(1.6, 0.5, 0.3, 1.2, par='1')
 params.to_par('B')
 ```
 
+## pandas
+
+    pip install ".[pandas]"
+
+`pdf`, `cdf` and `logpdf` accept a `Series` or a `DataFrame` and return one
+with the same index; `fit` accepts a `Series` or a single-column `DataFrame`
+(a wider one is refused rather than pooled), and `FitResult.to_series()`
+reports the parameters under their names.
+
+```python
+import numpy as np
+import pandas as pd
+from levy import api
+
+prices = pd.read_csv("prices.csv", index_col="date", parse_dates=True)["close"]
+returns = np.log(prices).diff().dropna()
+
+api.fit(returns).to_series()
+# alpha    1.63
+# beta    -0.07
+# mu       0.00
+# sigma    0.01
+```
+
+Without the extra, pandas is never imported.
+
 ## Regenerating the tables
 
 The shipped tables are enough for normal use. To rebuild them, at the default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ dev = ["pytest>=7", "build", "twine"]
 # Pinned to a minor series: ruff adds rules in every release, so an unpinned
 # floor turns a green branch red on somebody else's schedule.
 lint = ["ruff>=0.16,<0.17", "numpydoc>=1.6", "mypy>=1.8"]
+# Optional. Nothing in the core imports pandas, and nothing tries to: support
+# is detected by looking in sys.modules, so an install without this extra never
+# pays for it. See levy/_compat.py.
+pandas = ["pandas>=1.5"]
 
 # Regenerates the lookup tables into a user cache directory. Replaces
 # `python -m levy build`, which wrote 24 MB into the installed package.
@@ -150,7 +154,8 @@ exclude = ['\.__init__$']
 # tries. The annotations here are 3.9-safe by construction -- PEP 585 builtin
 # generics only, no `X | Y` -- and the 3.9 test leg is what proves it at run
 # time.
-files = ["src/levy/api.py", "src/levy/_typing.py"]
+files = ["src/levy/api.py", "src/levy/_typing.py", "src/levy/_compat.py",
+         "src/levy/_pandas.py"]
 mypy_path = "src"
 strict = true
 
@@ -172,6 +177,11 @@ module = [
     "levy._build.*",
     "levy._logging",
     "scipy.*",
+    # pandas ships no stubs by default and is an optional extra; requiring
+    # pandas-stubs to type-check the core would defeat the point of it being
+    # optional.
+    "pandas",
+    "pandas.*",
 ]
 ignore_missing_imports = true
 follow_imports = "skip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ dev = ["pytest>=7", "build", "twine"]
 # Pinned to a minor series: ruff adds rules in every release, so an unpinned
 # floor turns a green branch red on somebody else's schedule.
 lint = ["ruff>=0.16,<0.17", "numpydoc>=1.6", "mypy>=1.8"]
+# Optional. Nothing in the core imports pandas, and nothing tries to: support
+# is detected by looking in sys.modules, so an install without this extra never
+# pays for it. See levy/_compat.py.
+pandas = ["pandas>=1.5"]
 
 # Regenerates the lookup tables into a user cache directory. Replaces
 # `python -m levy build`, which wrote 24 MB into the installed package.
@@ -158,7 +162,8 @@ exclude = ['\.__init__$']
 # tries. The annotations here are 3.9-safe by construction -- PEP 585 builtin
 # generics only, no `X | Y` -- and the 3.9 test leg is what proves it at run
 # time.
-files = ["src/levy/api.py", "src/levy/_typing.py"]
+files = ["src/levy/api.py", "src/levy/_typing.py", "src/levy/_compat.py",
+         "src/levy/_pandas.py"]
 mypy_path = "src"
 strict = true
 
@@ -180,6 +185,11 @@ module = [
     "levy._build.*",
     "levy._logging",
     "scipy.*",
+    # pandas ships no stubs by default and is an optional extra; requiring
+    # pandas-stubs to type-check the core would defeat the point of it being
+    # optional.
+    "pandas",
+    "pandas.*",
 ]
 ignore_missing_imports = true
 follow_imports = "skip"

--- a/src/levy/_compat.py
+++ b/src/levy/_compat.py
@@ -1,0 +1,123 @@
+#    Copyright (C) 2017 José M. Miotto
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""Guards for the optional dependencies.
+
+The rule these enforce: an optional dependency that is not installed costs
+nothing and is never imported. Support for it is detected by looking in
+``sys.modules``, not by trying an import -- if a caller has not imported pandas,
+the object they just handed us cannot be a pandas object, so there is nothing
+to check and nothing to load.
+
+That distinction matters for import time and for the error a user sees. Probing
+with ``try: import pandas`` in a hot path would pay the lookup on every call;
+here the fast path is one dictionary get.
+"""
+
+import sys
+from types import ModuleType
+from typing import Optional
+
+__all__ = ['have', 'loaded', 'require']
+
+#: Optional dependencies, and the extra that installs each.
+_EXTRAS: dict[str, str] = {
+    'pandas': 'pandas',
+    'torch': 'torch',
+}
+
+
+def loaded(name: str) -> Optional[ModuleType]:
+    """Return the module only if the caller has already imported it.
+
+    Parameters
+    ----------
+    name : str
+        Top-level module name, e.g. ``'pandas'``.
+
+    Returns
+    -------
+    module or None
+        The module object if it is in ``sys.modules``, otherwise None. Never
+        imports anything.
+
+    Examples
+    --------
+    >>> loaded('sys') is sys
+    True
+    >>> loaded('a_module_nobody_has_imported') is None
+    True
+    """
+    return sys.modules.get(name)
+
+
+def have(name: str) -> bool:
+    """Report whether an optional dependency can be imported.
+
+    Parameters
+    ----------
+    name : str
+        Top-level module name.
+
+    Returns
+    -------
+    bool
+        True if the module is importable. Unlike :func:`loaded`, this will
+        import it, so use it for capability checks rather than in a hot path.
+
+    Examples
+    --------
+    >>> have('sys')
+    True
+    >>> have('a_module_nobody_has_installed')
+    False
+    """
+    import importlib.util
+
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def require(name: str) -> ModuleType:
+    """Import an optional dependency, or explain how to install it.
+
+    Parameters
+    ----------
+    name : str
+        Top-level module name.
+
+    Returns
+    -------
+    module
+        The imported module.
+
+    Raises
+    ------
+    ImportError
+        If it is not installed, naming the extra that provides it rather than
+        leaving the user to guess.
+    """
+    import importlib
+
+    try:
+        return importlib.import_module(name)
+    except ImportError as error:
+        extra = _EXTRAS.get(name, name)
+        raise ImportError(
+            f'{name} is needed for this, and is not installed. '
+            f'Install it with: pip install "pylevy[{extra}]"'
+        ) from error

--- a/src/levy/_compat.py
+++ b/src/levy/_compat.py
@@ -1,0 +1,142 @@
+#    Copyright (C) 2017 José M. Miotto
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""Guards for the optional dependencies.
+
+The rule these enforce: an optional dependency that is not installed costs
+nothing and is never imported. Support for it is detected by looking in
+``sys.modules``, not by trying an import -- if a caller has not imported pandas,
+the object they just handed us cannot be a pandas object, so there is nothing
+to check and nothing to load.
+
+That distinction matters for import time and for the error a user sees. Probing
+with ``try: import pandas`` in a hot path would pay the lookup on every call;
+here the fast path is one dictionary get.
+"""
+
+import sys
+from types import ModuleType
+from typing import Optional
+
+__all__ = ['have', 'loaded', 'require']
+
+#: Optional dependencies, and the extra that installs each.
+_EXTRAS: dict[str, str] = {
+    'pandas': 'pandas',
+    'torch': 'torch',
+}
+
+
+def loaded(name: str) -> Optional[ModuleType]:
+    """Return the module only if the caller has already imported it.
+
+    Parameters
+    ----------
+    name : str
+        Top-level module name, e.g. ``'pandas'``.
+
+    Returns
+    -------
+    module or None
+        The module object if it is in ``sys.modules``, otherwise None. Never
+        imports anything.
+
+    Examples
+    --------
+    >>> loaded('sys') is sys
+    True
+    >>> loaded('a_module_nobody_has_imported') is None
+    True
+    """
+    return sys.modules.get(name)
+
+
+def have(name: str) -> bool:
+    """Report whether an optional dependency can be imported.
+
+    Parameters
+    ----------
+    name : str
+        Top-level module name.
+
+    Returns
+    -------
+    bool
+        True if the module is importable. This does *not* import it: it asks
+        the import system whether a spec exists, which touches the filesystem
+        but leaves ``sys.modules`` alone. :func:`loaded` differs in reporting
+        only whether the module has *already* been imported.
+
+    Examples
+    --------
+    >>> have('sys')
+    True
+    >>> have('a_module_nobody_has_installed')
+    False
+    """
+    import importlib.util
+
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def require(name: str) -> ModuleType:
+    """Import an optional dependency, or explain how to install it.
+
+    Parameters
+    ----------
+    name : str
+        Top-level module name.
+
+    Returns
+    -------
+    module
+        The imported module.
+
+    Raises
+    ------
+    ImportError
+        If it is not installed, naming the extra that provides it rather than
+        leaving the user to guess. If it *is* installed but fails to import
+        -- a broken install, or a dependency of its own missing -- the error
+        says that instead, and chains the real cause; blaming the install
+        would send the user off to reinstall something that is there.
+    """
+    import importlib
+    import importlib.util
+
+    try:
+        return importlib.import_module(name)
+    except ImportError as error:
+        # find_spec itself can raise: a finder that refuses the name (as the
+        # no-pandas tests do) or a half-initialised module both count as
+        # "not there".
+        try:
+            installed = importlib.util.find_spec(name) is not None
+        except (ImportError, ValueError):
+            installed = False
+        if not installed:
+            extra = _EXTRAS.get(name, name)
+            raise ImportError(
+                f'{name} is needed for this, and is not installed. '
+                f'Install it with: pip install "pylevy[{extra}]"'
+            ) from error
+        raise ImportError(
+            f'{name} is installed but failed to import: {error}. The install '
+            f'is broken, or something {name} itself depends on is missing; '
+            f'see the chained exception.'
+        ) from error

--- a/src/levy/_pandas.py
+++ b/src/levy/_pandas.py
@@ -1,0 +1,129 @@
+#    Copyright (C) 2017 José M. Miotto
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""Unwrapping pandas objects on the way in, and restoring them on the way out.
+
+Everything here is boundary work. The numerical core never sees a ``Series`` or
+a ``DataFrame``: :mod:`levy.api` unwraps to a plain array, computes, and puts
+the labels back. A density evaluated at a labelled index should come back with
+that index attached -- losing it silently is how a misaligned join happens.
+
+pandas is optional and is never imported on its behalf. Detection goes through
+:func:`levy._compat.loaded`: if pandas is not already in ``sys.modules``, the
+object the caller passed cannot be a pandas object.
+"""
+
+from typing import Any, Optional
+
+import numpy as np
+
+from levy._compat import loaded
+from levy._typing import FloatArray
+
+__all__ = ['labels_of', 'relabel']
+
+
+def labels_of(x: Any) -> Optional[dict[str, Any]]:
+    """Describe how to put labels back on a result computed from `x`.
+
+    Parameters
+    ----------
+    x : object
+        Whatever the caller passed as the evaluation points.
+
+    Returns
+    -------
+    dict or None
+        None if `x` carries no pandas labels. Otherwise a description of them,
+        to be handed to :func:`relabel`.
+
+    Notes
+    -----
+    Returning a plain description rather than the object itself keeps this
+    module free of pandas types in its signatures, which is what lets
+    :mod:`levy.api` stay importable and type-checkable without pandas.
+    """
+    pandas = loaded('pandas')
+    if pandas is None:
+        return None
+
+    if isinstance(x, pandas.Series):
+        return {'kind': 'series', 'index': x.index, 'name': x.name}
+    if isinstance(x, pandas.DataFrame):
+        return {'kind': 'frame', 'index': x.index, 'columns': x.columns}
+    return None
+
+
+def relabel(values: Any, labels: Optional[dict[str, Any]]) -> Any:
+    """Put pandas labels back on a computed array.
+
+    Parameters
+    ----------
+    values : ndarray
+        The result, shaped like the input it was computed from.
+    labels : dict or None
+        The description returned by :func:`labels_of`. None returns `values`
+        unchanged, which is the path every non-pandas caller takes.
+
+    Returns
+    -------
+    ndarray or Series or DataFrame
+        `values` itself when `labels` is None; otherwise a pandas object
+        carrying the original index, and the original name or columns.
+    """
+    if labels is None:
+        return values
+
+    import pandas  # already imported, or labels_of would have returned None
+
+    if labels['kind'] == 'series':
+        return pandas.Series(np.asarray(values), index=labels['index'],
+                             name=labels['name'])
+    return pandas.DataFrame(np.asarray(values), index=labels['index'],
+                            columns=labels['columns'])
+
+
+def as_sample(x: Any) -> FloatArray:
+    """Reduce a fitting input to a one-dimensional array of observations.
+
+    Parameters
+    ----------
+    x : array_like or Series or DataFrame
+        The sample. A one-column DataFrame is accepted; a wider one is not,
+        because there is no single sensible reading of it.
+
+    Returns
+    -------
+    ndarray
+        The observations, as float64.
+
+    Raises
+    ------
+    ValueError
+        If a DataFrame has more than one column. Flattening it would fit one
+        distribution to several variables pooled together, silently -- which is
+        almost never what was meant.
+    """
+    pandas = loaded('pandas')
+    if pandas is not None and isinstance(x, pandas.DataFrame):
+        if x.shape[1] != 1:
+            raise ValueError(
+                f'expected a Series or a single-column DataFrame, got '
+                f'{x.shape[1]} columns. Fit one column at a time, or pass '
+                f'df[column]; pooling them would fit one distribution to '
+                f'several variables at once.'
+            )
+        x = x.iloc[:, 0]
+    return np.asarray(x, dtype='d')

--- a/src/levy/api.py
+++ b/src/levy/api.py
@@ -56,12 +56,20 @@ interpolation:
 ValidationError
 """
 
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field
 
-from levy._typing import ArrayLike, FloatArray, Parametrization, ScalarOrArray, Seed, Size
+from levy._pandas import as_sample, labels_of, relabel
+from levy._typing import (
+    ArrayLike,
+    FloatArray,
+    Parametrization,
+    ScalarOrArray,
+    Seed,
+    Size,
+)
 from levy.distribution import levy as _levy
 from levy.fitting import fit_levy as _fit_levy
 from levy.parametrization import Parameters
@@ -240,6 +248,40 @@ class FitResult(BaseModel):
     negative_log_likelihood: float
     parametrization: Parametrization = '0'
 
+    def to_series(self, par: Optional[Parametrization] = None) -> Any:
+        """Return the fitted parameters as a named pandas Series.
+
+        Parameters
+        ----------
+        par : {'0', '1', 'M', 'A', 'B'}, optional
+            Parametrization to report in. Defaults to the one the fit ran in,
+            which is what makes the index labels meaningful -- ``gamma`` and
+            ``lambda`` in M, A and B, ``mu`` and ``sigma`` in 0 and 1.
+
+        Returns
+        -------
+        pandas.Series
+            Four values, indexed by parameter name.
+
+        Raises
+        ------
+        ImportError
+            If pandas is not installed, naming the extra that provides it.
+
+        Notes
+        -----
+        The return type is not annotated as ``pandas.Series`` because pandas is
+        an optional extra and must not become a type-checking dependency.
+        """
+        from levy._compat import require
+        from levy.constants import par_names
+
+        pandas = require('pandas')
+        par = self.parametrization if par is None else par
+        return pandas.Series(list(self.params.to_par(par)),
+                             index=list(par_names[par]),
+                             name='levy')
+
     def as_par(self, par: Parametrization) -> tuple[float, float, float, float]:
         """Write the fitted parameters in another parametrization.
 
@@ -282,6 +324,30 @@ def _narrow(value: Any) -> ScalarOrArray:
     return float(value)
 
 
+def _labelled(values: Any, labels: dict[str, Any]) -> ScalarOrArray:
+    """Put pandas labels back on a result, and declare the type of the outcome.
+
+    Parameters
+    ----------
+    values : ndarray
+        The computed result.
+    labels : dict
+        The label description from :func:`levy._pandas.labels_of`.
+
+    Returns
+    -------
+    Series or DataFrame
+        Declared as ``ScalarOrArray``, which is a deliberate and localised
+        inaccuracy: what actually comes back is a pandas object. Expressing
+        that in the annotation would make pandas a type-checking dependency of
+        an *optional* extra. Every non-pandas call -- which is every call a
+        type checker will normally see -- really does return float or ndarray.
+        The docstrings of :func:`pdf`, :func:`cdf` and :func:`logpdf` say what
+        happens with pandas input.
+    """
+    return cast(ScalarOrArray, relabel(values, labels))
+
+
 def _validated(
     alpha: float, beta: float, mu: float, sigma: float, par: Parametrization
 ) -> StableParams:
@@ -317,8 +383,9 @@ def pdf(
 
     Parameters
     ----------
-    x : array_like
-        Points to evaluate at. A scalar in gives a float out.
+    x : array_like or Series or DataFrame
+        Points to evaluate at. A scalar in gives a float out; a pandas object
+        in gives one back, carrying the same index.
     alpha : float
         Index of stability, in ``[0.5, 2]``.
     beta : float
@@ -352,7 +419,10 @@ def pdf(
     array([0.202038, 0.084539])
     """
     p = _validated(alpha, beta, mu, sigma, par)
-    return _narrow(_levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=False))
+    labels = labels_of(x)
+    values = _levy(np.asarray(x, dtype='d') if labels else x,
+                   p.alpha, p.beta, p.mu, p.sigma, cdf=False)
+    return _labelled(values, labels) if labels else _narrow(values)
 
 
 def cdf(
@@ -368,8 +438,9 @@ def cdf(
 
     Parameters
     ----------
-    x : array_like
-        Points to evaluate at. A scalar in gives a float out.
+    x : array_like or Series or DataFrame
+        Points to evaluate at. A scalar in gives a float out; a pandas object
+        in gives one back, carrying the same index.
     alpha : float
         Index of stability, in ``[0.5, 2]``.
     beta : float
@@ -402,7 +473,10 @@ def cdf(
     array([0.756342, 0.89496 ])
     """
     p = _validated(alpha, beta, mu, sigma, par)
-    return _narrow(_levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=True))
+    labels = labels_of(x)
+    values = _levy(np.asarray(x, dtype='d') if labels else x,
+                   p.alpha, p.beta, p.mu, p.sigma, cdf=True)
+    return _labelled(values, labels) if labels else _narrow(values)
 
 
 def logpdf(
@@ -418,8 +492,9 @@ def logpdf(
 
     Parameters
     ----------
-    x : array_like
-        Points to evaluate at.
+    x : array_like or Series or DataFrame
+        Points to evaluate at. A pandas object in gives one back, carrying the
+        same index.
     alpha : float
         Index of stability, in ``[0.5, 2]``.
     beta : float
@@ -454,8 +529,11 @@ def logpdf(
     array([-1.599299, -2.470541])
     """
     p = _validated(alpha, beta, mu, sigma, par)
-    values = _levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=False)
-    return _narrow(np.log(np.maximum(1e-100, values)))
+    labels = labels_of(x)
+    values = np.log(np.maximum(1e-100, _levy(
+        np.asarray(x, dtype='d') if labels else x,
+        p.alpha, p.beta, p.mu, p.sigma, cdf=False)))
+    return _labelled(values, labels) if labels else _narrow(values)
 
 
 def rvs(
@@ -545,8 +623,9 @@ def fit(
 
     Parameters
     ----------
-    x : array_like
-        The sample.
+    x : array_like or Series or DataFrame
+        The sample. A single-column DataFrame is unwrapped; a wider one is
+        rejected rather than silently pooled.
     par : {'0', '1', 'M', 'A', 'B'}, default '0'
         Parametrization to search in. It sets the feasible region and the
         starting point, so different choices can reach different optima.
@@ -597,7 +676,7 @@ def fit(
             f'{", ".join(par_names[par])}'
         )
 
-    parameters, nll = _fit_levy(np.asarray(x, dtype='d'), par=par, **fixed)
+    parameters, nll = _fit_levy(as_sample(x), par=par, **fixed)
     alpha, beta, mu, sigma = (float(v) for v in parameters.get('0'))
     return FitResult(
         params=StableParams(alpha=alpha, beta=beta, mu=mu, sigma=sigma),

--- a/src/levy/api.py
+++ b/src/levy/api.py
@@ -57,12 +57,20 @@ ValidationError
 """
 
 import operator
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field
 
-from levy._typing import ArrayLike, FloatArray, Parametrization, ScalarOrArray, Seed, Size
+from levy._pandas import as_sample, labels_of, relabel
+from levy._typing import (
+    ArrayLike,
+    FloatArray,
+    Parametrization,
+    ScalarOrArray,
+    Seed,
+    Size,
+)
 from levy.constants import par_names
 from levy.distribution import levy as _levy
 from levy.fitting import fit_levy as _fit_levy
@@ -285,6 +293,43 @@ class FitResult(BaseModel):
     negative_log_likelihood: float
     parametrization: Parametrization = '0'
 
+    def to_series(self, par: Optional[Parametrization] = None) -> Any:
+        """Return the fitted parameters as a named pandas Series.
+
+        Parameters
+        ----------
+        par : {'0', '1', 'M', 'A', 'B'}, optional
+            Parametrization to report in. Defaults to the one the fit ran in,
+            which is what makes the index labels meaningful -- ``gamma`` and
+            ``lambda`` in M, A and B, ``mu`` and ``sigma`` in 0 and 1.
+
+        Returns
+        -------
+        pandas.Series
+            Four values, indexed by parameter name.
+
+        Raises
+        ------
+        ImportError
+            If pandas is not installed, naming the extra that provides it.
+        ValueError
+            If `par` is B and the fitted ``alpha`` is 1, where that
+            parametrization is singular (see :meth:`StableParams.to_par`).
+            A fit run in B with ``alpha`` pinned at 1 is the way to get there;
+            ask for another parametrization, ``to_series(par='0')`` say.
+
+        Notes
+        -----
+        The return type is not annotated as ``pandas.Series`` because pandas is
+        an optional extra and must not become a type-checking dependency.
+        """
+        from levy._compat import require
+
+        pandas = require('pandas')
+        par = self.parametrization if par is None else par
+        return pandas.Series(
+            list(self.params.to_par(par)), index=list(par_names[par]), name='levy')
+
     def as_par(self, par: Parametrization) -> tuple[float, float, float, float]:
         """Write the fitted parameters in another parametrization.
 
@@ -297,6 +342,12 @@ class FitResult(BaseModel):
         -------
         tuple of float
             The four fitted values in that parametrization.
+
+        Raises
+        ------
+        ValueError
+            If `par` is B and the fitted ``alpha`` is 1, where that
+            parametrization is singular; see :meth:`StableParams.to_par`.
         """
         return self.params.to_par(par)
 
@@ -325,6 +376,30 @@ def _narrow(value: Any) -> ScalarOrArray:
     if isinstance(value, np.ndarray):
         return cast(FloatArray, value)
     return float(value)
+
+
+def _labelled(values: Any, labels: dict[str, Any]) -> ScalarOrArray:
+    """Put pandas labels back on a result, and declare the type of the outcome.
+
+    Parameters
+    ----------
+    values : ndarray
+        The computed result.
+    labels : dict
+        The label description from :func:`levy._pandas.labels_of`.
+
+    Returns
+    -------
+    Series or DataFrame
+        Declared as ``ScalarOrArray``, which is a deliberate and localised
+        inaccuracy: what actually comes back is a pandas object. Expressing
+        that in the annotation would make pandas a type-checking dependency of
+        an *optional* extra. Every non-pandas call -- which is every call a
+        type checker will normally see -- really does return float or ndarray.
+        The docstrings of :func:`pdf`, :func:`cdf` and :func:`logpdf` say what
+        happens with pandas input.
+    """
+    return cast(ScalarOrArray, relabel(values, labels))
 
 
 def _validated(
@@ -362,8 +437,9 @@ def pdf(
 
     Parameters
     ----------
-    x : array_like
-        Points to evaluate at. A scalar input gives a float result.
+    x : array_like or Series or DataFrame
+        Points to evaluate at. A scalar input gives a float result; a pandas
+        object gives one back, carrying the same index.
     alpha : float
         Index of stability, in ``[0.5, 2]``.
     beta : float
@@ -377,8 +453,8 @@ def pdf(
 
     Returns
     -------
-    float or ndarray
-        The density at `x`.
+    float or ndarray, or Series or DataFrame
+        The density at `x`; a pandas object when `x` is one, with its index.
 
     Raises
     ------
@@ -397,7 +473,10 @@ def pdf(
     array([0.202038, 0.084539])
     """
     p = _validated(alpha, beta, mu, sigma, par)
-    return _narrow(_levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=False))
+    labels = labels_of(x)
+    values = _levy(np.asarray(x, dtype='d') if labels else x,
+                   p.alpha, p.beta, p.mu, p.sigma, cdf=False)
+    return _labelled(values, labels) if labels else _narrow(values)
 
 
 def cdf(
@@ -413,8 +492,9 @@ def cdf(
 
     Parameters
     ----------
-    x : array_like
-        Points to evaluate at. A scalar input gives a float result.
+    x : array_like or Series or DataFrame
+        Points to evaluate at. A scalar input gives a float result; a pandas
+        object gives one back, carrying the same index.
     alpha : float
         Index of stability, in ``[0.5, 2]``.
     beta : float
@@ -428,8 +508,9 @@ def cdf(
 
     Returns
     -------
-    float or ndarray
-        The distribution function at `x`.
+    float or ndarray, or Series or DataFrame
+        The distribution function at `x`; a pandas object when `x` is one,
+        with its index.
 
     Raises
     ------
@@ -447,7 +528,10 @@ def cdf(
     array([0.756342, 0.89496 ])
     """
     p = _validated(alpha, beta, mu, sigma, par)
-    return _narrow(_levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=True))
+    labels = labels_of(x)
+    values = _levy(np.asarray(x, dtype='d') if labels else x,
+                   p.alpha, p.beta, p.mu, p.sigma, cdf=True)
+    return _labelled(values, labels) if labels else _narrow(values)
 
 
 def logpdf(
@@ -463,8 +547,9 @@ def logpdf(
 
     Parameters
     ----------
-    x : array_like
-        Points to evaluate at.
+    x : array_like or Series or DataFrame
+        Points to evaluate at. A pandas object gives one back, carrying the
+        same index.
     alpha : float
         Index of stability, in ``[0.5, 2]``.
     beta : float
@@ -478,8 +563,8 @@ def logpdf(
 
     Returns
     -------
-    float or ndarray
-        ``log(pdf(x))``.
+    float or ndarray, or Series or DataFrame
+        ``log(pdf(x))``; a pandas object when `x` is one, with its index.
 
     See Also
     --------
@@ -499,8 +584,11 @@ def logpdf(
     array([-1.599299, -2.470541])
     """
     p = _validated(alpha, beta, mu, sigma, par)
-    values = _levy(x, p.alpha, p.beta, p.mu, p.sigma, cdf=False)
-    return _narrow(np.log(np.maximum(1e-100, values)))
+    labels = labels_of(x)
+    values = np.log(np.maximum(1e-100, _levy(
+        np.asarray(x, dtype='d') if labels else x,
+        p.alpha, p.beta, p.mu, p.sigma, cdf=False)))
+    return _labelled(values, labels) if labels else _narrow(values)
 
 
 def rvs(
@@ -604,8 +692,9 @@ def fit(
 
     Parameters
     ----------
-    x : array_like
-        The sample.
+    x : array_like or Series or DataFrame
+        The sample. A single-column DataFrame is unwrapped; a wider one is
+        rejected rather than silently pooled.
     par : {'0', '1', 'M', 'A', 'B'}, default '0'
         Parametrization to search in. It sets the feasible region and the
         starting point, so different choices can reach different optima.
@@ -683,7 +772,7 @@ def fit(
             f'{names[3]} must be strictly positive, got {fixed[names[3]]!r}'
         )
 
-    parameters, nll = _fit_levy(np.asarray(x, dtype='d'), par=par, **pinned)
+    parameters, nll = _fit_levy(as_sample(x), par=par, **pinned)
     alpha, beta, mu, sigma = (float(v) for v in parameters.get('0'))
     return FitResult(
         params=StableParams(alpha=alpha, beta=beta, mu=mu, sigma=sigma),

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,28 @@
+"""levy._compat: optional dependencies are looked up, never imported blindly."""
+
+from __future__ import annotations
+
+import pytest
+
+from levy._compat import require
+
+
+def test_require_names_the_extra_when_the_module_is_not_installed():
+    expected = r'not installed.*pip install "pylevy\[no_such_module_xyz\]"'
+    with pytest.raises(ImportError, match=expected):
+        require("no_such_module_xyz")
+
+
+def test_require_does_not_blame_the_install_when_the_module_is_broken(tmp_path, monkeypatch):
+    """A module that is present but fails to import used to be reported as
+    "not installed", with an install command that would have changed nothing.
+    """
+    package = tmp_path / "brokenpkg_for_levy"
+    package.mkdir()
+    (package / "__init__.py").write_text("import a_dependency_that_is_missing\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    with pytest.raises(ImportError, match="installed but failed to import") as info:
+        require("brokenpkg_for_levy")
+    assert "a_dependency_that_is_missing" in str(info.value)
+    assert "not installed" not in str(info.value)

--- a/tests/test_no_pandas.py
+++ b/tests/test_no_pandas.py
@@ -1,0 +1,123 @@
+"""An install without pandas never imports it, and never pays for it.
+
+`pandas` is an optional extra. The tests here run in a subprocess with pandas
+blocked at the import system, so they hold whether or not pandas happens to be
+installed in the environment running the suite -- which is the only way to
+check this claim on a developer machine that has pandas for other reasons.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+import levy
+
+# Refuses to import pandas, or anything under it, no matter who asks.
+BLOCK_PANDAS = """
+import sys
+
+class _Blocked:
+    def find_module(self, name, path=None):
+        if name == 'pandas' or name.startswith('pandas.'):
+            return self
+    def load_module(self, name):
+        raise ImportError('pandas is blocked for this test')
+    def find_spec(self, name, path=None, target=None):
+        if name == 'pandas' or name.startswith('pandas.'):
+            raise ImportError('pandas is blocked for this test')
+        return None
+
+sys.meta_path.insert(0, _Blocked())
+"""
+
+
+def _run(body):
+    """Run `body` in a fresh interpreter with pandas blocked."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(pathlib.Path(levy.__file__).parents[1]), env.get("PYTHONPATH", "")]
+    )
+    return subprocess.run(
+        [sys.executable, "-c", BLOCK_PANDAS + textwrap.dedent(body)],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def test_the_whole_api_works_without_pandas():
+    result = _run("""
+        import numpy as np
+        from levy import api
+
+        x = np.linspace(-5.0, 5.0, 101)
+        api.pdf(x, alpha=1.5, beta=0.0)
+        api.cdf(x, alpha=1.5, beta=0.0)
+        api.logpdf(x, alpha=1.5, beta=0.0)
+        sample = api.rvs(alpha=1.5, beta=0.0, size=200, random_state=0)
+        api.fit(sample)
+        print('ok')
+    """)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_pandas_is_never_imported():
+    result = _run("""
+        import sys
+        import numpy as np
+        from levy import api
+
+        api.pdf(np.array([1.0]), alpha=1.5, beta=0.0)
+        api.fit(api.rvs(alpha=1.5, beta=0.0, size=100, random_state=0))
+        print('pandas' in sys.modules)
+    """)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "False"
+
+
+def test_the_1x_surface_works_without_pandas():
+    result = _run("""
+        import warnings
+        import numpy as np
+        import levy
+
+        warnings.simplefilter('ignore', DeprecationWarning)
+        levy.levy(np.array([1.0]), 1.5, 0.0)
+        levy.fit_levy(levy.random(1.5, 0.0, shape=(100,)))
+        print('ok')
+    """)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_to_series_fails_with_an_instruction_not_a_traceback():
+    result = _run("""
+        from levy import api
+
+        sample = api.rvs(alpha=1.5, beta=0.0, size=100, random_state=0)
+        try:
+            api.fit(sample).to_series()
+        except ImportError as error:
+            print(error)
+        else:
+            print('NO ERROR')
+    """)
+    assert result.returncode == 0, result.stderr
+    message = result.stdout.strip()
+    assert "pandas" in message
+    assert 'pip install "pylevy[pandas]"' in message, message
+
+
+def test_labels_of_is_a_dictionary_lookup_when_pandas_is_absent():
+    # The fast path has to stay fast: no import attempt, no exception handling,
+    # just a miss in sys.modules.
+    from levy._pandas import labels_of
+
+    if "pandas" in sys.modules:
+        pytest.skip("pandas is imported in this process; covered in a subprocess above")
+    assert labels_of(object()) is None

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,195 @@
+"""pandas objects in, labelled pandas objects out -- and nothing in the core.
+
+Two claims are tested here. The first is that labels survive: a density
+evaluated at a labelled index comes back with that index, because silently
+dropping it is how a misaligned join happens later. The second is that the
+numbers are the same ones the array path produces, bit for bit -- the pandas
+layer converts, it does not compute.
+
+`tests/test_no_pandas.py` covers the other half: that an install without pandas
+never imports it and never pays for it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from levy import api  # noqa: E402
+
+XS = np.linspace(-8.0, 8.0, 33)
+PARAMS = {"alpha": 1.5, "beta": -0.3, "mu": 0.2, "sigma": 1.1}
+
+
+@pytest.fixture
+def series():
+    return pd.Series(XS, index=pd.RangeIndex(100, 133, name="obs"), name="returns")
+
+
+@pytest.fixture
+def frame():
+    return pd.DataFrame({"a": XS, "b": XS[::-1]},
+                        index=pd.RangeIndex(100, 133, name="obs"))
+
+
+# --------------------------------------------------------------------------
+# labels survive
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("function", ["pdf", "cdf", "logpdf"])
+def test_series_in_series_out(function, series):
+    result = getattr(api, function)(series, **PARAMS)
+    assert isinstance(result, pd.Series)
+    pd.testing.assert_index_equal(result.index, series.index)
+    assert result.name == series.name
+
+
+@pytest.mark.parametrize("function", ["pdf", "cdf", "logpdf"])
+def test_frame_in_frame_out(function, frame):
+    result = getattr(api, function)(frame, **PARAMS)
+    assert isinstance(result, pd.DataFrame)
+    pd.testing.assert_index_equal(result.index, frame.index)
+    pd.testing.assert_index_equal(result.columns, frame.columns)
+
+
+def test_a_datetime_index_survives():
+    index = pd.date_range("2020-01-01", periods=len(XS), freq="D")
+    result = api.pdf(pd.Series(XS, index=index), **PARAMS)
+    pd.testing.assert_index_equal(result.index, index)
+
+
+def test_an_unsorted_index_is_not_reordered():
+    index = pd.Index([3, 1, 2, 0][: 4], name="k")
+    values = pd.Series([1.0, 2.0, 3.0, 4.0], index=index)
+    result = api.pdf(values, **PARAMS)
+    pd.testing.assert_index_equal(result.index, index)
+    assert result.iloc[0] == api.pdf(np.array([1.0]), **PARAMS)[0]
+
+
+def test_an_unnamed_series_stays_unnamed(series):
+    result = api.pdf(series.rename(None), **PARAMS)
+    assert result.name is None
+
+
+# --------------------------------------------------------------------------
+# the numbers do not move
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("function", ["pdf", "cdf", "logpdf"])
+def test_values_are_bit_identical_to_the_array_path(function, series):
+    from_pandas = getattr(api, function)(series, **PARAMS)
+    from_array = getattr(api, function)(XS, **PARAMS)
+    assert np.array_equal(from_pandas.to_numpy(), from_array)
+
+
+def test_frame_values_are_bit_identical_column_by_column(frame):
+    result = api.pdf(frame, **PARAMS)
+    for column in frame.columns:
+        expected = api.pdf(frame[column].to_numpy(), **PARAMS)
+        assert np.array_equal(result[column].to_numpy(), expected)
+
+
+def test_fit_on_a_series_matches_fit_on_its_values():
+    sample = api.rvs(alpha=1.5, beta=0.0, size=500, random_state=3)
+    labelled = pd.Series(sample, index=pd.date_range("2021-01-01", periods=500))
+
+    from_series = api.fit(labelled)
+    from_array = api.fit(sample)
+
+    assert from_series.params == from_array.params
+    assert from_series.negative_log_likelihood == from_array.negative_log_likelihood
+
+
+def test_fit_on_a_one_column_frame_matches_the_series():
+    sample = api.rvs(alpha=1.5, beta=0.0, size=300, random_state=4)
+    frame = pd.DataFrame({"x": sample})
+    assert api.fit(frame).params == api.fit(sample).params
+
+
+# --------------------------------------------------------------------------
+# results as pandas
+# --------------------------------------------------------------------------
+
+def test_to_series_is_named_by_parameter():
+    sample = api.rvs(alpha=1.5, beta=0.0, size=300, random_state=5)
+    reported = api.fit(sample).to_series()
+
+    assert isinstance(reported, pd.Series)
+    assert list(reported.index) == ["alpha", "beta", "mu", "sigma"]
+    np.testing.assert_allclose(
+        reported.to_numpy(), api.fit(sample).params.as_tuple(), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(("par", "names"), [
+    ("0", ["alpha", "beta", "mu", "sigma"]),
+    ("1", ["alpha", "beta", "mu", "sigma"]),
+    ("M", ["alpha", "beta", "gamma", "lambda"]),
+    ("A", ["alpha", "beta", "gamma", "lambda"]),
+    ("B", ["alpha", "beta", "gamma", "lambda"]),
+])
+def test_to_series_uses_the_parametrizations_own_names(par, names):
+    sample = api.rvs(alpha=1.5, beta=0.0, size=200, random_state=6)
+    assert list(api.fit(sample, par=par).to_series().index) == names
+
+
+def test_to_series_can_report_in_another_parametrization():
+    sample = api.rvs(alpha=1.5, beta=0.0, size=200, random_state=7)
+    result = api.fit(sample)
+    np.testing.assert_allclose(
+        result.to_series("B").to_numpy(), result.params.to_par("B"), rtol=0, atol=0)
+
+
+# --------------------------------------------------------------------------
+# refusals
+# --------------------------------------------------------------------------
+
+def test_fitting_a_wide_frame_is_refused_rather_than_pooled(frame):
+    with pytest.raises(ValueError, match="single-column DataFrame"):
+        api.fit(frame)
+
+
+def test_the_refusal_says_what_to_do_instead(frame):
+    with pytest.raises(ValueError, match=r"df\[column\]"):
+        api.fit(frame)
+
+
+def test_validation_still_runs_on_pandas_input(series):
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        api.pdf(series, alpha=0.3, beta=0.0)
+
+
+# --------------------------------------------------------------------------
+# the core never sees pandas
+# --------------------------------------------------------------------------
+
+def test_the_numerical_core_receives_a_plain_array(monkeypatch, series):
+    seen = []
+    import levy.api
+
+    original = levy.api._levy
+
+    def recording(x, *args, **kwargs):
+        seen.append(type(x))
+        return original(x, *args, **kwargs)
+
+    monkeypatch.setattr(levy.api, "_levy", recording)
+    api.pdf(series, **PARAMS)
+
+    assert seen == [np.ndarray], f"the core was handed {seen}"
+
+
+def test_deprecated_levy_does_not_grow_pandas_support(series):
+    # The 1.x function is frozen. pandas support is a 2.0 feature of levy.api;
+    # adding it to levy.levy would change what a 1.x caller gets back.
+    import warnings
+
+    import levy
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = levy.levy(series, 1.5, -0.3, 0.2, 1.1)
+    assert isinstance(result, np.ndarray)

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,197 @@
+"""pandas objects in, labelled pandas objects out -- and nothing in the core.
+
+Two claims are tested here. The first is that labels survive: a density
+evaluated at a labelled index comes back with that index, because silently
+dropping it is how a misaligned join happens later. The second is that the
+numbers are the same ones the array path produces, bit for bit -- the pandas
+layer converts, it does not compute.
+
+`tests/test_no_pandas.py` covers the other half: that an install without pandas
+never imports it and never pays for it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from levy import api  # noqa: E402
+
+XS = np.linspace(-8.0, 8.0, 33)
+PARAMS = {"alpha": 1.5, "beta": -0.3, "mu": 0.2, "sigma": 1.1}
+
+
+@pytest.fixture
+def series():
+    return pd.Series(XS, index=pd.RangeIndex(100, 133, name="obs"), name="returns")
+
+
+@pytest.fixture
+def frame():
+    return pd.DataFrame(
+        {"a": XS, "b": XS[::-1]}, index=pd.RangeIndex(100, 133, name="obs"))
+
+
+# --------------------------------------------------------------------------
+# labels survive
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("function", ["pdf", "cdf", "logpdf"])
+def test_series_in_series_out(function, series):
+    result = getattr(api, function)(series, **PARAMS)
+    assert isinstance(result, pd.Series)
+    pd.testing.assert_index_equal(result.index, series.index)
+    assert result.name == series.name
+
+
+@pytest.mark.parametrize("function", ["pdf", "cdf", "logpdf"])
+def test_frame_in_frame_out(function, frame):
+    result = getattr(api, function)(frame, **PARAMS)
+    assert isinstance(result, pd.DataFrame)
+    pd.testing.assert_index_equal(result.index, frame.index)
+    pd.testing.assert_index_equal(result.columns, frame.columns)
+
+
+def test_a_datetime_index_survives():
+    index = pd.date_range("2020-01-01", periods=len(XS), freq="D")
+    result = api.pdf(pd.Series(XS, index=index), **PARAMS)
+    pd.testing.assert_index_equal(result.index, index)
+
+
+def test_an_unsorted_index_is_not_reordered():
+    index = pd.Index([3, 1, 2, 0][: 4], name="k")
+    values = pd.Series([1.0, 2.0, 3.0, 4.0], index=index)
+    result = api.pdf(values, **PARAMS)
+    pd.testing.assert_index_equal(result.index, index)
+    assert result.iloc[0] == api.pdf(np.array([1.0]), **PARAMS)[0]
+
+
+def test_an_unnamed_series_stays_unnamed(series):
+    result = api.pdf(series.rename(None), **PARAMS)
+    assert result.name is None
+
+
+# --------------------------------------------------------------------------
+# the numbers do not move
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("function", ["pdf", "cdf", "logpdf"])
+def test_values_are_bit_identical_to_the_array_path(function, series):
+    from_pandas = getattr(api, function)(series, **PARAMS)
+    from_array = getattr(api, function)(XS, **PARAMS)
+    assert np.array_equal(from_pandas.to_numpy(), from_array)
+
+
+def test_frame_values_are_bit_identical_column_by_column(frame):
+    result = api.pdf(frame, **PARAMS)
+    for column in frame.columns:
+        expected = api.pdf(frame[column].to_numpy(), **PARAMS)
+        assert np.array_equal(result[column].to_numpy(), expected)
+
+
+def test_fit_on_a_series_matches_fit_on_its_values():
+    sample = api.rvs(alpha=1.5, beta=0.0, size=500, random_state=3)
+    labelled = pd.Series(sample, index=pd.date_range("2021-01-01", periods=500))
+
+    from_series = api.fit(labelled)
+    from_array = api.fit(sample)
+
+    assert from_series.params == from_array.params
+    assert from_series.negative_log_likelihood == from_array.negative_log_likelihood
+
+
+def test_fit_on_a_one_column_frame_matches_the_series():
+    sample = api.rvs(alpha=1.5, beta=0.0, size=300, random_state=4)
+    frame = pd.DataFrame({"x": sample})
+    assert api.fit(frame).params == api.fit(sample).params
+
+
+# --------------------------------------------------------------------------
+# results as pandas
+# --------------------------------------------------------------------------
+
+def test_to_series_is_named_by_parameter():
+    sample = api.rvs(alpha=1.5, beta=0.0, size=300, random_state=5)
+    result = api.fit(sample)
+    reported = result.to_series()
+
+    assert isinstance(reported, pd.Series)
+    assert list(reported.index) == ["alpha", "beta", "mu", "sigma"]
+    # The same FitResult on both sides: to_series() must report exactly the
+    # parameters it holds, and one fit is enough to say so.
+    np.testing.assert_array_equal(reported.to_numpy(), result.params.as_tuple())
+
+
+@pytest.mark.parametrize(("par", "names"), [
+    ("0", ["alpha", "beta", "mu", "sigma"]),
+    ("1", ["alpha", "beta", "mu", "sigma"]),
+    ("M", ["alpha", "beta", "gamma", "lambda"]),
+    ("A", ["alpha", "beta", "gamma", "lambda"]),
+    ("B", ["alpha", "beta", "gamma", "lambda"]),
+])
+def test_to_series_uses_the_parametrizations_own_names(par, names):
+    sample = api.rvs(alpha=1.5, beta=0.0, size=200, random_state=6)
+    assert list(api.fit(sample, par=par).to_series().index) == names
+
+
+def test_to_series_can_report_in_another_parametrization():
+    sample = api.rvs(alpha=1.5, beta=0.0, size=200, random_state=7)
+    result = api.fit(sample)
+    np.testing.assert_allclose(
+        result.to_series("B").to_numpy(), result.params.to_par("B"), rtol=0, atol=0)
+
+
+# --------------------------------------------------------------------------
+# refusals
+# --------------------------------------------------------------------------
+
+def test_fitting_a_wide_frame_is_refused_rather_than_pooled(frame):
+    with pytest.raises(ValueError, match="single-column DataFrame"):
+        api.fit(frame)
+
+
+def test_the_refusal_says_what_to_do_instead(frame):
+    with pytest.raises(ValueError, match=r"df\[column\]"):
+        api.fit(frame)
+
+
+def test_validation_still_runs_on_pandas_input(series):
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        api.pdf(series, alpha=0.3, beta=0.0)
+
+
+# --------------------------------------------------------------------------
+# the core never sees pandas
+# --------------------------------------------------------------------------
+
+def test_the_numerical_core_receives_a_plain_array(monkeypatch, series):
+    seen = []
+    import levy.api
+
+    original = levy.api._levy
+
+    def recording(x, *args, **kwargs):
+        seen.append(type(x))
+        return original(x, *args, **kwargs)
+
+    monkeypatch.setattr(levy.api, "_levy", recording)
+    api.pdf(series, **PARAMS)
+
+    assert seen == [np.ndarray], f"the core was handed {seen}"
+
+
+def test_deprecated_levy_does_not_grow_pandas_support(series):
+    # The 1.x function is frozen. pandas support is a 2.0 feature of levy.api;
+    # adding it to levy.levy would change what a 1.x caller gets back.
+    import warnings
+
+    import levy
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = levy.levy(series, 1.5, -0.3, 0.2, 1.1)
+    assert isinstance(result, np.ndarray)


### PR DESCRIPTION
> Part 15 of a 20-commit stack. Stacked on #36 — review that first; the diff here against its base is a single commit.

pdf, cdf and logpdf accept a Series or a DataFrame and return one carrying the
same index; fit accepts a Series or a single-column DataFrame; and
FitResult.to_series() reports the four parameters under the names of whichever
parametrization the fit ran in -- gamma and lambda in M, A and B, mu and sigma
in 0 and 1.

Dropping an index silently is how a misaligned join happens two steps later, so
the index survives evaluation. What does not survive is pandas reaching the
numerical core: levy/_pandas.py unwraps at the boundary, and a test records the
type the core is handed and asserts it is ndarray.

The extra costs nothing when it is not installed. Support is detected with
`sys.modules.get('pandas')`, not by attempting an import: if the caller has not
imported pandas, the object they just passed cannot be a pandas object, so
there is nothing to check and nothing to load. The fast path is one dictionary
lookup, and `import levy` never pulls pandas in.

tests/test_no_pandas.py proves that half in a subprocess with pandas blocked at
the import system, so it holds on a developer machine that has pandas installed
for other reasons. It runs the whole API, the whole 1.x surface, and asserts
'pandas' never appears in sys.modules. It also checks the failure mode users
actually hit: to_series() without the extra raises ImportError saying
`pip install "pylevy[pandas]"`, not an ImportError from three frames down.

A DataFrame with more than one column is refused by fit rather than flattened.
Pooling several variables into one distribution is almost never what was meant,
and doing it silently would be the same class of bug as dropping an index.

Numbers do not move: every value through the pandas path is bit-identical to
the array path, checked per function and per column. levy.levy is deliberately
left alone -- pandas support is a 2.0 feature of levy.api, and giving the
deprecated function a new return type would change what a 1.x caller gets.

Also adds levy/_compat.py, the guard the torch extra will use next, and an
`optional extras` CI leg. The five existing test legs install *without* extras,
which is what proves the base install works; the new leg installs with them, so
test_pandas.py runs instead of being skipped.

32 new tests (805 total, 1 skipped). Goldens unchanged.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

