### PR TITLE
Add an optional torch backend: the same numbers, differentiable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       # -- every parameter documented, in order, with a type, and a Returns
       # section that matches. ruff cannot see that far.
       - name: numpydoc
-        run: python -m numpydoc lint src/levy/*.py src/levy/_build/*.py
+        run: python -m numpydoc lint src/levy/*.py src/levy/_build/*.py src/levy/backends/*.py
 
       # Strict, but only over the typed surface -- levy/api.py and
       # levy/_typing.py. The numerical core has no annotations and is checked
@@ -213,16 +213,21 @@ jobs:
       # is what proves an install without them works. This one is the other
       # half: pandas installed, so tests/test_pandas.py actually runs instead of
       # being skipped.
+      # CPU-only: the torch wheel index below avoids pulling ~2 GB of CUDA
+      # libraries onto a runner that has no GPU.
       - name: Install package with extras
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,pandas]"
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install -e ".[dev,pandas,torch]"
 
       - name: Run tests
         run: python -m pytest tests/ -q -m "not build"
 
-      - name: pandas support is exercised, not skipped
-        run: python -m pytest tests/test_pandas.py -q --no-header -p no:cacheprovider
+      # Guards against these being silently skipped, which is what would happen
+      # if an extra failed to install.
+      - name: Optional-dependency suites are exercised, not skipped
+        run: python -m pytest tests/test_pandas.py tests/test_torch.py -q --no-header -p no:cacheprovider
 
   doctests:
     name: doctests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
       # -- every parameter documented, in order, with a type, and a Returns
       # section that matches. ruff cannot see that far.
       - name: numpydoc
-        run: python -m numpydoc lint src/levy/*.py src/levy/_build/*.py
+        run: python -m numpydoc lint src/levy/*.py src/levy/_build/*.py src/levy/backends/*.py
 
       # Strict, but only over the typed surface -- levy/api.py and
       # levy/_typing.py. The numerical core has no annotations and is checked
@@ -263,15 +263,18 @@ jobs:
       # is what proves an install without them works. This one is the other
       # half: pandas installed, so tests/test_pandas.py actually runs instead of
       # being skipped.
+      # CPU-only: the torch wheel index below avoids pulling ~2 GB of CUDA
+      # libraries onto a runner that has no GPU.
       - name: Install package with extras
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,pandas]"
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install -e ".[dev,pandas,torch]"
 
-      # The extra must be declared in the package metadata, not merely be
-      # importable on this runner: `pip install ".[pandas]"` only *warns* when
-      # an extra does not exist, so a misspelt or dropped extra would otherwise
-      # pass here as long as pandas got installed some other way.
+      # The extras must be declared in the package metadata, not merely be
+      # importable on this runner: `pip install ".[torch]"` only *warns* when
+      # an extra does not exist, and torch is pre-installed above anyway (for
+      # the CPU wheel), so a misspelt or dropped extra would otherwise pass.
       - name: The extras are declared in the package metadata
         run: |
           python - <<'PY'
@@ -280,24 +283,27 @@ jobs:
           with open("pyproject.toml", "rb") as handle:
               name = tomllib.load(handle)["project"]["name"]
           declared = requires(name) or []
-          for extra in ("pandas",):
+          for extra in ("pandas", "torch"):
               assert any(f'extra == "{extra}"' in r for r in declared), (extra, declared)
           print("extras declared:", sorted(r for r in declared if "extra ==" in r))
           PY
 
-      # The optional suite is left out here and run exactly once below, where
-      # a skip is made visible and fatal.
+      # The optional suites are left out here and run exactly once below,
+      # where a skip is made visible and fatal.
       - name: Run tests
-        run: python -m pytest tests/ -q -m "not build" --ignore=tests/test_pandas.py
+        run: >-
+          python -m pytest tests/ -q -m "not build"
+          --ignore=tests/test_pandas.py --ignore=tests/test_torch.py
 
-      # -rs prints every skip. test_pandas.py skips itself when pandas is
-      # missing, so any SKIPPED line means the extra did not install.
-      - name: pandas support is exercised, not skipped
+      # -rs prints every skip. Each optional suite skips itself when its
+      # dependency is missing, so any SKIPPED line means an extra did not
+      # install -- which pre-installing torch above would otherwise hide.
+      - name: Optional-dependency suites are exercised, not skipped
         run: |
           # pipefail: without it the pipeline's status is tee's, and a failing
           # pytest would pass this step as long as nothing was skipped.
           set -o pipefail
-          python -m pytest tests/test_pandas.py -q -rs -p no:cacheprovider | tee optional.log
+          python -m pytest tests/test_pandas.py tests/test_torch.py -q -rs -p no:cacheprovider | tee optional.log
           ! grep -q "SKIPPED" optional.log
 
   doctests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ public name still works and still returns the same floats, bit for bit.
   support is detected by looking in `sys.modules`, so the fast path is one
   dictionary lookup. `tests/test_no_pandas.py` runs the whole API in a
   subprocess with pandas blocked at the import system.
+- An optional `torch` extra: `levy.backends`, with a torch implementation of
+  the interpolation written to be differentiable. Hand `pdf`, `cdf` or `logpdf`
+  a tensor -- or select the backend with `levy.set_backend('torch')` or
+  `levy.using('torch')` -- and gradients flow to `alpha`, `beta`, `mu` and
+  `sigma`, so a stable distribution can sit inside a larger torch model and be
+  fitted by gradient descent. `torch.autograd.gradcheck` passes for all four
+  parameters, for pdf, cdf and the negative log density, in float64. NumPy
+  remains the default, and an install without the extra never imports torch.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ number, a NaN, or an error -- it returns the same floats, bit for bit.
   support is detected by looking in `sys.modules`, so the fast path is one
   dictionary lookup. `tests/test_no_pandas.py` runs the whole API in a
   subprocess with pandas blocked at the import system.
+- An optional `torch` extra: `levy.backends`, with a torch implementation of
+  the interpolation written to be differentiable. Hand `pdf`, `cdf` or `logpdf`
+  a tensor -- or select the backend with `levy.set_backend('torch')` or
+  `levy.using('torch')` -- and gradients flow to `alpha`, `beta`, `mu` and
+  `sigma`, so a stable distribution can sit inside a larger torch model and be
+  fitted by gradient descent. `torch.autograd.gradcheck` passes for all four
+  parameters, for pdf, cdf and the negative log density, in float64. NumPy
+  remains the default, and an install without the extra never imports torch.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,33 @@ api.fit(returns).to_series()
 
 Without the extra, pandas is never imported.
 
+## torch
+
+    pip install ".[torch]"
+
+Hand the functions tensors and the result carries gradients, so the log
+likelihood can be minimised by gradient descent inside a larger model:
+
+```python
+import torch
+from levy import api
+
+sample = torch.tensor(observations)
+params = torch.tensor([1.4, 0.0, 0.0, 1.0], requires_grad=True)
+optimizer = torch.optim.Adam([params], lr=0.03)
+
+for _ in range(400):
+    optimizer.zero_grad()
+    loss = -api.logpdf(sample, alpha=params[0], beta=params[1],
+                       mu=params[2], sigma=params[3]).sum()
+    loss.backward()
+    optimizer.step()
+```
+
+`levy.set_backend('torch')` or `with levy.using('torch'):` selects it
+explicitly. NumPy is the default, and without the extra torch is never
+imported.
+
 ## Regenerating the tables
 
 The shipped tables are enough for normal use. To rebuild them, at the default

--- a/README.md
+++ b/README.md
@@ -78,6 +78,40 @@ api.fit(returns).to_series()
 
 Without the extra, pandas is never imported.
 
+## torch
+
+    pip install ".[torch]"
+
+Hand the functions tensors and the result carries gradients, so the log
+likelihood can be minimised by gradient descent inside a larger model:
+
+```python
+import torch
+from levy import api
+
+sample = torch.tensor(observations)
+params = torch.tensor([1.4, 0.0, 0.0, 1.0], requires_grad=True)
+optimizer = torch.optim.Adam([params], lr=0.03)
+
+for _ in range(400):
+    optimizer.zero_grad()
+    # The parameters are validated on every call, so keep the optimizer's
+    # raw values inside the domain: alpha in [0.5, 2], beta in [-1, 1],
+    # sigma > 0. clamp is differentiable inside the range and stops the
+    # gradient at its edges, which is what a bound should do.
+    loss = -api.logpdf(sample,
+                       alpha=params[0].clamp(0.55, 1.95),
+                       beta=params[1].clamp(-0.95, 0.95),
+                       mu=params[2],
+                       sigma=params[3].clamp(min=1e-3)).sum()
+    loss.backward()
+    optimizer.step()
+```
+
+`levy.set_backend('torch')` or `with levy.using('torch'):` selects it
+explicitly. NumPy is the default, and without the extra torch is never
+imported.
+
 ## Regenerating the tables
 
 The shipped tables are enough for normal use. To rebuild them, at the default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ lint = ["ruff>=0.16,<0.17", "numpydoc>=1.6", "mypy>=1.8"]
 # is detected by looking in sys.modules, so an install without this extra never
 # pays for it. See levy/_compat.py.
 pandas = ["pandas>=1.5"]
+# Optional. The torch backend exists to make the log likelihood
+# differentiable, so a stable distribution can be fitted by gradient descent
+# inside a larger model. If torch is absent, not one line of it is imported.
+torch = ["torch>=2.0"]
 
 # Regenerates the lookup tables into a user cache directory. Replaces
 # `python -m levy build`, which wrote 24 MB into the installed package.
@@ -176,6 +180,11 @@ module = [
     "levy._build",
     "levy._build.*",
     "levy._logging",
+    # The backends are numerical code in the same untyped style as the core,
+    # and typing the torch one strictly would need torch stubs -- for a
+    # dependency that is optional by design.
+    "levy.backends",
+    "levy.backends.*",
     "scipy.*",
     # pandas ships no stubs by default and is an optional extra; requiring
     # pandas-stubs to type-check the core would defeat the point of it being

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ lint = ["ruff>=0.16,<0.17", "numpydoc>=1.6", "mypy>=1.8"]
 # is detected by looking in sys.modules, so an install without this extra never
 # pays for it. See levy/_compat.py.
 pandas = ["pandas>=1.5"]
+# Optional. The torch backend exists to make the log likelihood
+# differentiable, so a stable distribution can be fitted by gradient descent
+# inside a larger model. If torch is absent, not one line of it is imported.
+torch = ["torch>=2.0"]
 
 # Regenerates the lookup tables into a user cache directory. Replaces
 # `python -m levy build`, which wrote 24 MB into the installed package.
@@ -184,6 +188,11 @@ module = [
     "levy._build",
     "levy._build.*",
     "levy._logging",
+    # The backends are numerical code in the same untyped style as the core,
+    # and typing the torch one strictly would need torch stubs -- for a
+    # dependency that is optional by design.
+    "levy.backends",
+    "levy.backends.*",
     "scipy.*",
     # pandas ships no stubs by default and is an optional extra; requiring
     # pandas-stubs to type-check the core would defeat the point of it being

--- a/src/levy/__init__.py
+++ b/src/levy/__init__.py
@@ -52,6 +52,7 @@ whole public surface, so ``import levy`` behaves exactly as before:
 ``fitting``           ``fit_levy``
 ``sampling``          ``random``
 ``api``               the typed, validated API: ``pdf``/``cdf``/``rvs``/``fit``
+``backends``          which array library evaluates: NumPy, or optional torch
 ``_build``            offline table generation (only the CLI imports it)
 ===================== =========================================================
 
@@ -106,6 +107,9 @@ __version__ = "2.0.0"
 #: The 2.0 surface.
 _CURRENT = [
     'api',
+    'backends',
+    'set_backend',
+    'using',
     'data_dir',
     'user_cache_dir',
     'PACKAGED_DATA',
@@ -215,8 +219,13 @@ def __getattr__(name):
     resolves to the very same object 1.1 exported, so numbers cannot drift
     between the old spelling and the new one. Only the lookup is intercepted.
     """
-    if name == 'api':
-        return importlib.import_module('levy.api')
+    if name in ('api', 'backends'):
+        return importlib.import_module(f'levy.{name}')
+
+    if name in ('set_backend', 'using'):
+        # levy.backends imports nothing heavier than levy._compat, so this
+        # costs nothing for a caller who never selects a backend.
+        return getattr(importlib.import_module('levy.backends'), name)
 
     if name in _DEPRECATED:
         module_name, attribute, replacement = _DEPRECATED[name]

--- a/src/levy/__init__.py
+++ b/src/levy/__init__.py
@@ -52,6 +52,7 @@ whole public surface, so ``import levy`` behaves exactly as before:
 ``fitting``           ``fit_levy``
 ``sampling``          ``random``
 ``api``               the typed API: ``pdf``/``cdf``/``logpdf``/``rvs``/``fit``
+``backends``          which array library evaluates: NumPy, or optional torch
 ``_build``            offline table generation (only the CLI imports it)
 ===================== =========================================================
 
@@ -107,6 +108,9 @@ __version__ = "2.0.0"
 #: The 2.0 surface.
 _CURRENT = [
     'api',
+    'backends',
+    'set_backend',
+    'using',
     'data_dir',
     'user_cache_dir',
     'PACKAGED_DATA',
@@ -171,6 +175,7 @@ _DEPRECATED = {
 # `import levy`.
 _SUBMODULES = (
     'api',
+    'backends',
     'constants',
     'distribution',
     'fitting',
@@ -218,6 +223,11 @@ def __getattr__(name):
     """
     if name in _SUBMODULES:
         return importlib.import_module(f'levy.{name}')
+
+    if name in ('set_backend', 'using'):
+        # levy.backends imports nothing heavier than levy._compat, so this
+        # costs nothing for a caller who never selects a backend.
+        return getattr(importlib.import_module('levy.backends'), name)
 
     if name in _DEPRECATED:
         module_name, attribute, replacement = _DEPRECATED[name]

--- a/src/levy/api.py
+++ b/src/levy/api.py
@@ -61,6 +61,7 @@ from typing import Any, Optional, cast
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field
 
+from levy import backends
 from levy._pandas import as_sample, labels_of, relabel
 from levy._typing import (
     ArrayLike,
@@ -324,6 +325,106 @@ def _narrow(value: Any) -> ScalarOrArray:
     return float(value)
 
 
+def _plain(value: Any) -> Any:
+    """Reduce a parameter to a plain float for validation, if it is one.
+
+    Parameters
+    ----------
+    value : object
+        A parameter as the caller wrote it: a float, or a zero-dimensional
+        tensor when they are differentiating through it.
+
+    Returns
+    -------
+    float or object
+        A float when one can be read out without side effects, otherwise
+        `value` unchanged, so that validation reports on what it really got.
+    """
+    if isinstance(value, (int, float)):
+        return float(value)
+    item = getattr(value, 'item', None)
+    if item is not None and getattr(value, 'ndim', 1) == 0:
+        try:
+            return float(item())
+        except (TypeError, ValueError, RuntimeError):
+            return value
+    return value
+
+
+def _dispatch(
+    backend: Optional[str],
+    par: Parametrization,
+    x: Any,
+    alpha: Any,
+    beta: Any,
+    mu: Any,
+    sigma: Any,
+) -> Any:
+    """Choose a backend, and check that the request is one it can serve.
+
+    Parameters
+    ----------
+    backend : str or None
+        An explicit choice, or None for automatic selection.
+    par : {'0', '1', 'M', 'A', 'B'}
+        Parametrization the parameters are written in.
+    x : object
+        The evaluation points, inspected for tensors.
+    alpha, beta, mu, sigma : object
+        The parameters, inspected for tensors.
+
+    Returns
+    -------
+    module
+        The backend module to evaluate with.
+
+    Raises
+    ------
+    ValueError
+        If tensor parameters are given in a parametrization other than 0. The
+        conversion between parametrizations runs in NumPy, so routing tensors
+        through it would cut the gradient without saying so.
+    """
+    module = backends.get(backend, x, alpha, beta, mu, sigma)
+    if module.name != 'numpy' and par != '0':
+        # Tensor-ness, not float-readability: a zero-dimensional tensor reads
+        # as a float perfectly well, and converting it is exactly the silent
+        # gradient cut this refuses to make.
+        tensors = [label for label, value in
+                   (('alpha', alpha), ('beta', beta), ('mu', mu), ('sigma', sigma))
+                   if backends._is_tensor(value)]
+        if tensors:
+            raise ValueError(
+                f'the {module.name} backend needs parametrization 0 for tensor '
+                f'parameters ({", ".join(tensors)} given in {par!r}). The '
+                f'conversion between parametrizations runs in NumPy, so it '
+                f'would cut the gradient without saying so. Convert first with '
+                f'StableParams.from_par, or work in parametrization 0.'
+            )
+    return module
+
+
+def _from_backend(value: Any) -> ScalarOrArray:
+    """Declare the type of a non-default backend's result.
+
+    Parameters
+    ----------
+    value : object
+        Whatever the backend returned -- a ``torch.Tensor`` for the torch
+        backend.
+
+    Returns
+    -------
+    float or ndarray
+        Declared, not checked. The same localised inaccuracy as
+        :func:`_labelled`, and for the same reason: torch is an optional extra
+        and must not become a type-checking dependency. Every call a type
+        checker will normally see uses the NumPy backend and really does return
+        float or ndarray.
+    """
+    return cast(ScalarOrArray, value)
+
+
 def _labelled(values: Any, labels: dict[str, Any]) -> ScalarOrArray:
     """Put pandas labels back on a result, and declare the type of the outcome.
 
@@ -378,6 +479,7 @@ def pdf(
     mu: float = 0.0,
     sigma: float = 1.0,
     par: Parametrization = '0',
+    backend: Optional[str] = None,
 ) -> ScalarOrArray:
     """Evaluate the probability density function.
 
@@ -396,6 +498,10 @@ def pdf(
         Scale, strictly positive.
     par : {'0', '1', 'M', 'A', 'B'}, default '0'
         Parametrization the four parameters are written in.
+    backend : {'numpy', 'torch'}, optional
+        Which array library evaluates this. The default picks torch when any
+        argument is a ``torch.Tensor``, and NumPy otherwise. Tensor parameters
+        carry gradients through the result.
 
     Returns
     -------
@@ -418,7 +524,11 @@ def pdf(
     >>> np.round(pdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
     array([0.202038, 0.084539])
     """
-    p = _validated(alpha, beta, mu, sigma, par)
+    module = _dispatch(backend, par, x, alpha, beta, mu, sigma)
+    p = _validated(_plain(alpha), _plain(beta), _plain(mu), _plain(sigma), par)
+    if module.name != 'numpy':
+        return _from_backend(module.pdf(x, alpha, beta, mu, sigma))
+
     labels = labels_of(x)
     values = _levy(np.asarray(x, dtype='d') if labels else x,
                    p.alpha, p.beta, p.mu, p.sigma, cdf=False)
@@ -433,6 +543,7 @@ def cdf(
     mu: float = 0.0,
     sigma: float = 1.0,
     par: Parametrization = '0',
+    backend: Optional[str] = None,
 ) -> ScalarOrArray:
     """Evaluate the cumulative distribution function.
 
@@ -451,6 +562,10 @@ def cdf(
         Scale, strictly positive.
     par : {'0', '1', 'M', 'A', 'B'}, default '0'
         Parametrization the four parameters are written in.
+    backend : {'numpy', 'torch'}, optional
+        Which array library evaluates this. The default picks torch when any
+        argument is a ``torch.Tensor``, and NumPy otherwise. Tensor parameters
+        carry gradients through the result.
 
     Returns
     -------
@@ -472,7 +587,11 @@ def cdf(
     >>> np.round(cdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
     array([0.756342, 0.89496 ])
     """
-    p = _validated(alpha, beta, mu, sigma, par)
+    module = _dispatch(backend, par, x, alpha, beta, mu, sigma)
+    p = _validated(_plain(alpha), _plain(beta), _plain(mu), _plain(sigma), par)
+    if module.name != 'numpy':
+        return _from_backend(module.cdf(x, alpha, beta, mu, sigma))
+
     labels = labels_of(x)
     values = _levy(np.asarray(x, dtype='d') if labels else x,
                    p.alpha, p.beta, p.mu, p.sigma, cdf=True)
@@ -487,6 +606,7 @@ def logpdf(
     mu: float = 0.0,
     sigma: float = 1.0,
     par: Parametrization = '0',
+    backend: Optional[str] = None,
 ) -> ScalarOrArray:
     """Evaluate the log of the probability density function.
 
@@ -505,6 +625,10 @@ def logpdf(
         Scale, strictly positive.
     par : {'0', '1', 'M', 'A', 'B'}, default '0'
         Parametrization the four parameters are written in.
+    backend : {'numpy', 'torch'}, optional
+        Which array library evaluates this. The default picks torch when any
+        argument is a ``torch.Tensor``, and NumPy otherwise. Tensor parameters
+        carry gradients through the result.
 
     Returns
     -------
@@ -528,7 +652,11 @@ def logpdf(
     >>> np.round(logpdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
     array([-1.599299, -2.470541])
     """
-    p = _validated(alpha, beta, mu, sigma, par)
+    module = _dispatch(backend, par, x, alpha, beta, mu, sigma)
+    p = _validated(_plain(alpha), _plain(beta), _plain(mu), _plain(sigma), par)
+    if module.name != 'numpy':
+        return _from_backend(-module.neglog(x, alpha, beta, mu, sigma))
+
     labels = labels_of(x)
     values = np.log(np.maximum(1e-100, _levy(
         np.asarray(x, dtype='d') if labels else x,

--- a/src/levy/api.py
+++ b/src/levy/api.py
@@ -62,6 +62,7 @@ from typing import Any, Optional, cast
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field
 
+from levy import backends
 from levy._pandas import as_sample, labels_of, relabel
 from levy._typing import (
     ArrayLike,
@@ -378,6 +379,117 @@ def _narrow(value: Any) -> ScalarOrArray:
     return float(value)
 
 
+def _plain(value: Any) -> Any:
+    """Reduce a parameter to a plain float for validation, if it is one.
+
+    Parameters
+    ----------
+    value : object
+        A parameter as the caller wrote it: a float, or a zero-dimensional
+        tensor when they are differentiating through it.
+
+    Returns
+    -------
+    float or object
+        A float when one can be read out without side effects, otherwise
+        `value` unchanged, so that validation reports on what it really got.
+    """
+    if isinstance(value, (int, float)):
+        return float(value)
+    item = getattr(value, 'item', None)
+    if item is not None and getattr(value, 'ndim', 1) == 0:
+        try:
+            return float(item())
+        except (TypeError, ValueError, RuntimeError):
+            return value
+    return value
+
+
+def _dispatch(
+    backend: Optional[str],
+    par: Parametrization,
+    x: Any,
+    alpha: Any,
+    beta: Any,
+    mu: Any,
+    sigma: Any,
+) -> Any:
+    """Choose a backend, and check that the request is one it can serve.
+
+    Parameters
+    ----------
+    backend : str or None
+        An explicit choice, or None for automatic selection.
+    par : {'0', '1', 'M', 'A', 'B'}
+        Parametrization the parameters are written in.
+    x : object
+        The evaluation points, inspected for tensors.
+    alpha, beta, mu, sigma : object
+        The parameters, inspected for tensors.
+
+    Returns
+    -------
+    module
+        The backend module to evaluate with.
+
+    Raises
+    ------
+    ValueError
+        If tensor parameters are given in a parametrization other than 0 --
+        the conversion between parametrizations runs in NumPy, so routing
+        tensors through it would cut the gradient without saying so -- or if
+        `x` is a pandas object and the backend is not NumPy, since its labels
+        could not be put back on a tensor.
+    """
+    module = backends.get(backend, x, alpha, beta, mu, sigma)
+    if module.name != 'numpy' and labels_of(x):
+        # A labelled result would have to be a Series or DataFrame, and that
+        # cannot carry a tensor's gradient; converting silently would drop
+        # the labels the caller passed in on purpose. Say so instead.
+        raise ValueError(
+            f'pandas input cannot be evaluated on the {module.name} backend: the '
+            f'labels cannot be put back on a tensor. Pass x.to_numpy() to get a '
+            f'tensor back, or use NumPy parameters to keep the labels.'
+        )
+    if module.name != 'numpy' and par != '0':
+        # Tensor-ness, not float-readability: a zero-dimensional tensor reads
+        # as a float perfectly well, and converting it is exactly the silent
+        # gradient cut this refuses to make.
+        tensors = [label for label, value in
+                   (('alpha', alpha), ('beta', beta), ('mu', mu), ('sigma', sigma))
+                   if backends._is_tensor(value)]
+        if tensors:
+            raise ValueError(
+                f'the {module.name} backend needs parametrization 0 for tensor '
+                f'parameters ({", ".join(tensors)} given in {par!r}). The '
+                f'conversion between parametrizations runs in NumPy, so it '
+                f'would cut the gradient without saying so. Convert first with '
+                f'StableParams.from_par, or work in parametrization 0.'
+            )
+    return module
+
+
+def _from_backend(value: Any) -> ScalarOrArray:
+    """Declare the type of a non-default backend's result.
+
+    Parameters
+    ----------
+    value : object
+        Whatever the backend returned -- a ``torch.Tensor`` for the torch
+        backend.
+
+    Returns
+    -------
+    float or ndarray
+        Declared, not checked. The same localised inaccuracy as
+        :func:`_labelled`, and for the same reason: torch is an optional extra
+        and must not become a type-checking dependency. Every call a type
+        checker will normally see uses the NumPy backend and really does return
+        float or ndarray.
+    """
+    return cast(ScalarOrArray, value)
+
+
 def _labelled(values: Any, labels: dict[str, Any]) -> ScalarOrArray:
     """Put pandas labels back on a result, and declare the type of the outcome.
 
@@ -400,6 +512,38 @@ def _labelled(values: Any, labels: dict[str, Any]) -> ScalarOrArray:
         happens with pandas input.
     """
     return cast(ScalarOrArray, relabel(values, labels))
+
+
+def _for_backend(
+    p: StableParams, alpha: Any, beta: Any, mu: Any, sigma: Any
+) -> tuple[Any, Any, Any, Any]:
+    """Pick what a non-NumPy backend evaluates with.
+
+    Parameters
+    ----------
+    p : StableParams
+        The validated parameters, in parametrization 0.
+    alpha, beta, mu, sigma : object
+        The parameters as the caller gave them.
+
+    Returns
+    -------
+    tuple
+        For each parameter: the caller's own object if it is a tensor, so its
+        gradient survives; otherwise the validated value in parametrization 0.
+
+    Notes
+    -----
+    :func:`_dispatch` has already refused tensors outside parametrization 0,
+    so a call made in another parametrization always reaches the backend
+    converted. It used to be handed the caller's values unchanged, which
+    evaluated a request in B as if it had been made in 0.
+    """
+    chosen = [
+        given if backends._is_tensor(given) else validated
+        for given, validated in ((alpha, p.alpha), (beta, p.beta), (mu, p.mu), (sigma, p.sigma))
+    ]
+    return chosen[0], chosen[1], chosen[2], chosen[3]
 
 
 def _validated(
@@ -432,6 +576,7 @@ def pdf(
     mu: float = 0.0,
     sigma: float = 1.0,
     par: Parametrization = '0',
+    backend: Optional[str] = None,
 ) -> ScalarOrArray:
     """Evaluate the probability density function.
 
@@ -450,6 +595,12 @@ def pdf(
         Scale, strictly positive.
     par : {'0', '1', 'M', 'A', 'B'}, default '0'
         Parametrization the four parameters are written in.
+    backend : {'numpy', 'torch'}, optional
+        Which array library evaluates this. The default picks torch when any
+        argument is a ``torch.Tensor``, and NumPy otherwise. Tensor parameters
+        carry gradients through the result. pandas input is NumPy-only: its
+        labels cannot be put back on a tensor, so it is refused rather than
+        silently unlabelled.
 
     Returns
     -------
@@ -472,7 +623,11 @@ def pdf(
     >>> np.round(pdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
     array([0.202038, 0.084539])
     """
-    p = _validated(alpha, beta, mu, sigma, par)
+    module = _dispatch(backend, par, x, alpha, beta, mu, sigma)
+    p = _validated(_plain(alpha), _plain(beta), _plain(mu), _plain(sigma), par)
+    if module.name != 'numpy':
+        return _from_backend(module.pdf(x, *_for_backend(p, alpha, beta, mu, sigma)))
+
     labels = labels_of(x)
     values = _levy(np.asarray(x, dtype='d') if labels else x,
                    p.alpha, p.beta, p.mu, p.sigma, cdf=False)
@@ -487,6 +642,7 @@ def cdf(
     mu: float = 0.0,
     sigma: float = 1.0,
     par: Parametrization = '0',
+    backend: Optional[str] = None,
 ) -> ScalarOrArray:
     """Evaluate the cumulative distribution function.
 
@@ -505,6 +661,12 @@ def cdf(
         Scale, strictly positive.
     par : {'0', '1', 'M', 'A', 'B'}, default '0'
         Parametrization the four parameters are written in.
+    backend : {'numpy', 'torch'}, optional
+        Which array library evaluates this. The default picks torch when any
+        argument is a ``torch.Tensor``, and NumPy otherwise. Tensor parameters
+        carry gradients through the result. pandas input is NumPy-only: its
+        labels cannot be put back on a tensor, so it is refused rather than
+        silently unlabelled.
 
     Returns
     -------
@@ -527,7 +689,11 @@ def cdf(
     >>> np.round(cdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
     array([0.756342, 0.89496 ])
     """
-    p = _validated(alpha, beta, mu, sigma, par)
+    module = _dispatch(backend, par, x, alpha, beta, mu, sigma)
+    p = _validated(_plain(alpha), _plain(beta), _plain(mu), _plain(sigma), par)
+    if module.name != 'numpy':
+        return _from_backend(module.cdf(x, *_for_backend(p, alpha, beta, mu, sigma)))
+
     labels = labels_of(x)
     values = _levy(np.asarray(x, dtype='d') if labels else x,
                    p.alpha, p.beta, p.mu, p.sigma, cdf=True)
@@ -542,6 +708,7 @@ def logpdf(
     mu: float = 0.0,
     sigma: float = 1.0,
     par: Parametrization = '0',
+    backend: Optional[str] = None,
 ) -> ScalarOrArray:
     """Evaluate the log of the probability density function.
 
@@ -560,6 +727,12 @@ def logpdf(
         Scale, strictly positive.
     par : {'0', '1', 'M', 'A', 'B'}, default '0'
         Parametrization the four parameters are written in.
+    backend : {'numpy', 'torch'}, optional
+        Which array library evaluates this. The default picks torch when any
+        argument is a ``torch.Tensor``, and NumPy otherwise. Tensor parameters
+        carry gradients through the result. pandas input is NumPy-only: its
+        labels cannot be put back on a tensor, so it is refused rather than
+        silently unlabelled.
 
     Returns
     -------
@@ -575,15 +748,22 @@ def logpdf(
     -----
     Note the sign. This returns the log density, following ``scipy.stats``;
     the 1.x function ``levy.neglog_levy`` returns its negative, and both remain
-    available. Densities are floored at 1e-100 before the logarithm, so the
-    result is bounded below by about -230 rather than being ``-inf``.
+    available. Densities are floored before the logarithm, so the result is
+    bounded below rather than being ``-inf``: at 1e-100 (about -230) on the
+    NumPy path and for float64 tensors, and at the dtype's smallest positive
+    normal for lower-precision tensors -- about 1.2e-38, or -87, in float32,
+    where 1e-100 is not representable.
 
     Examples
     --------
     >>> np.round(logpdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0), 6)
     array([-1.599299, -2.470541])
     """
-    p = _validated(alpha, beta, mu, sigma, par)
+    module = _dispatch(backend, par, x, alpha, beta, mu, sigma)
+    p = _validated(_plain(alpha), _plain(beta), _plain(mu), _plain(sigma), par)
+    if module.name != 'numpy':
+        return _from_backend(-module.neglog(x, *_for_backend(p, alpha, beta, mu, sigma)))
+
     labels = labels_of(x)
     values = np.log(np.maximum(1e-100, _levy(
         np.asarray(x, dtype='d') if labels else x,

--- a/src/levy/backends/__init__.py
+++ b/src/levy/backends/__init__.py
@@ -1,0 +1,186 @@
+#    Copyright (C) 2017 José M. Miotto
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""Which array library evaluates the distribution.
+
+NumPy is the default and always will be. The optional ``torch`` backend exists
+for one reason: it makes the log likelihood differentiable, so a stable
+distribution can sit inside a larger model and be fitted by gradient descent
+along with everything else. It also runs on a GPU, which matters only for very
+large samples.
+
+Selection, in order of precedence:
+
+1. an explicit ``backend='torch'`` argument;
+2. whatever :func:`set_backend` or :func:`using` last selected;
+3. automatic: if any argument is a ``torch.Tensor``, torch; otherwise NumPy.
+
+Rule 3 is what makes the common case work without ceremony -- hand the
+functions tensors and you get tensors back, with gradients attached. It costs
+nothing when torch is absent, because the check is a lookup in ``sys.modules``
+and not an import attempt.
+
+Examples
+--------
+>>> get().name
+'numpy'
+>>> with using('numpy'):
+...     get().name
+'numpy'
+"""
+
+from contextlib import contextmanager
+
+from levy._compat import loaded, require
+
+__all__ = ['get', 'set_backend', 'using']
+
+_BACKENDS = ('numpy', 'torch')
+
+#: What set_backend last selected, or None for automatic.
+_selected = None
+
+
+def _load(name):
+    """Import and return a backend module.
+
+    Parameters
+    ----------
+    name : {'numpy', 'torch'}
+        Which backend.
+
+    Returns
+    -------
+    module
+        The backend module, which exposes ``name``, ``pdf``, ``cdf`` and
+        ``neglog``.
+
+    Raises
+    ------
+    ValueError
+        If `name` is not a known backend.
+    ImportError
+        If the backend's library is not installed, naming the extra.
+    """
+    if name not in _BACKENDS:
+        raise ValueError(
+            f'unknown backend {name!r}; available: {", ".join(_BACKENDS)}')
+    if name == 'torch':
+        require('torch')
+        from levy.backends import _torch
+
+        return _torch
+    from levy.backends import _numpy
+
+    return _numpy
+
+
+def _is_tensor(value):
+    """Report whether `value` is a torch tensor, without importing torch.
+
+    Parameters
+    ----------
+    value : object
+        Anything.
+
+    Returns
+    -------
+    bool
+        True only if torch is already imported and `value` is one of its
+        tensors. If nobody has imported torch, nothing can be a tensor.
+    """
+    torch = loaded('torch')
+    return torch is not None and isinstance(value, torch.Tensor)
+
+
+def get(name=None, *values):
+    """Return the backend to use for a call.
+
+    Parameters
+    ----------
+    name : {'numpy', 'torch'}, optional
+        An explicit choice, which wins over everything else.
+    *values
+        The arguments of the call. If any is a ``torch.Tensor`` and no explicit
+        or global choice is in force, the torch backend is selected.
+
+    Returns
+    -------
+    module
+        The backend module.
+
+    Examples
+    --------
+    >>> get().name
+    'numpy'
+    >>> get('numpy').name
+    'numpy'
+    """
+    if name is not None:
+        return _load(name)
+    if _selected is not None:
+        return _load(_selected)
+    if any(_is_tensor(value) for value in values):
+        return _load('torch')
+    return _load('numpy')
+
+
+def set_backend(name):
+    """Select a backend for every subsequent call.
+
+    Parameters
+    ----------
+    name : {'numpy', 'torch'} or None
+        The backend, or None to go back to automatic selection.
+
+    Returns
+    -------
+    str or None
+        Whatever was selected before, so a caller can restore it.
+
+    Raises
+    ------
+    ValueError
+        If `name` is not a known backend.
+    ImportError
+        If the backend's library is not installed.
+    """
+    global _selected
+    previous = _selected
+    if name is not None:
+        _load(name)          # fail here, not at the first evaluation
+    _selected = name
+    return previous
+
+
+@contextmanager
+def using(name):
+    """Select a backend for the duration of a block.
+
+    Parameters
+    ----------
+    name : {'numpy', 'torch'} or None
+        The backend, or None for automatic selection.
+
+    Yields
+    ------
+    module
+        The backend in force inside the block.
+    """
+    previous = set_backend(name)
+    try:
+        yield _load(name) if name is not None else get()
+    finally:
+        set_backend(previous)

--- a/src/levy/backends/_numpy.py
+++ b/src/levy/backends/_numpy.py
@@ -1,0 +1,84 @@
+#    Copyright (C) 2017 José M. Miotto
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""The default backend: the package's own NumPy implementation.
+
+Deliberately nothing but a re-export. The numerical core is not reorganised to
+accommodate a second backend, so adding torch cannot have moved a NumPy number
+-- there is no shared code to have changed.
+"""
+
+import numpy as np
+
+from levy.distribution import levy as _levy
+
+__all__ = ['cdf', 'name', 'neglog', 'pdf']
+
+#: Identifies this backend in error messages and tests.
+name = 'numpy'
+
+
+def pdf(x, alpha, beta, mu=0.0, sigma=1.0):
+    """Evaluate the density.
+
+    Parameters
+    ----------
+    x : array_like
+        Points to evaluate at.
+    alpha, beta, mu, sigma : float
+        Parameters, in parametrization 0.
+
+    Returns
+    -------
+    float or ndarray
+        The density at `x`.
+    """
+    return _levy(x, alpha, beta, mu, sigma, cdf=False)
+
+
+def cdf(x, alpha, beta, mu=0.0, sigma=1.0):
+    """Evaluate the distribution function.
+
+    Parameters
+    ----------
+    x : array_like
+        Points to evaluate at.
+    alpha, beta, mu, sigma : float
+        Parameters, in parametrization 0.
+
+    Returns
+    -------
+    float or ndarray
+        The distribution function at `x`.
+    """
+    return _levy(x, alpha, beta, mu, sigma, cdf=True)
+
+
+def neglog(x, alpha, beta, mu=0.0, sigma=1.0):
+    """Evaluate the negative log density.
+
+    Parameters
+    ----------
+    x : array_like
+        Points to evaluate at.
+    alpha, beta, mu, sigma : float
+        Parameters, in parametrization 0.
+
+    Returns
+    -------
+    float or ndarray
+        ``-log(pdf(x))``, floored so the logarithm stays finite.
+    """
+    return -np.log(np.maximum(1e-100, _levy(x, alpha, beta, mu, sigma, cdf=False)))

--- a/src/levy/backends/_torch.py
+++ b/src/levy/backends/_torch.py
@@ -1,0 +1,359 @@
+#    Copyright (C) 2017 José M. Miotto
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""The torch backend: the same interpolation, written to be differentiable.
+
+This is a reimplementation, not a wrapper. The NumPy code mutates arrays under
+boolean masks, which autograd cannot follow; the same arithmetic is expressed
+here with ``torch.where``, ``torch.stack`` and out-of-place indexing so that a
+gradient reaches every one of ``alpha``, ``beta``, ``mu`` and ``sigma``.
+
+What that buys is a stable distribution you can put inside a larger torch model
+and fit by gradient descent along with the rest of it, instead of only through
+this package's own L-BFGS-B.
+
+Notes
+-----
+Two things are deliberately not differentiable, and both are choices rather
+than values:
+
+* the grid cell used to look up the tail crossover limits, which is an integer
+  index derived from ``alpha`` and ``beta``;
+* the mask separating the interpolated region from the power-law tail, which
+  follows from those limits.
+
+A gradient with respect to ``alpha`` therefore ignores the fact that moving
+``alpha`` far enough would move the crossover. Over any distance a gradient step
+cares about, that term is zero anyway -- the crossover is piecewise constant in
+``alpha`` -- so the gradient is right almost everywhere and wrong only exactly
+at a cell boundary, where a step function has no derivative to begin with.
+
+The lookup tables are stored as ``float32``. They are converted to whatever
+dtype the caller's tensors use and cached per (table, dtype, device), so a
+``float64`` computation carries ``float64`` weights over a ``float32`` grid --
+exactly what the NumPy path does.
+"""
+
+import math
+
+import numpy as np
+
+from levy.constants import _lower, _upper
+from levy.distribution import _check_alpha_beta, _grid_index
+from levy.tables import _read_from_cache
+
+__all__ = ['approximate', 'cdf', 'interpolate', 'name', 'neglog', 'pdf']
+
+#: Identifies this backend in error messages and tests.
+name = 'torch'
+
+_table_cache = {}
+
+
+def _torch():
+    """Return the torch module.
+
+    Returns
+    -------
+    module
+        ``torch``. Imported here rather than at module scope so that merely
+        importing :mod:`levy.backends` costs nothing.
+    """
+    import torch
+
+    return torch
+
+
+def _table(key, like):
+    """Return a lookup table as a tensor matching `like`.
+
+    Parameters
+    ----------
+    key : {'pdf', 'cdf', 'lower_limit', 'upper_limit'}
+        Which table.
+    like : Tensor
+        Tensor whose dtype and device the result should match.
+
+    Returns
+    -------
+    Tensor
+        The table. Cached, and shared between calls, so treat it as read-only.
+    """
+    torch = _torch()
+    dtype = like.dtype if like.dtype.is_floating_point else torch.get_default_dtype()
+    signature = (key, dtype, str(like.device))
+    cached = _table_cache.get(signature)
+    if cached is None:
+        cached = torch.as_tensor(
+            np.asarray(_read_from_cache(key)), dtype=dtype, device=like.device)
+        _table_cache[signature] = cached
+    return cached
+
+
+def _as_tensor(value, like):
+    """Bring a parameter into the tensor world without breaking its gradient.
+
+    Parameters
+    ----------
+    value : Tensor or float
+        A parameter.
+    like : Tensor
+        Tensor whose dtype and device to match.
+
+    Returns
+    -------
+    Tensor
+        `value` itself when it is already a tensor -- untouched, so that any
+        ``requires_grad`` on it survives -- otherwise a scalar tensor.
+    """
+    torch = _torch()
+    if isinstance(value, torch.Tensor):
+        return value.to(dtype=like.dtype, device=like.device) \
+            if (value.dtype != like.dtype or value.device != like.device) else value
+    return torch.as_tensor(value, dtype=like.dtype, device=like.device)
+
+
+def interpolate(points, grid, lower, upper):
+    """Multi-dimensional Catmull-Rom interpolation, differentiably.
+
+    Parameters
+    ----------
+    points : Tensor
+        Coordinates to evaluate at, shaped ``(..., ndim)``.
+    grid : Tensor
+        Samples of the function on a regular lattice.
+    lower : array_like
+        Coordinate of the first grid node along each dimension.
+    upper : array_like
+        Coordinate of the last grid node along each dimension.
+
+    Returns
+    -------
+    Tensor
+        Interpolated values, shaped like `points` without its last axis.
+
+    Notes
+    -----
+    The same 4**ndim weighted gather as :func:`levy.interpolation._interpolate`,
+    with indices clamped at the edges. Everything that carries a gradient --
+    the offsets, the cubic weights -- is out of place; only the integer indices
+    are not, and integers have no gradient to lose.
+    """
+    torch = _torch()
+
+    point_shape = points.shape[:-1]
+    flat = points.reshape(-1, points.shape[-1])
+
+    dims = grid.dim()
+    sizes = list(grid.shape)
+    scale = torch.as_tensor(
+        [(sizes[j] - 1) / (upper[j] - lower[j]) for j in range(dims)],
+        dtype=flat.dtype, device=flat.device)
+    origin = torch.as_tensor(
+        [float(lower[j]) for j in range(dims)], dtype=flat.dtype, device=flat.device)
+
+    scaled = (flat - origin) * scale
+    floors = torch.floor(scaled).detach().to(torch.long)
+
+    offsets = scaled - floors.to(flat.dtype)
+    offsets2 = offsets * offsets
+    offsets3 = offsets2 * offsets
+    weighters = [
+        -0.5 * offsets3 + offsets2 - 0.5 * offsets,
+        1.5 * offsets3 - 2.5 * offsets2 + 1.0,
+        -1.5 * offsets3 + 2.0 * offsets2 + 0.5 * offsets,
+        0.5 * offsets3 - 0.5 * offsets2,
+    ]
+
+    ravel_grid = grid.reshape(-1)
+    result = torch.zeros(flat.shape[:-1], dtype=flat.dtype, device=flat.device)
+
+    for i in range(1 << (dims * 2)):
+        weights = torch.ones(flat.shape[:-1], dtype=flat.dtype, device=flat.device)
+        ravel_offset = torch.zeros(
+            flat.shape[:-1], dtype=torch.long, device=flat.device)
+        for j in range(dims):
+            n = (i >> (j * 2)) % 4
+            index = torch.clamp(floors[:, j] + (n - 1), 0, sizes[j] - 1)
+            ravel_offset = ravel_offset * sizes[j] + index
+            weights = weights * weighters[n][:, j]
+        result = result + weights * ravel_grid[ravel_offset]
+
+    return result.reshape(point_shape)
+
+
+def approximate(x, alpha, beta, cdf=False):
+    """Evaluate the power-law tail approximation, differentiably.
+
+    Parameters
+    ----------
+    x : Tensor
+        Standardised values outside the crossover limits.
+    alpha : Tensor
+        Index of stability.
+    beta : Tensor
+        Skewness.
+    cdf : bool, default False
+        Return the distribution function instead of the density.
+
+    Returns
+    -------
+    Tensor
+        The asymptotic pdf or cdf at `x`.
+
+    Notes
+    -----
+    ``scipy.special.gamma(alpha)`` becomes ``exp(lgamma(alpha))``, which is
+    differentiable in ``alpha`` and, for the range this package covers, equal to
+    it to within rounding. The in-place masked writes of the NumPy version
+    become :func:`torch.where`, which is what autograd can follow.
+    """
+    torch = _torch()
+
+    positive = x > 0
+    magnitude = (torch.sin(math.pi * alpha / 2.0) * torch.exp(torch.lgamma(alpha))
+                 / math.pi * torch.abs(x) ** (-alpha - 1.0))
+    values = torch.where(positive, magnitude * (1.0 + beta), magnitude * (1.0 - beta))
+    if cdf:
+        return torch.where(positive, 1.0 - values * x, values * (-x))
+    return values * alpha
+
+
+def _evaluate(x, alpha, beta, mu, sigma, cdf):
+    """Evaluate the density or distribution function on tensors.
+
+    Parameters
+    ----------
+    x : Tensor
+        Points to evaluate at.
+    alpha, beta, mu, sigma : Tensor or float
+        Parameters, in parametrization 0.
+    cdf : bool
+        Return the distribution function instead of the density.
+
+    Returns
+    -------
+    Tensor
+        The result, shaped like `x`.
+    """
+    torch = _torch()
+
+    x = torch.as_tensor(x)
+    if not x.dtype.is_floating_point:
+        x = x.to(torch.get_default_dtype())
+
+    alpha_t = _as_tensor(alpha, x)
+    beta_t = _as_tensor(beta, x)
+    mu_t = _as_tensor(mu, x)
+    sigma_t = _as_tensor(sigma, x)
+
+    alpha_value = float(alpha_t.detach().reshape(-1)[0]) if alpha_t.dim() \
+        else float(alpha_t.detach())
+    beta_value = float(beta_t.detach().reshape(-1)[0]) if beta_t.dim() \
+        else float(beta_t.detach())
+    _check_alpha_beta(alpha_value, beta_value)
+
+    table = _table('cdf' if cdf else 'pdf', x)
+    lower_limit = _table('lower_limit', x)
+    upper_limit = _table('upper_limit', x)
+
+    xr = (x - mu_t) / sigma_t
+
+    # An integer cell, chosen from detached values: see the module docstring on
+    # why this is a choice rather than a quantity, and has no gradient.
+    alpha_index = _grid_index(alpha_value, 1, lower_limit.shape[0])
+    beta_index = _grid_index(beta_value, 2, lower_limit.shape[1])
+    low = lower_limit[alpha_index, beta_index]
+    up = upper_limit[alpha_index, beta_index]
+
+    inside = (low <= xr) & (xr <= up)
+    z = xr[inside]
+
+    points = torch.stack(
+        [torch.atan(z), alpha_t.expand_as(z), beta_t.expand_as(z)], dim=-1)
+    interpolated = interpolate(points, table, _lower, _upper)
+    approximated = approximate(xr[~inside], alpha_t, beta_t, cdf)
+
+    result = torch.zeros_like(xr)
+    result = result.masked_scatter(inside, interpolated)
+    result = result.masked_scatter(~inside, approximated)
+    if not cdf:
+        result = result / sigma_t
+    return result
+
+
+def pdf(x, alpha, beta, mu=0.0, sigma=1.0):
+    """Evaluate the density on tensors.
+
+    Parameters
+    ----------
+    x : Tensor or array_like
+        Points to evaluate at.
+    alpha, beta, mu, sigma : Tensor or float
+        Parameters, in parametrization 0.
+
+    Returns
+    -------
+    Tensor
+        The density at `x`, carrying gradients from any parameter that has them.
+    """
+    return _evaluate(x, alpha, beta, mu, sigma, cdf=False)
+
+
+def cdf(x, alpha, beta, mu=0.0, sigma=1.0):
+    """Evaluate the distribution function on tensors.
+
+    Parameters
+    ----------
+    x : Tensor or array_like
+        Points to evaluate at.
+    alpha, beta, mu, sigma : Tensor or float
+        Parameters, in parametrization 0.
+
+    Returns
+    -------
+    Tensor
+        The distribution function at `x`.
+    """
+    return _evaluate(x, alpha, beta, mu, sigma, cdf=True)
+
+
+def neglog(x, alpha, beta, mu=0.0, sigma=1.0):
+    """Evaluate the negative log density on tensors.
+
+    Parameters
+    ----------
+    x : Tensor or array_like
+        Points to evaluate at.
+    alpha, beta, mu, sigma : Tensor or float
+        Parameters, in parametrization 0.
+
+    Returns
+    -------
+    Tensor
+        ``-log(pdf(x))``. Summing this over a sample gives an objective that
+        ``loss.backward()`` can differentiate.
+
+    Notes
+    -----
+    The floor at 1e-100 matches the NumPy path. It is applied with
+    :func:`torch.clamp`, whose gradient is zero for clamped entries -- the right
+    answer, since a density the table reports as non-positive carries no
+    information about which way to move.
+    """
+    torch = _torch()
+
+    return -torch.log(torch.clamp(
+        _evaluate(x, alpha, beta, mu, sigma, cdf=False), min=1e-100))

--- a/src/levy/backends/_torch.py
+++ b/src/levy/backends/_torch.py
@@ -1,0 +1,377 @@
+#    Copyright (C) 2017 José M. Miotto
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""The torch backend: the same interpolation, written to be differentiable.
+
+This is a reimplementation, not a wrapper. The NumPy code mutates arrays under
+boolean masks, which autograd cannot follow; the same arithmetic is expressed
+here with ``torch.where``, ``torch.stack`` and out-of-place indexing so that a
+gradient reaches every one of ``alpha``, ``beta``, ``mu`` and ``sigma``.
+
+What that buys is a stable distribution you can put inside a larger torch model
+and fit by gradient descent along with the rest of it, instead of only through
+this package's own L-BFGS-B.
+
+Notes
+-----
+Two things are deliberately not differentiable, and both are choices rather
+than values:
+
+* the grid cell used to look up the tail crossover limits, which is an integer
+  index derived from ``alpha`` and ``beta``;
+* the mask separating the interpolated region from the power-law tail. It
+  compares ``(x - mu) / sigma`` against those limits, so it is a step function
+  in ``x``, ``mu`` and ``sigma`` as well as in ``alpha`` and ``beta``.
+
+A gradient therefore ignores the fact that moving a parameter far enough would
+carry a point across the crossover. Over any distance a gradient step cares
+about, that term is zero anyway -- the mask is piecewise constant in every
+argument -- so the gradient is right almost everywhere and wrong only exactly
+at a boundary, where a step function has no derivative to begin with.
+
+The lookup tables are stored as ``float32``. They are converted to whatever
+dtype the caller's tensors use and cached per (table, dtype, device), so a
+``float64`` computation carries ``float64`` weights over a ``float32`` grid --
+exactly what the NumPy path does.
+"""
+
+import math
+
+import numpy as np
+
+from levy.constants import _lower, _upper
+from levy.distribution import _check_alpha_beta, _grid_index
+from levy.tables import _read_from_cache
+
+__all__ = ['approximate', 'cdf', 'interpolate', 'name', 'neglog', 'pdf']
+
+#: Identifies this backend in error messages and tests.
+name = 'torch'
+
+_table_cache = {}
+
+
+def _torch():
+    """Return the torch module.
+
+    Returns
+    -------
+    module
+        ``torch``. Imported here rather than at module scope so that merely
+        importing :mod:`levy.backends` costs nothing.
+    """
+    import torch
+
+    return torch
+
+
+def _table(key, like):
+    """Return a lookup table as a tensor matching `like`.
+
+    Parameters
+    ----------
+    key : {'pdf', 'cdf', 'lower_limit', 'upper_limit'}
+        Which table.
+    like : Tensor
+        Tensor whose dtype and device the result should match.
+
+    Returns
+    -------
+    Tensor
+        The table. Cached, and shared between calls, so treat it as read-only.
+    """
+    torch = _torch()
+    dtype = like.dtype if like.dtype.is_floating_point else torch.get_default_dtype()
+    signature = (key, dtype, str(like.device))
+    cached = _table_cache.get(signature)
+    if cached is None:
+        cached = torch.as_tensor(
+            np.asarray(_read_from_cache(key)), dtype=dtype, device=like.device)
+        _table_cache[signature] = cached
+    return cached
+
+
+def _as_tensor(value, like):
+    """Bring a parameter into the tensor world without breaking its gradient.
+
+    Parameters
+    ----------
+    value : Tensor or float
+        A parameter.
+    like : Tensor
+        Tensor whose dtype and device to match.
+
+    Returns
+    -------
+    Tensor
+        `value` itself when it is already a tensor -- untouched, so that any
+        ``requires_grad`` on it survives -- otherwise a scalar tensor.
+    """
+    torch = _torch()
+    if isinstance(value, torch.Tensor):
+        return value.to(dtype=like.dtype, device=like.device) \
+            if (value.dtype != like.dtype or value.device != like.device) else value
+    return torch.as_tensor(value, dtype=like.dtype, device=like.device)
+
+
+def interpolate(points, grid, lower, upper):
+    """Multi-dimensional Catmull-Rom interpolation, differentiably.
+
+    Parameters
+    ----------
+    points : Tensor
+        Coordinates to evaluate at, shaped ``(..., ndim)``.
+    grid : Tensor
+        Samples of the function on a regular lattice.
+    lower : array_like
+        Coordinate of the first grid node along each dimension.
+    upper : array_like
+        Coordinate of the last grid node along each dimension.
+
+    Returns
+    -------
+    Tensor
+        Interpolated values, shaped like `points` without its last axis.
+
+    Notes
+    -----
+    The same 4**ndim weighted gather as :func:`levy.interpolation._interpolate`,
+    with indices clamped at the edges. Everything that carries a gradient --
+    the offsets, the cubic weights -- is out of place; only the integer indices
+    are not, and integers have no gradient to lose.
+    """
+    torch = _torch()
+
+    point_shape = points.shape[:-1]
+    flat = points.reshape(-1, points.shape[-1])
+
+    dims = grid.dim()
+    sizes = list(grid.shape)
+    scale = torch.as_tensor(
+        [(sizes[j] - 1) / (upper[j] - lower[j]) for j in range(dims)],
+        dtype=flat.dtype, device=flat.device)
+    origin = torch.as_tensor(
+        [float(lower[j]) for j in range(dims)], dtype=flat.dtype, device=flat.device)
+
+    scaled = (flat - origin) * scale
+    floors = torch.floor(scaled).detach().to(torch.long)
+
+    offsets = scaled - floors.to(flat.dtype)
+    offsets2 = offsets * offsets
+    offsets3 = offsets2 * offsets
+    weighters = [
+        -0.5 * offsets3 + offsets2 - 0.5 * offsets,
+        1.5 * offsets3 - 2.5 * offsets2 + 1.0,
+        -1.5 * offsets3 + 2.0 * offsets2 + 0.5 * offsets,
+        0.5 * offsets3 - 0.5 * offsets2,
+    ]
+
+    ravel_grid = grid.reshape(-1)
+    result = torch.zeros(flat.shape[:-1], dtype=flat.dtype, device=flat.device)
+
+    for i in range(1 << (dims * 2)):
+        weights = torch.ones(flat.shape[:-1], dtype=flat.dtype, device=flat.device)
+        ravel_offset = torch.zeros(
+            flat.shape[:-1], dtype=torch.long, device=flat.device)
+        for j in range(dims):
+            n = (i >> (j * 2)) % 4
+            index = torch.clamp(floors[:, j] + (n - 1), 0, sizes[j] - 1)
+            ravel_offset = ravel_offset * sizes[j] + index
+            weights = weights * weighters[n][:, j]
+        result = result + weights * ravel_grid[ravel_offset]
+
+    return result.reshape(point_shape)
+
+
+def approximate(x, alpha, beta, cdf=False):
+    """Evaluate the power-law tail approximation, differentiably.
+
+    Parameters
+    ----------
+    x : Tensor
+        Standardised values outside the crossover limits.
+    alpha : Tensor
+        Index of stability.
+    beta : Tensor
+        Skewness.
+    cdf : bool, default False
+        Return the distribution function instead of the density.
+
+    Returns
+    -------
+    Tensor
+        The asymptotic pdf or cdf at `x`.
+
+    Notes
+    -----
+    ``scipy.special.gamma(alpha)`` becomes ``exp(lgamma(alpha))``, which is
+    differentiable in ``alpha`` and, for the range this package covers, equal to
+    it to within rounding. The in-place masked writes of the NumPy version
+    become :func:`torch.where`, which is what autograd can follow.
+    """
+    torch = _torch()
+
+    positive = x > 0
+    # sin(pi*alpha/2) in float64 whatever the tensor dtype: at alpha = 2 the
+    # argument rounds to float32 pi, whose sine is -8.7e-8, and the whole
+    # tail went negative -- a pdf below zero and a cdf above one. In float64
+    # the same rounding gives +1.2e-16, which is what the NumPy path gets.
+    # The cast back keeps the result in the caller's dtype, and autograd
+    # follows both casts.
+    sine = torch.sin(alpha.to(torch.float64) * (math.pi / 2.0)).to(alpha.dtype)
+    magnitude = (sine * torch.exp(torch.lgamma(alpha))
+                 / math.pi * torch.abs(x) ** (-alpha - 1.0))
+    values = torch.where(positive, magnitude * (1.0 + beta), magnitude * (1.0 - beta))
+    if cdf:
+        return torch.where(positive, 1.0 - values * x, values * (-x))
+    return values * alpha
+
+
+def _evaluate(x, alpha, beta, mu, sigma, cdf):
+    """Evaluate the density or distribution function on tensors.
+
+    Parameters
+    ----------
+    x : Tensor
+        Points to evaluate at.
+    alpha, beta, mu, sigma : Tensor or float
+        Parameters, in parametrization 0.
+    cdf : bool
+        Return the distribution function instead of the density.
+
+    Returns
+    -------
+    Tensor
+        The result, shaped like `x`.
+    """
+    torch = _torch()
+
+    # A NumPy view with a negative stride -- x[::-1], say -- is refused by
+    # torch.as_tensor outright. Copy such an array to a contiguous one first;
+    # anything already a tensor, or an ordinary array, passes through as is.
+    if isinstance(x, np.ndarray) and any(stride < 0 for stride in x.strides):
+        x = np.ascontiguousarray(x)
+    x = torch.as_tensor(x)
+    if not x.dtype.is_floating_point:
+        x = x.to(torch.get_default_dtype())
+
+    alpha_t = _as_tensor(alpha, x)
+    beta_t = _as_tensor(beta, x)
+    mu_t = _as_tensor(mu, x)
+    sigma_t = _as_tensor(sigma, x)
+
+    alpha_value = float(alpha_t.detach().reshape(-1)[0]) if alpha_t.dim() \
+        else float(alpha_t.detach())
+    beta_value = float(beta_t.detach().reshape(-1)[0]) if beta_t.dim() \
+        else float(beta_t.detach())
+    _check_alpha_beta(alpha_value, beta_value)
+
+    table = _table('cdf' if cdf else 'pdf', x)
+    lower_limit = _table('lower_limit', x)
+    upper_limit = _table('upper_limit', x)
+
+    xr = (x - mu_t) / sigma_t
+
+    # An integer cell, chosen from detached values: see the module docstring on
+    # why this is a choice rather than a quantity, and has no gradient.
+    alpha_index = _grid_index(alpha_value, 1, lower_limit.shape[0])
+    beta_index = _grid_index(beta_value, 2, lower_limit.shape[1])
+    low = lower_limit[alpha_index, beta_index]
+    up = upper_limit[alpha_index, beta_index]
+
+    inside = (low <= xr) & (xr <= up)
+    z = xr[inside]
+
+    points = torch.stack(
+        [torch.atan(z), alpha_t.expand_as(z), beta_t.expand_as(z)], dim=-1)
+    interpolated = interpolate(points, table, _lower, _upper)
+    approximated = approximate(xr[~inside], alpha_t, beta_t, cdf)
+
+    result = torch.zeros_like(xr)
+    result = result.masked_scatter(inside, interpolated)
+    result = result.masked_scatter(~inside, approximated)
+    if not cdf:
+        result = result / sigma_t
+    return result
+
+
+def pdf(x, alpha, beta, mu=0.0, sigma=1.0):
+    """Evaluate the density on tensors.
+
+    Parameters
+    ----------
+    x : Tensor or array_like
+        Points to evaluate at.
+    alpha, beta, mu, sigma : Tensor or float
+        Parameters, in parametrization 0.
+
+    Returns
+    -------
+    Tensor
+        The density at `x`, carrying gradients from any parameter that has them.
+    """
+    return _evaluate(x, alpha, beta, mu, sigma, cdf=False)
+
+
+def cdf(x, alpha, beta, mu=0.0, sigma=1.0):
+    """Evaluate the distribution function on tensors.
+
+    Parameters
+    ----------
+    x : Tensor or array_like
+        Points to evaluate at.
+    alpha, beta, mu, sigma : Tensor or float
+        Parameters, in parametrization 0.
+
+    Returns
+    -------
+    Tensor
+        The distribution function at `x`.
+    """
+    return _evaluate(x, alpha, beta, mu, sigma, cdf=True)
+
+
+def neglog(x, alpha, beta, mu=0.0, sigma=1.0):
+    """Evaluate the negative log density on tensors.
+
+    Parameters
+    ----------
+    x : Tensor or array_like
+        Points to evaluate at.
+    alpha, beta, mu, sigma : Tensor or float
+        Parameters, in parametrization 0.
+
+    Returns
+    -------
+    Tensor
+        ``-log(pdf(x))``. Summing this over a sample gives an objective that
+        ``loss.backward()`` can differentiate.
+
+    Notes
+    -----
+    The floor is 1e-100, matching the NumPy path, or the smallest positive
+    normal of the tensor's dtype if that is larger: 1e-100 is below what
+    float32 can represent, so clamping there clamps at zero and a far-tail
+    density that underflows would come back as ``inf`` where NumPy returns a
+    finite number. The floor is applied with :func:`torch.clamp`, whose
+    gradient is zero for clamped entries -- the right answer, since a density
+    the table reports as non-positive carries no information about which way
+    to move.
+    """
+    torch = _torch()
+
+    density = _evaluate(x, alpha, beta, mu, sigma, cdf=False)
+    floor = max(1e-100, torch.finfo(density.dtype).tiny)
+    return -torch.log(torch.clamp(density, min=floor))

--- a/tests/test_no_torch.py
+++ b/tests/test_no_torch.py
@@ -1,0 +1,156 @@
+"""An install without torch never imports it, and never pays for it.
+
+`torch` is a ~200 MB optional extra. The claim that it costs nothing when
+absent is worth checking rather than asserting, and checking it needs a
+subprocess with torch blocked at the import system -- otherwise the test would
+pass for the wrong reason on any machine that happens not to have torch.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import levy
+
+BLOCK_TORCH = """
+import sys
+
+class _Blocked:
+    def find_module(self, name, path=None):
+        if name == 'torch' or name.startswith('torch.'):
+            return self
+    def load_module(self, name):
+        raise ImportError('torch is blocked for this test')
+    def find_spec(self, name, path=None, target=None):
+        if name == 'torch' or name.startswith('torch.'):
+            raise ImportError('torch is blocked for this test')
+        return None
+
+sys.meta_path.insert(0, _Blocked())
+"""
+
+
+def _run(body):
+    """Run `body` in a fresh interpreter with torch blocked."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(pathlib.Path(levy.__file__).parents[1]), env.get("PYTHONPATH", "")]
+    )
+    return subprocess.run(
+        [sys.executable, "-c", BLOCK_TORCH + textwrap.dedent(body)],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def test_the_whole_api_works_without_torch():
+    result = _run("""
+        import numpy as np
+        from levy import api
+
+        x = np.linspace(-5.0, 5.0, 101)
+        api.pdf(x, alpha=1.5, beta=0.0)
+        api.cdf(x, alpha=1.5, beta=0.0)
+        api.logpdf(x, alpha=1.5, beta=0.0)
+        api.fit(api.rvs(alpha=1.5, beta=0.0, size=200, random_state=0))
+        print('ok')
+    """)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_torch_is_never_imported():
+    result = _run("""
+        import sys
+        import numpy as np
+        import levy
+        from levy import api, backends
+
+        api.pdf(np.array([1.0]), alpha=1.5, beta=0.0)
+        backends.get(None, np.array([1.0]))
+        print('torch' in sys.modules)
+    """)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "False"
+
+
+def test_importing_the_backend_package_does_not_import_torch():
+    # levy.backends is imported by levy.api on every call. If merely importing
+    # it pulled torch in, the extra would not be optional in any useful sense.
+    result = _run("""
+        import sys
+        import levy.backends
+        print('torch' in sys.modules)
+    """)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "False"
+
+
+def test_selecting_torch_fails_with_an_instruction_not_a_traceback():
+    result = _run("""
+        import levy
+
+        try:
+            levy.set_backend('torch')
+        except ImportError as error:
+            print(error)
+        else:
+            print('NO ERROR')
+    """)
+    assert result.returncode == 0, result.stderr
+    message = result.stdout.strip()
+    assert "torch" in message
+    assert 'pip install "pylevy[torch]"' in message, message
+
+
+def test_the_failure_comes_at_selection_not_at_the_first_evaluation():
+    # set_backend loads the backend eagerly so the error arrives where the
+    # mistake was made, rather than several calls later.
+    result = _run("""
+        import numpy as np
+        import levy
+        from levy import api
+
+        try:
+            levy.set_backend('torch')
+            print('SELECTED')
+        except ImportError:
+            print('failed at selection')
+        api.pdf(np.array([1.0]), alpha=1.5, beta=0.0)
+        print('numpy still works')
+    """)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split("\n")[0] == "failed at selection"
+    assert "numpy still works" in result.stdout
+
+
+def test_an_explicit_backend_argument_also_explains_itself():
+    result = _run("""
+        import numpy as np
+        from levy import api
+
+        try:
+            api.pdf(np.array([1.0]), alpha=1.5, beta=0.0, backend='torch')
+        except ImportError as error:
+            print('pylevy[torch]' in str(error))
+    """)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "True"
+
+
+def test_the_1x_surface_works_without_torch():
+    result = _run("""
+        import warnings
+        import numpy as np
+        import levy
+
+        warnings.simplefilter('ignore', DeprecationWarning)
+        levy.levy(np.array([1.0]), 1.5, 0.0)
+        levy.fit_levy(levy.random(1.5, 0.0, shape=(100,)))
+        print('ok')
+    """)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -1,0 +1,261 @@
+"""The torch backend: same numbers, plus gradients.
+
+Two claims, and the second is the reason the backend exists at all.
+
+Parity: the torch implementation is a rewrite, not a wrapper, so it has to be
+shown to agree with NumPy rather than assumed to. It is checked here at
+``rtol=1e-6`` over a grid spanning both the interpolated region and both tails.
+
+Gradients: ``torch.autograd.gradcheck`` compares the analytic gradient against
+finite differences in float64, for all four parameters, for pdf, cdf and the
+negative log density. Passing that is what makes "differentiable" a fact rather
+than a claim -- and the optimisation test below shows it is *useful*: gradient
+descent lands on the same optimum this package's own L-BFGS-B finds.
+
+`tests/test_no_torch.py` covers the other half: an install without torch never
+imports it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import levy  # noqa: E402
+from levy import api, backends  # noqa: E402
+from levy.backends import _numpy as numpy_backend  # noqa: E402
+from levy.backends import _torch as torch_backend  # noqa: E402
+
+DOUBLE = torch.float64
+
+# Spans the interpolated region and both power-law tails.
+XS = np.concatenate([
+    np.linspace(-2000.0, 2000.0, 401),
+    np.linspace(-25.0, 25.0, 401),
+    np.linspace(-1.0, 1.0, 51),
+])
+
+CASES = [
+    (1.5, 0.0, 0.0, 1.0),
+    (0.7, -0.5, 1.0, 2.0),
+    (1.0, 0.4, -1.0, 0.5),
+    (1.9, 1.0, -2.0, 0.5),
+    (1.3, -1.0, 0.0, 3.0),
+    (2.0, 0.0, 0.5, 1.5),
+]
+
+
+@pytest.fixture(autouse=True)
+def automatic_backend():
+    """Leave the global selection as it was, whatever a test does to it."""
+    previous = backends.set_backend(None)
+    yield
+    backends.set_backend(previous)
+
+
+# --------------------------------------------------------------------------
+# parity
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), CASES)
+@pytest.mark.parametrize("function", ["pdf", "cdf", "neglog"])
+def test_matches_the_numpy_backend(function, alpha, beta, mu, sigma):
+    expected = getattr(numpy_backend, function)(XS, alpha, beta, mu, sigma)
+    got = getattr(torch_backend, function)(
+        torch.tensor(XS, dtype=DOUBLE), alpha, beta, mu, sigma).numpy()
+    np.testing.assert_allclose(got, expected, rtol=1e-6, atol=1e-12)
+
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), CASES)
+def test_agreement_is_far_tighter_than_the_contract(alpha, beta, mu, sigma):
+    # The stated contract is 1e-6. What is actually observed is accumulated
+    # float64 rounding, because both paths do the same arithmetic in the same
+    # order over the same float32 grid -- nothing systematic. This second,
+    # tighter assertion exists so that if the two ever genuinely diverge, the
+    # loose 1e-6 above does not hide it.
+    #
+    # The bound is 1e-10 rather than the ~1e-16 a single operation would give:
+    # the interpolation is a 64-term weighted sum, and torch and NumPy do not
+    # order or vectorise it identically. Measured worst case is 2.6e-16 on
+    # macOS/x86 and 1.4e-12 on the Linux CI runner -- a libm difference, not a
+    # divergence. 1e-10 keeps two orders of magnitude of headroom over the
+    # worse of those while staying four below the contract.
+    expected = numpy_backend.pdf(XS, alpha, beta, mu, sigma)
+    got = torch_backend.pdf(torch.tensor(XS, dtype=DOUBLE),
+                            alpha, beta, mu, sigma).numpy()
+    finite = np.abs(expected) > 1e-300
+    relative = np.abs(got[finite] - expected[finite]) / np.abs(expected[finite])
+    assert relative.max() < 1e-10, f"max relative deviation {relative.max():.3e}"
+
+
+def test_float32_tensors_are_accepted_and_stay_float32():
+    result = torch_backend.pdf(torch.tensor(XS, dtype=torch.float32), 1.5, 0.0)
+    assert result.dtype == torch.float32
+    expected = numpy_backend.pdf(XS, 1.5, 0.0)
+    np.testing.assert_allclose(result.numpy(), expected, rtol=1e-5, atol=1e-7)
+
+
+# --------------------------------------------------------------------------
+# gradients
+# --------------------------------------------------------------------------
+
+GRADCHECK_CASES = [
+    (1.53, 0.17, 0.21, 1.07),
+    (0.83, -0.41, -0.50, 2.10),
+    (1.87, 0.63, 1.30, 0.40),
+]
+
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), GRADCHECK_CASES)
+@pytest.mark.parametrize("function", ["pdf", "cdf", "neglog"])
+def test_gradcheck(function, alpha, beta, mu, sigma):
+    x = torch.tensor([-4.3, -1.1, 0.3, 1.9, 6.7], dtype=DOUBLE)
+    evaluate = getattr(torch_backend, function)
+
+    args = tuple(torch.tensor(v, dtype=DOUBLE, requires_grad=True)
+                 for v in (alpha, beta, mu, sigma))
+    assert torch.autograd.gradcheck(
+        lambda a, b, m, s: evaluate(x, a, b, m, s), args,
+        eps=1e-6, atol=1e-5, rtol=1e-3)
+
+
+def test_a_gradient_reaches_every_parameter():
+    x = torch.tensor([-2.0, 0.5, 3.0], dtype=DOUBLE)
+    params = {name: torch.tensor(value, dtype=DOUBLE, requires_grad=True)
+              for name, value in
+              (("alpha", 1.5), ("beta", 0.2), ("mu", 0.1), ("sigma", 1.1))}
+
+    torch_backend.neglog(x, **params).sum().backward()
+
+    for name, tensor in params.items():
+        assert tensor.grad is not None, f"no gradient for {name}"
+        assert torch.isfinite(tensor.grad), f"non-finite gradient for {name}"
+        assert tensor.grad != 0.0, f"zero gradient for {name}"
+
+
+def test_gradient_descent_finds_the_same_optimum_as_l_bfgs_b():
+    from levy.sampling import random
+
+    np.random.seed(0)
+    sample = random(1.6, 0.3, 0.5, 1.2, shape=(4000,))
+    tensor_sample = torch.tensor(sample, dtype=DOUBLE)
+
+    guess = torch.tensor([1.4, 0.0, 0.0, 1.0], dtype=DOUBLE, requires_grad=True)
+    optimizer = torch.optim.Adam([guess], lr=0.03)
+    for _ in range(400):
+        optimizer.zero_grad()
+        loss = torch_backend.neglog(
+            tensor_sample,
+            guess[0].clamp(0.55, 1.95), guess[1].clamp(-0.95, 0.95),
+            guess[2], guess[3].clamp(0.05, 20.0)).sum()
+        loss.backward()
+        optimizer.step()
+
+    by_gradient = guess.detach().numpy()
+    by_lbfgsb = np.asarray(api.fit(sample).params.as_tuple())
+
+    # Two different optimizers on the same objective; they should agree far
+    # more closely than either agrees with the true parameters.
+    np.testing.assert_allclose(by_gradient, by_lbfgsb, atol=5e-3)
+
+
+def test_the_numpy_backend_has_no_gradients_to_offer():
+    # Stated as a test so the difference between the two is on the record.
+    values = numpy_backend.pdf(XS, 1.5, 0.0)
+    assert isinstance(values, np.ndarray)
+    assert not hasattr(values, "requires_grad")
+
+
+# --------------------------------------------------------------------------
+# selection
+# --------------------------------------------------------------------------
+
+def test_a_tensor_argument_selects_torch():
+    assert backends.get(None, torch.tensor([1.0])).name == "torch"
+    assert backends.get(None, np.array([1.0])).name == "numpy"
+
+
+def test_a_tensor_parameter_also_selects_torch():
+    result = api.pdf(np.array([1.0, 2.0]), alpha=torch.tensor(1.5), beta=0.0)
+    assert isinstance(result, torch.Tensor)
+
+
+def test_an_explicit_choice_wins():
+    assert backends.get("numpy", torch.tensor([1.0])).name == "numpy"
+    assert backends.get("torch", np.array([1.0])).name == "torch"
+
+
+def test_set_backend_applies_globally_until_reset():
+    levy.set_backend("torch")
+    try:
+        assert isinstance(api.pdf(np.array([1.0]), alpha=1.5, beta=0.0), torch.Tensor)
+    finally:
+        levy.set_backend(None)
+    assert isinstance(api.pdf(np.array([1.0]), alpha=1.5, beta=0.0), np.ndarray)
+
+
+def test_using_restores_the_previous_selection_even_on_failure():
+    levy.set_backend("numpy")
+    with pytest.raises(RuntimeError), levy.using("torch"):
+        raise RuntimeError("boom")
+    assert backends.get(None, torch.tensor([1.0])).name == "numpy"
+    levy.set_backend(None)
+
+
+def test_an_unknown_backend_is_rejected_immediately():
+    with pytest.raises(ValueError, match="unknown backend"):
+        backends.set_backend("jax")
+    # and the selection is unchanged
+    assert backends.get(None, np.array([1.0])).name == "numpy"
+
+
+def test_torch_results_are_bit_identical_through_api_and_backend():
+    direct = torch_backend.pdf(torch.tensor(XS, dtype=DOUBLE), 1.5, 0.2, 0.1, 1.1)
+    through_api = api.pdf(torch.tensor(XS, dtype=DOUBLE),
+                          alpha=1.5, beta=0.2, mu=0.1, sigma=1.1)
+    assert torch.equal(direct, through_api)
+
+
+def test_logpdf_through_the_api_is_the_negated_neglog():
+    x = torch.tensor(XS, dtype=DOUBLE)
+    assert torch.equal(api.logpdf(x, alpha=1.5, beta=0.0),
+                       -torch_backend.neglog(x, 1.5, 0.0))
+
+
+# --------------------------------------------------------------------------
+# refusals
+# --------------------------------------------------------------------------
+
+def test_validation_still_runs_on_tensor_input():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        api.pdf(torch.tensor([1.0]), alpha=0.3, beta=0.0)
+
+
+def test_tensor_parameters_in_another_parametrization_are_refused():
+    with pytest.raises(ValueError, match="parametrization 0"):
+        api.pdf(torch.tensor([1.0]),
+                alpha=torch.tensor(1.5), beta=torch.tensor(0.5), par="B")
+
+
+def test_the_refusal_says_why_and_what_to_do():
+    with pytest.raises(ValueError, match="cut the gradient"):
+        api.pdf(torch.tensor([1.0]), alpha=torch.tensor(1.5), beta=0.0, par="1")
+
+
+def test_float_parameters_in_another_parametrization_are_fine():
+    # Nothing to cut, so nothing to refuse.
+    result = api.pdf(torch.tensor([1.0]), alpha=1.5, beta=0.5, par="B")
+    assert isinstance(result, torch.Tensor)
+
+
+def test_the_deprecated_1x_functions_stay_on_numpy():
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = levy.levy(np.array([1.0]), 1.5, 0.0)
+    assert isinstance(result, np.ndarray)

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -1,0 +1,331 @@
+"""The torch backend: same numbers, plus gradients.
+
+Two claims, and the second is the reason the backend exists at all.
+
+Parity: the torch implementation is a rewrite, not a wrapper, so it has to be
+shown to agree with NumPy rather than assumed to. It is checked here at
+``rtol=1e-6`` over a grid spanning both the interpolated region and both tails.
+
+Gradients: ``torch.autograd.gradcheck`` compares the analytic gradient against
+finite differences in float64, for all four parameters, for pdf, cdf and the
+negative log density. Passing that is what makes "differentiable" a fact rather
+than a claim -- and the optimisation test below shows it is *useful*: gradient
+descent lands on the same optimum this package's own L-BFGS-B finds.
+
+`tests/test_no_torch.py` covers the other half: an install without torch never
+imports it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import levy  # noqa: E402
+from levy import api, backends  # noqa: E402
+from levy.backends import _numpy as numpy_backend  # noqa: E402
+from levy.backends import _torch as torch_backend  # noqa: E402
+
+DOUBLE = torch.float64
+
+# Spans the interpolated region and both power-law tails.
+XS = np.concatenate([
+    np.linspace(-2000.0, 2000.0, 401),
+    np.linspace(-25.0, 25.0, 401),
+    np.linspace(-1.0, 1.0, 51),
+])
+
+CASES = [
+    (1.5, 0.0, 0.0, 1.0),
+    (0.7, -0.5, 1.0, 2.0),
+    (1.0, 0.4, -1.0, 0.5),
+    (1.9, 1.0, -2.0, 0.5),
+    (1.3, -1.0, 0.0, 3.0),
+    (2.0, 0.0, 0.5, 1.5),
+]
+
+
+@pytest.fixture(autouse=True)
+def automatic_backend():
+    """Leave the global selection as it was, whatever a test does to it."""
+    previous = backends.set_backend(None)
+    yield
+    backends.set_backend(previous)
+
+
+# --------------------------------------------------------------------------
+# parity
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), CASES)
+@pytest.mark.parametrize("function", ["pdf", "cdf", "neglog"])
+def test_matches_the_numpy_backend(function, alpha, beta, mu, sigma):
+    expected = getattr(numpy_backend, function)(XS, alpha, beta, mu, sigma)
+    got = getattr(torch_backend, function)(
+        torch.tensor(XS, dtype=DOUBLE), alpha, beta, mu, sigma).numpy()
+    np.testing.assert_allclose(got, expected, rtol=1e-6, atol=1e-12)
+
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), CASES)
+def test_agreement_is_far_tighter_than_the_contract(alpha, beta, mu, sigma):
+    # The stated contract is 1e-6. What is actually observed is accumulated
+    # float64 rounding, because both paths do the same arithmetic in the same
+    # order over the same float32 grid -- nothing systematic. This second,
+    # tighter assertion exists so that if the two ever genuinely diverge, the
+    # loose 1e-6 above does not hide it.
+    #
+    # The bound is 1e-10 rather than the ~1e-16 a single operation would give:
+    # the interpolation is a 64-term weighted sum, and torch and NumPy do not
+    # order or vectorise it identically. Measured worst case is 2.6e-16 on
+    # macOS/x86 and 1.4e-12 on the Linux CI runner -- a libm difference, not a
+    # divergence. 1e-10 keeps two orders of magnitude of headroom over the
+    # worse of those while staying four below the contract.
+    expected = numpy_backend.pdf(XS, alpha, beta, mu, sigma)
+    got = torch_backend.pdf(torch.tensor(XS, dtype=DOUBLE),
+                            alpha, beta, mu, sigma).numpy()
+    finite = np.abs(expected) > 1e-300
+    relative = np.abs(got[finite] - expected[finite]) / np.abs(expected[finite])
+    assert relative.max() < 1e-10, f"max relative deviation {relative.max():.3e}"
+
+
+def test_float32_tensors_are_accepted_and_stay_float32():
+    result = torch_backend.pdf(torch.tensor(XS, dtype=torch.float32), 1.5, 0.0)
+    assert result.dtype == torch.float32
+    expected = numpy_backend.pdf(XS, 1.5, 0.0)
+    np.testing.assert_allclose(result.numpy(), expected, rtol=1e-5, atol=1e-7)
+
+
+# --------------------------------------------------------------------------
+# gradients
+# --------------------------------------------------------------------------
+
+GRADCHECK_CASES = [
+    (1.53, 0.17, 0.21, 1.07),
+    (0.83, -0.41, -0.50, 2.10),
+    (1.87, 0.63, 1.30, 0.40),
+]
+
+
+@pytest.mark.parametrize(("alpha", "beta", "mu", "sigma"), GRADCHECK_CASES)
+@pytest.mark.parametrize("function", ["pdf", "cdf", "neglog"])
+def test_gradcheck(function, alpha, beta, mu, sigma):
+    x = torch.tensor([-4.3, -1.1, 0.3, 1.9, 6.7], dtype=DOUBLE)
+    evaluate = getattr(torch_backend, function)
+
+    args = tuple(torch.tensor(v, dtype=DOUBLE, requires_grad=True)
+                 for v in (alpha, beta, mu, sigma))
+    assert torch.autograd.gradcheck(
+        lambda a, b, m, s: evaluate(x, a, b, m, s), args,
+        eps=1e-6, atol=1e-5, rtol=1e-3)
+
+
+def test_a_gradient_reaches_every_parameter():
+    x = torch.tensor([-2.0, 0.5, 3.0], dtype=DOUBLE)
+    params = {name: torch.tensor(value, dtype=DOUBLE, requires_grad=True)
+              for name, value in
+              (("alpha", 1.5), ("beta", 0.2), ("mu", 0.1), ("sigma", 1.1))}
+
+    torch_backend.neglog(x, **params).sum().backward()
+
+    for name, tensor in params.items():
+        assert tensor.grad is not None, f"no gradient for {name}"
+        assert torch.isfinite(tensor.grad), f"non-finite gradient for {name}"
+        assert tensor.grad != 0.0, f"zero gradient for {name}"
+
+
+def test_gradient_descent_finds_the_same_optimum_as_l_bfgs_b():
+    from levy.sampling import random
+
+    np.random.seed(0)
+    sample = random(1.6, 0.3, 0.5, 1.2, shape=(4000,))
+    tensor_sample = torch.tensor(sample, dtype=DOUBLE)
+
+    guess = torch.tensor([1.4, 0.0, 0.0, 1.0], dtype=DOUBLE, requires_grad=True)
+    optimizer = torch.optim.Adam([guess], lr=0.03)
+    for _ in range(400):
+        optimizer.zero_grad()
+        loss = torch_backend.neglog(
+            tensor_sample,
+            guess[0].clamp(0.55, 1.95), guess[1].clamp(-0.95, 0.95),
+            guess[2], guess[3].clamp(0.05, 20.0)).sum()
+        loss.backward()
+        optimizer.step()
+
+    by_gradient = guess.detach().numpy()
+    by_lbfgsb = np.asarray(api.fit(sample).params.as_tuple())
+
+    # Two different optimizers on the same objective; they should agree far
+    # more closely than either agrees with the true parameters.
+    np.testing.assert_allclose(by_gradient, by_lbfgsb, atol=5e-3)
+
+
+def test_the_numpy_backend_has_no_gradients_to_offer():
+    # Stated as a test so the difference between the two is on the record.
+    values = numpy_backend.pdf(XS, 1.5, 0.0)
+    assert isinstance(values, np.ndarray)
+    assert not hasattr(values, "requires_grad")
+
+
+# --------------------------------------------------------------------------
+# selection
+# --------------------------------------------------------------------------
+
+def test_a_tensor_argument_selects_torch():
+    assert backends.get(None, torch.tensor([1.0])).name == "torch"
+    assert backends.get(None, np.array([1.0])).name == "numpy"
+
+
+def test_a_tensor_parameter_also_selects_torch():
+    result = api.pdf(np.array([1.0, 2.0]), alpha=torch.tensor(1.5), beta=0.0)
+    assert isinstance(result, torch.Tensor)
+
+
+def test_an_explicit_choice_wins():
+    assert backends.get("numpy", torch.tensor([1.0])).name == "numpy"
+    assert backends.get("torch", np.array([1.0])).name == "torch"
+
+
+def test_set_backend_applies_globally_until_reset():
+    levy.set_backend("torch")
+    try:
+        assert isinstance(api.pdf(np.array([1.0]), alpha=1.5, beta=0.0), torch.Tensor)
+    finally:
+        levy.set_backend(None)
+    assert isinstance(api.pdf(np.array([1.0]), alpha=1.5, beta=0.0), np.ndarray)
+
+
+def test_using_restores_the_previous_selection_even_on_failure():
+    levy.set_backend("numpy")
+    with pytest.raises(RuntimeError), levy.using("torch"):
+        raise RuntimeError("boom")
+    assert backends.get(None, torch.tensor([1.0])).name == "numpy"
+    levy.set_backend(None)
+
+
+def test_an_unknown_backend_is_rejected_immediately():
+    with pytest.raises(ValueError, match="unknown backend"):
+        backends.set_backend("jax")
+    # and the selection is unchanged
+    assert backends.get(None, np.array([1.0])).name == "numpy"
+
+
+def test_torch_results_are_bit_identical_through_api_and_backend():
+    direct = torch_backend.pdf(torch.tensor(XS, dtype=DOUBLE), 1.5, 0.2, 0.1, 1.1)
+    through_api = api.pdf(torch.tensor(XS, dtype=DOUBLE),
+                          alpha=1.5, beta=0.2, mu=0.1, sigma=1.1)
+    assert torch.equal(direct, through_api)
+
+
+def test_logpdf_through_the_api_is_the_negated_neglog():
+    x = torch.tensor(XS, dtype=DOUBLE)
+    assert torch.equal(api.logpdf(x, alpha=1.5, beta=0.0),
+                       -torch_backend.neglog(x, 1.5, 0.0))
+
+
+# --------------------------------------------------------------------------
+# refusals
+# --------------------------------------------------------------------------
+
+def test_validation_still_runs_on_tensor_input():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        api.pdf(torch.tensor([1.0]), alpha=0.3, beta=0.0)
+
+
+def test_tensor_parameters_in_another_parametrization_are_refused():
+    with pytest.raises(ValueError, match="parametrization 0"):
+        api.pdf(torch.tensor([1.0]),
+                alpha=torch.tensor(1.5), beta=torch.tensor(0.5), par="B")
+
+
+def test_the_refusal_says_why_and_what_to_do():
+    with pytest.raises(ValueError, match="cut the gradient"):
+        api.pdf(torch.tensor([1.0]), alpha=torch.tensor(1.5), beta=0.0, par="1")
+
+
+def test_float_parameters_in_another_parametrization_are_fine():
+    # Nothing to cut, so nothing to refuse.
+    result = api.pdf(torch.tensor([1.0]), alpha=1.5, beta=0.5, par="B")
+    assert isinstance(result, torch.Tensor)
+
+
+@pytest.mark.parametrize("par", ["1", "M", "A", "B"])
+@pytest.mark.parametrize("function", ["pdf", "cdf", "logpdf"])
+def test_float_parameters_in_another_parametrization_are_converted(function, par):
+    """The torch path used to receive the caller's values unconverted, so a
+    call made in B was evaluated as if it had been made in parametrization 0.
+    The NumPy path is the reference: same call, same numbers.
+    """
+    x = np.linspace(-3.0, 3.0, 13)
+    kwargs = dict(alpha=1.5, beta=0.5, mu=0.3, sigma=1.4, par=par)
+    expected = getattr(api, function)(x, **kwargs)
+    result = getattr(api, function)(torch.tensor(x, dtype=DOUBLE), **kwargs)
+    np.testing.assert_allclose(result.numpy(), expected, rtol=1e-6, atol=1e-12)
+
+
+def test_float32_neglog_stays_finite_where_the_density_underflows():
+    """The 1e-100 floor is below float32's range, so `clamp(min=1e-100)`
+    clamped at zero and a far-tail density that underflowed to 0 gave
+    -log(0) = inf. NumPy returns a finite number there; so does float32 now.
+    """
+    x = torch.tensor([1e16, 1e20, 1e30], dtype=torch.float32)
+    result = torch_backend.neglog(x, 1.5, 0.0)
+    assert torch.isfinite(result).all(), result
+    assert (result > 0).all()
+    # And nothing changed for float64, where 1e-100 is representable.
+    x64 = torch.tensor([1e16, 1e20, 1e30], dtype=DOUBLE)
+    np.testing.assert_allclose(
+        torch_backend.neglog(x64, 1.5, 0.0).numpy(),
+        numpy_backend.neglog(x64.numpy(), 1.5, 0.0), rtol=1e-6)
+
+
+def test_float32_tail_at_alpha_2_is_not_negative():
+    """sin(pi*alpha/2) was taken in float32, and float32 pi's sine is -8.7e-8,
+    so at alpha = 2 the whole power-law tail was negative: a pdf below zero
+    and a cdf above one. The coefficient is computed in float64 now.
+    """
+    x = torch.tensor([50.0, 200.0, 1000.0], dtype=torch.float32)
+    density = torch_backend.pdf(x, 2.0, 0.0)
+    distribution = torch_backend.cdf(x, 2.0, 0.0)
+    assert (density >= 0).all(), density
+    assert (distribution <= 1.0).all(), distribution
+    # And the gradient still flows through alpha at the endpoint.
+    alpha = torch.tensor(2.0, dtype=torch.float32, requires_grad=True)
+    torch_backend.pdf(x, alpha, 0.0).sum().backward()
+    assert torch.isfinite(alpha.grad)
+
+
+def test_a_negative_stride_array_is_accepted_on_the_torch_backend():
+    """torch.as_tensor refuses a NumPy view with a negative stride, so
+    `api.pdf(x[::-1], ..., backend='torch')` raised where the NumPy backend
+    accepted the same array. It is copied to a contiguous array first now.
+    """
+    x = np.linspace(-3.0, 3.0, 7)[::-1]
+    assert x.strides[0] < 0
+    result = api.pdf(x, alpha=1.5, beta=0.0, backend="torch")
+    np.testing.assert_allclose(result.numpy(), api.pdf(x, alpha=1.5, beta=0.0), rtol=1e-6)
+
+
+def test_pandas_input_on_the_torch_backend_is_refused_with_a_reason():
+    """Used to fail inside torch.as_tensor with "could not determine the shape
+    of object type 'Series'", or would have silently dropped the labels.
+    """
+    pd = pytest.importorskip("pandas")
+
+    series = pd.Series([0.5, 1.0], index=["a", "b"])
+    with pytest.raises(ValueError, match="labels cannot be put back on a tensor"):
+        api.pdf(series, alpha=torch.tensor(1.5), beta=0.0)
+    with pytest.raises(ValueError, match="to_numpy"):
+        api.cdf(series, alpha=1.5, beta=0.0, backend="torch")
+
+
+def test_the_deprecated_1x_functions_stay_on_numpy():
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = levy.levy(np.array([1.0]), 1.5, 0.0)
+    assert isinstance(result, np.ndarray)


### PR DESCRIPTION
> Part 16 of a 20-commit stack. Stacked on #37 — review that first; the diff here against its base is a single commit.

levy/backends/ gains a torch implementation of the interpolation and the tail
approximation. It is a reimplementation, not a wrapper -- the NumPy code writes
into arrays under boolean masks, which autograd cannot follow, so the same
arithmetic is expressed with torch.where, torch.stack and out-of-place indexing.

What it buys: a stable distribution can sit inside a larger torch model and be
fitted by gradient descent along with everything else, instead of only through
this package's own L-BFGS-B. Hand pdf/cdf/logpdf a tensor and you get a tensor
back with gradients attached; levy.set_backend('torch') and levy.using('torch')
select it explicitly.

Two claims, both measured rather than asserted:

* Parity. Contract is rtol=1e-6 over a grid spanning the interpolated region
  and both tails, six (alpha, beta, mu, sigma) settings, pdf/cdf/neglog. What
  is actually observed is max relative deviation of 2.6e-16 on macOS/x86 and
  1.4e-12 on the Linux CI runner -- float64 rounding and a libm difference,
  because both paths do the same arithmetic over the same float32 grid but
  torch and NumPy do not order the 64-term interpolation sum identically. A
  second test asserts 1e-10 -- two orders of magnitude over the worse of those
  measurements, four below the contract -- so that if the two ever genuinely
  diverge the loose 1e-6 does not hide it.

* Gradients. torch.autograd.gradcheck passes in float64 for all four
  parameters, for pdf, cdf and neglog, at three parameter settings. And it is
  useful, not just correct: 400 Adam steps on a 4000-point sample land on the
  same optimum scipy's L-BFGS-B finds, to within 5e-3 --

      gradient descent  [1.576, 0.355, 0.466, 1.233]
      L-BFGS-B          [1.576, 0.355, 0.466, 1.233]
      truth             [1.6,   0.3,   0.5,   1.2  ]

Two things are deliberately not differentiable, and the module docstring says
so: the integer grid cell used to look up the crossover limits, and the mask it
implies. Both are choices, not quantities -- the crossover is piecewise
constant in alpha -- so the gradient is right everywhere except exactly at a
cell boundary, where a step function has no derivative anyway.

Tensor parameters in a parametrization other than 0 are refused, with the
reason: the conversion formulas run in NumPy and would cut the gradient without
saying so. Float parameters in any parametrization are fine, because there is
nothing to cut.

If torch is absent, not one line of it is imported. tests/test_no_torch.py
proves that in a subprocess with torch blocked at the import system: the whole
API works, the whole 1.x surface works, importing levy.backends does not pull
torch in, and selecting it fails at set_backend -- where the mistake was made,
not three calls later -- with `pip install "pylevy[torch]"`.

fit() is deliberately left on scipy. The value here is a differentiable
objective you can drop into your own optimizer; rerouting fit through
torch.optim would change its numerics for everyone to no purpose.

levy/backends/_numpy.py is a pure re-export. The core was not reorganised to
accommodate a second backend, so adding torch cannot have moved a NumPy number
-- and the install-parity check confirms it: 99,312 values bit-identical
against the parent commit.

57 new tests (862 total). Goldens unchanged.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


