### PR TITLE
Add governance, release automation, and the remaining CI jobs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Something returns the wrong number, or raises when it should not.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For a numerical bug, the reproducer is most of the report. `levy._build.calculate_levy`
+        is the ground truth if you need something independent of the interpolation tables to
+        compare against.
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Reproducer
+      description: The smallest script that shows it. Include the parameters and the input.
+      render: python
+      placeholder: |
+        import numpy as np
+        from levy import api
+        api.pdf(np.array([0.0]), alpha=0.58, beta=0.74)
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What you got
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected, and why
+      description: A reference value, an analytical result, or a comparison against another tool.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: "Output of: `python -c \"import sys, numpy, scipy, levy; print(sys.version, numpy.__version__, scipy.__version__, levy.__version__)\"`"
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: tables
+    attributes:
+      label: Which tables are in use
+      description: "Output of `levy-tables where`. Only relevant if you have regenerated them."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Something the package should be able to do and cannot.
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: The problem, not the solution. What does your code look like today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would it look like?
+      render: python
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What did you try instead?
+      description: Including other packages. If scipy.stats.levy_stable already does this, say so.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # GitHub Actions is the ecosystem that actually accrues security debt here:
+  # a pinned action tag stops receiving fixes the moment it is pinned, and
+  # nothing else in the repository notices.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "ci"
+
+  # Against pyproject.toml. The two existing dependabot branches target
+  # requirements.txt, which no longer exists; they can be closed.
+  #
+  # Dependencies here are floors, not pins, so this will mostly be quiet -- it
+  # opens a PR only when a floor genuinely has to move.
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "build"
+    groups:
+      dev-dependencies:
+        patterns: ["*"]
+        dependency-type: development

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## What this changes
+
+<!-- One or two sentences. -->
+
+## How it was verified
+
+<!-- Commands run, and what they said. Not "tests pass" -- which tests, and what
+     new ones were added. -->
+
+## Did the golden file move?
+
+<!-- Delete whichever does not apply. -->
+
+- [ ] **No.** `tests/golden/golden_v1.jsonl` is untouched.
+- [ ] **Yes**, deliberately. Below: which records moved, by how much, and a
+      comparison against `levy._build.calculate_levy` showing the new values are
+      closer to the truth.
+
+<!-- A pull request that regenerates the goldens without that evidence should be
+     rejected however green CI is. See CONTRIBUTING.md. -->
+
+## Checklist
+
+- [ ] A bug fix comes with a regression test that fails before it
+- [ ] `ruff check .` and `mypy` pass
+- [ ] Docstrings are NumPy style, and any examples run
+- [ ] `CHANGELOG.md` updated if the change is user-visible

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,32 @@ jobs:
       - name: Run tests
         run: python -m pytest tests/ -q -m "not build"
 
+  test-numpy2:
+    name: numpy 2.x (pinned)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The matrix legs above take whatever numpy resolves to today, which is a
+      # moving target. This one pins the 2.x series explicitly, so the pair of
+      # legs states the supported range as a fact rather than as a coincidence
+      # of when CI last ran.
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "numpy>=2,<3" "scipy>=1.13" pytest pydantic
+          python -m pip install -e . --no-deps
+
+      - name: Show environment
+        run: python -c "import numpy, scipy; print('numpy', numpy.__version__, '| scipy', scipy.__version__)"
+
+      - name: Run tests
+        run: python -m pytest tests/ -q -m "not build"
+
   build-tables:
     name: table generation
     runs-on: ubuntu-latest
@@ -112,32 +138,6 @@ jobs:
           levy-tables build --out "$RUNNER_TEMP/tables" --size 24,10,13 --what pdf
           test -f "$RUNNER_TEMP/tables/pdf.npz"
           test -f "$RUNNER_TEMP/tables/manifest.json"
-
-  test-numpy2:
-    name: numpy 2.x (pinned)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      # The matrix legs above take whatever numpy resolves to today, which is a
-      # moving target. This one pins the 2.x series explicitly, so the pair of
-      # legs states the supported range as a fact rather than as a coincidence
-      # of when CI last ran.
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install "numpy>=2,<3" "scipy>=1.13" pytest pydantic
-          python -m pip install -e . --no-deps
-
-      - name: Show environment
-        run: python -c "import numpy, scipy; print('numpy', numpy.__version__, '| scipy', scipy.__version__)"
-
-      - name: Run tests
-        run: python -m pytest tests/ -q
 
   golden:
     name: golden file is reproducible

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,34 @@ jobs:
       - name: Run tests
         run: python -m pytest tests/ -q -m "not build"
 
+  test-numpy2:
+    name: numpy 2.x (pinned)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The matrix legs above take whatever numpy resolves to today, which is a
+      # moving target. This one pins the 2.x series explicitly, so the pair of
+      # legs states the supported range as a fact rather than as a coincidence
+      # of when CI last ran. scipy is bounded to its 1.x series for the same
+      # reason: a "pinned" leg that lets one of its two dependencies float
+      # would break on somebody else's release schedule.
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "numpy>=2,<3" "scipy>=1.13,<2" pytest pydantic
+          python -m pip install -e . --no-deps
+
+      - name: Show environment
+        run: python -c "import numpy, scipy; print('numpy', numpy.__version__, '| scipy', scipy.__version__)"
+
+      - name: Run tests
+        run: python -m pytest tests/ -q -m "not build"
+
   build-tables:
     name: table generation
     runs-on: ubuntu-latest
@@ -117,34 +145,6 @@ jobs:
           levy-tables build --out "$RUNNER_TEMP/tables" --size 24,10,13 --what pdf
           test -f "$RUNNER_TEMP/tables/pdf.npz"
           test -f "$RUNNER_TEMP/tables/manifest.json"
-
-  test-numpy2:
-    name: numpy 2.x (pinned)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      # The matrix legs above take whatever numpy resolves to today, which is a
-      # moving target. This one pins the 2.x series explicitly, so the pair of
-      # legs states the supported range as a fact rather than as a coincidence
-      # of when CI last ran. scipy is bounded to its 1.x series for the same
-      # reason: a "pinned" leg that lets one of its two dependencies float
-      # would break on somebody else's release schedule.
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install "numpy>=2,<3" "scipy>=1.13,<2" pytest pydantic
-          python -m pip install -e . --no-deps
-
-      - name: Show environment
-        run: python -c "import numpy, scipy; print('numpy', numpy.__version__, '| scipy', scipy.__version__)"
-
-      - name: Run tests
-        run: python -m pytest tests/ -q -m "not build"
 
   golden:
     name: golden file is reproducible

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release
+
+# Publishes to PyPI when a `vX.Y.Z` tag is pushed.
+#
+# Trusted Publishing (OIDC), not an API token. That matters specifically here:
+# a token has to be minted by the account owner, stored as a repository secret,
+# and rotated -- three steps a dormant maintainer will not do. Trusted
+# Publishing needs one configuration on PyPI and then nothing, ever.
+#
+# See docs/proposals/pypi-name.md: the distribution name is read from
+# pyproject.toml, so the `pylevy` versus `levy-stable` decision can be made at
+# merge time and does not block anything.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: tag matches __version__
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # levy.__version__ is the single source of truth. Releasing v2.0.1 from a
+      # tree that says "2.0.0" would put a wheel on PyPI whose metadata
+      # disagrees with its own contents -- which has already happened once in
+      # this repository's history: the tag `1.2` was cut while __version__ still
+      # read "1.1". Read statically, so this does not need numpy installed.
+      - name: Compare the tag against the package version
+        run: |
+          python - <<'PY'
+          import ast, os, pathlib, sys
+
+          source = pathlib.Path("src/levy/__init__.py").read_text()
+          version = None
+          for node in ast.parse(source).body:
+              if isinstance(node, ast.Assign):
+                  for target in node.targets:
+                      if getattr(target, "id", None) == "__version__":
+                          version = ast.literal_eval(node.value)
+          tag = os.environ["GITHUB_REF_NAME"]
+          print(f"tag={tag!r} __version__={version!r}")
+          if tag != f"v{version}":
+              sys.exit(f"tag {tag!r} does not match v{version!r}; refusing to publish")
+          PY
+
+  build:
+    name: build and check
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          python -m twine check --strict dist/*
+
+      # A wheel that imports and computes, from a clean environment, before it
+      # goes anywhere public.
+      - name: Smoke-test the built wheel
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install --quiet dist/*.whl
+          /tmp/smoke/bin/python - <<'PY'
+          import numpy as np
+          from levy import api
+          values = api.cdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0)
+          assert np.allclose(values, [0.756342, 0.894960], atol=1e-6), values
+          print("wheel imports and computes:", values)
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: distributions
+          path: dist/
+
+  publish:
+    name: publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pylevy
+    permissions:
+      # The OIDC token Trusted Publishing exchanges for an upload credential.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: distributions
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  attach:
+    name: attach tables to the release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Gives `levy-tables` a download fallback: someone who wants the tables
+      # without a 10 MB wheel, or who needs to check that theirs match, can get
+      # them and the manifest from the release page.
+      - name: Attach the lookup tables and their manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" \
+            src/levy/data/pdf.npz \
+            src/levy/data/cdf.npz \
+            src/levy/data/limits.npz \
+            src/levy/data/manifest.json \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,216 @@
+name: Release
+
+# Publishes to PyPI when a `vX.Y.Z` tag is pushed.
+#
+# Trusted Publishing (OIDC), not an API token. That matters specifically here:
+# a token has to be minted by the account owner, stored as a repository secret,
+# and rotated -- three steps a dormant maintainer will not do. Trusted
+# Publishing needs one configuration on PyPI and then nothing, ever.
+#
+# See docs/proposals/pypi-name.md: the distribution name is read from
+# pyproject.toml, so the `pylevy` versus `levy-stable` decision can be made at
+# merge time and does not block anything.
+
+on:
+  push:
+    tags: ["v*"]
+  # A manual run has to say which tag it is releasing: from the Actions tab
+  # GITHUB_REF_NAME is the branch the run was started on, so without this
+  # input the version check below would compare `master` against v2.0.0 and
+  # refuse every manual run.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to release, e.g. v2.0.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# Every action in this workflow is pinned to a commit SHA, not a tag: the
+# publish job holds the OIDC credential PyPI exchanges for upload rights, and
+# a tag can be moved. The version is kept in a trailing comment so Dependabot
+# (.github/dependabot.yml) can keep the pins current.
+
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+
+jobs:
+  check:
+    name: tag matches __version__
+    runs-on: ubuntu-latest
+    outputs:
+      name: ${{ steps.name.outputs.name }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      # A manual run executes the workflow file from the ref it was started
+      # on, so the ancestry check below -- which is about the *tagged*
+      # commit -- would not cover an edited copy of this file on a branch.
+      # Only master's copy may publish.
+      - name: Manual runs must start from master
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master'
+        run: |
+          echo "start manual releases from master, not ${{ github.ref }}"
+          exit 1
+
+      # The full history, so the tag can be checked for ancestry below.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          ref: refs/tags/${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      # Three things a version string cannot prove, checked here once and
+      # handed to every later job as one immutable commit:
+      #   - the ref is a tag, not a branch that happens to be called v2.0.0;
+      #   - the tagged commit is on master, so nothing reaches PyPI that was
+      #     not reviewed there -- a tag can be pushed from any branch;
+      #   - build and attach use this exact SHA, so a tag moved mid-run cannot
+      #     put one commit's wheel on PyPI and another's tables on the release.
+      - name: Resolve the tag to a reviewed commit
+        id: resolve
+        run: |
+          sha=$(git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}") \
+            || { echo "$RELEASE_TAG is not a tag"; exit 1; }
+          git fetch --quiet origin master
+          git merge-base --is-ancestor "$sha" origin/master \
+            || { echo "$RELEASE_TAG ($sha) is not on master; refusing to publish"; exit 1; }
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "releasing $RELEASE_TAG at $sha"
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      # levy.__version__ is the single source of truth. Releasing v2.0.1 from a
+      # tree that says "2.0.0" would put a wheel on PyPI whose metadata
+      # disagrees with its own contents -- which has already happened once in
+      # this repository's history: the tag `1.2` was cut while __version__ still
+      # read "1.1". Read statically, so this does not need numpy installed.
+      - name: Compare the tag against the package version
+        run: |
+          python - <<'PY'
+          import ast, os, pathlib, sys
+
+          source = pathlib.Path("src/levy/__init__.py").read_text()
+          version = None
+          for node in ast.parse(source).body:
+              if isinstance(node, ast.Assign):
+                  for target in node.targets:
+                      if getattr(target, "id", None) == "__version__":
+                          version = ast.literal_eval(node.value)
+          tag = os.environ["RELEASE_TAG"]
+          print(f"tag={tag!r} __version__={version!r}")
+          if tag != f"v{version}":
+              sys.exit(f"tag {tag!r} does not match v{version}; refusing to publish")
+          PY
+
+      # The distribution name is deliberately not written anywhere else in
+      # this workflow -- see docs/proposals/pypi-name.md: the `pylevy` versus
+      # `levy-stable` decision is made by editing one line of pyproject.toml,
+      # and the environment URL below has to follow it rather than go stale.
+      # Normalised as PyPI does (PEP 503), so `PyLevy` links to /project/pylevy/.
+      - name: Read the distribution name
+        id: name
+        run: |
+          python - <<'PY'
+          import os, re, tomllib
+          with open("pyproject.toml", "rb") as handle:
+              name = tomllib.load(handle)["project"]["name"]
+          normalised = re.sub(r"[-_.]+", "-", name).lower()
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write(f"name={normalised}\n")
+          print(f"distribution name: {name} -> {normalised}")
+          PY
+
+  build:
+    name: build and check
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          ref: ${{ needs.check.outputs.sha }}
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Build
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          python -m twine check --strict dist/*
+
+      # A wheel that imports and computes, from a clean environment, before it
+      # goes anywhere public.
+      - name: Smoke-test the built wheel
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install --quiet dist/*.whl
+          /tmp/smoke/bin/python - <<'PY'
+          import numpy as np
+          from levy import api
+          values = api.cdf(np.array([1.0, 2.0]), alpha=1.5, beta=0.0)
+          assert np.allclose(values, [0.756342, 0.894960], atol=1e-6), values
+          print("wheel imports and computes:", values)
+          PY
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: distributions
+          path: dist/
+
+  publish:
+    name: publish to PyPI
+    needs: [check, build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/${{ needs.check.outputs.name }}/
+    permissions:
+      # The OIDC token Trusted Publishing exchanges for an upload credential.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: distributions
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
+
+  attach:
+    name: attach tables to the release
+    # After publish, not alongside it: the pypi environment can hold a run
+    # for approval, or the upload can fail, and a public GitHub release with
+    # the tables attached must not appear for a version that never reached
+    # PyPI.
+    needs: [check, build, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          ref: ${{ needs.check.outputs.sha }}
+
+      # Makes the tables available on their own: someone who wants them
+      # without a 10 MB wheel can download them and point $LEVY_DATA_DIR at
+      # the directory, and anyone can check a local build against the
+      # manifest's checksums. This is a manual path -- neither `levy-tables`
+      # nor the loader fetches from a release.
+      - name: Attach the lookup tables and their manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Pushing a tag does not create a release object, and `gh release
+          # upload` needs one to exist. Create it on the first run for this
+          # tag; a re-run, or a release made by hand, leaves it alone.
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 \
+            || gh release create "$RELEASE_TAG" --verify-tag --generate-notes
+          gh release upload "$RELEASE_TAG" \
+            src/levy/data/pdf.npz \
+            src/levy/data/cdf.npz \
+            src/levy/data/limits.npz \
+            src/levy/data/manifest.json \
+            --clobber

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+# Runs the fast checks on commit. The slow ones -- the test suite, mypy, the
+# docs build -- stay in CI, so committing does not take a minute.
+#
+#   pre-commit install
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '\.jsonl$'   # the golden file is exact; do not touch it
+      - id: end-of-file-fixer
+        exclude: '\.jsonl$'
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+        # The lookup tables are 10.3 MB and are committed on purpose. This
+        # catches a *new* one being added by accident, which is how .git got to
+        # 55 MB for 647 lines of code.
+        args: ["--maxkb=12000"]
+      - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.5
+    hooks:
+      - id: ruff
+        args: [--fix]
+
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.9.0
+    hooks:
+      - id: numpydoc-validation
+        files: ^src/levy/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# Runs the fast checks on commit. The slow ones -- the test suite, mypy, the
+# docs build -- stay in CI, so committing does not take a minute.
+#
+#   pre-commit install
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '\.jsonl$'   # the golden file is exact; do not touch it
+      - id: end-of-file-fixer
+        exclude: '\.jsonl$'
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+        # The limit is per file. The two density tables are 5.2 MB each and
+        # are committed on purpose; a float64 table of the same grid is
+        # ~11 MB, so 6000 lets the shipped ones through and catches a new
+        # one being added by accident -- which is how .git got to 55 MB for
+        # 647 lines of code. (A 12 MB limit would have let that happen again.)
+        args: ["--maxkb=6000"]
+      - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.5
+    hooks:
+      - id: ruff
+        args: [--fix]
+
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.9.0
+    hooks:
+      - id: numpydoc-validation
+        files: ^src/levy/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# Coding guidelines
+
+For humans and for coding agents alike. These are the conventions this codebase
+actually follows; a change that breaks one of them will be caught by CI, so this
+file is mostly here to save you the round trip.
+
+## The one rule that matters
+
+**Numbers do not move by accident.**
+
+`tests/golden/golden_v1.jsonl` pins the output of `levy`, `neglog_levy`,
+`random` and `fit_levy` at 251 points as exact hex floats. If your change moves
+any of them, either it was not supposed to and you have a bug, or it was and you
+owe the reviewer evidence — a comparison against `levy._build.calculate_levy`
+showing the new values are closer to the truth. See
+[CONTRIBUTING.md](CONTRIBUTING.md#the-golden-file).
+
+Never regenerate the golden file to make a test pass. That inverts the entire
+point of having it.
+
+## Docstrings
+
+NumPy style, checked two ways in CI:
+
+- `ruff` runs pydocstyle under the numpy convention, so the section grammar is
+  enforced;
+- `numpydoc lint` checks the docstring against the signature — every parameter
+  documented, in order, with a type.
+
+Practically:
+
+- Summary on the first line, after the opening quotes, imperative mood, ending
+  in a period.
+- Document parameters in signature order with types.
+- `Returns` for anything that returns.
+- `Raises` for anything that raises deliberately.
+- Examples that run. They are executed by `pytest --doctest-modules` and by
+  Sphinx's doctest builder, both gated. Round floats (`np.round(..., 6)`) rather
+  than pasting 17 digits — the 1.x doctests failed precisely because they pinned
+  the last digits of an L-BFGS-B optimum.
+
+## Comments
+
+Explain the reasoning, not the mechanics. Several constants here look arbitrary
+and are not: `_ALPHA_1_RADIUS = 1e-8` has fifteen lines above it explaining what
+1e-15 did wrong and why every value from 1e-10 to 1e-6 behaves identically. When
+you make a numerical choice, write down what you measured.
+
+Conversely, do not narrate the obvious. `# increment i` earns nothing.
+
+## Logging
+
+A library does not write to stdout. `levy._logging` provides a logger with a
+`NullHandler`; use it. The only `print()` in the package is in the `levy-tables`
+command, which is a CLI and is supposed to print.
+
+## Validation and the hot loop
+
+Pydantic validates **once, at the API boundary**, and never inside a likelihood
+evaluation. A fit runs thousands of density evaluations; a model construction in
+that loop would make the package slow in the one place it exists to be fast.
+
+`tests/test_hot_loop.py` counts `StableParams` constructions during a fit and
+fails if the count grows with the sample size. If you add a code path, keep it
+outside the loop.
+
+## Optional dependencies
+
+`pandas` and `torch` are extras. Neither may be imported unless it is being
+used, and "is it available" is answered by looking in `sys.modules`
+(`levy._compat.loaded`) — not by a `try: import` in a hot path.
+
+`tests/test_no_pandas.py` and `tests/test_no_torch.py` run the whole API in a
+subprocess with each blocked at the import system. If you add a third optional
+dependency, add the matching pair of test files.
+
+When an optional dependency really is required for something, raise through
+`levy._compat.require`, which names the extra: `pip install "pylevy[torch]"`,
+not an `ImportError` from three frames down.
+
+## Types
+
+`levy/api.py`, `levy/_typing.py`, `levy/_compat.py` and `levy/_pandas.py` are
+checked with `mypy --strict` and shipped with `py.typed`. The numerical core is
+not annotated and is deliberately excluded — it is checked by tests instead.
+
+If you add to the typed surface, keep it strict. If you need a value from the
+untyped core, narrow it with a checked `isinstance` (see `api._narrow`) rather
+than a bare `cast`.
+
+Annotations must work on Python 3.9: PEP 585 builtin generics (`list[str]`) are
+fine, `X | Y` unions are not.
+
+## Deprecations
+
+The 1.x names resolve through a PEP 562 module `__getattr__` and warn **on
+access, not on import**. `import levy` under `-W error::DeprecationWarning` must
+keep succeeding; there is a test for it.
+
+A deprecation message says three things: that the name is deprecated and since
+when, when it goes away, and what to use instead.
+
+Nothing is a wrapper — a deprecated name resolves to the same object, so numbers
+cannot drift between the old spelling and the new one.
+
+## Tests
+
+- Name them after the claim: `test_random_ignores_loc_scale_at_alpha_2`, not
+  `test_random_3`.
+- A bug fix comes with a regression test that fails before it.
+- State tolerances as constants with a reason. Do not tighten one to the last
+  digit you happened to observe on your machine — `libm` differs across
+  platforms, and CI will find out before you do.
+- Tests may use the 1.x names; that is how the goldens prove the shims return
+  identical numbers.
+
+## Commits and pull requests
+
+One purpose per pull request. The body says what changed, what it was verified
+against, and whether the goldens moved. Include the numbers — a table of
+measured deviations is what makes a numerical change reviewable at all.
+
+If you tried something, measured it, and it was worse, say so and say by how
+much. Two changes in this package's history were reverted on measurement, and
+recording that is more useful than quietly dropping them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,132 @@
+# Coding guidelines
+
+For humans and for coding agents alike. These are the conventions this codebase
+actually follows; a change that breaks one of them will be caught by CI, so this
+file is mostly here to save you the round trip.
+
+## The one rule that matters
+
+**Numbers do not move by accident.**
+
+`tests/golden/golden_v1.jsonl` pins the output of `levy`, `neglog_levy`,
+`random` and `fit_levy` at 251 points as exact hex floats. If your change moves
+any of them, either it was not supposed to and you have a bug, or it was and you
+owe the reviewer evidence. For the density, distribution and sampling records
+that is a comparison against `levy._build.calculate_levy` showing the new
+values are closer to the truth. For the `fit_levy` records the truth is the
+maximum of the *interpolated* likelihood — that is what the fitter optimises —
+so the evidence is the negative log likelihood of the old and new optima on
+the same sample and the same tables, which must not get worse; a quadrature
+score is worth reporting alongside, but its per-point error (~1e-7 relative,
+and a known failure at |z| < 1e-3) is larger than the moves a starting-point
+change makes, so it cannot adjudicate them on its own. See
+[CONTRIBUTING.md](CONTRIBUTING.md#the-golden-file).
+
+Never regenerate the golden file to make a test pass. That inverts the entire
+point of having it.
+
+## Docstrings
+
+NumPy style, checked two ways in CI:
+
+- `ruff` runs pydocstyle under the numpy convention, so the section grammar is
+  enforced;
+- `numpydoc lint` checks the docstring against the signature — every parameter
+  documented, in order, with a type.
+
+Practically:
+
+- Summary on the first line, after the opening quotes, imperative mood, ending
+  in a period.
+- Document parameters in signature order with types.
+- `Returns` for anything that returns.
+- `Raises` for anything that raises deliberately.
+- Examples that run. They are executed by `pytest --doctest-modules` and by
+  Sphinx's doctest builder, both gated. Round floats (`np.round(..., 6)`) rather
+  than pasting 17 digits — the 1.x doctests failed precisely because they pinned
+  the last digits of an L-BFGS-B optimum.
+
+## Comments
+
+Explain the reasoning, not the mechanics. Several constants here look arbitrary
+and are not: `_ALPHA_1_RADIUS = 1e-8` has fifteen lines above it explaining what
+1e-15 did wrong and why every value from 1e-10 to 1e-6 behaves identically. When
+you make a numerical choice, write down what you measured.
+
+Conversely, do not narrate the obvious. `# increment i` earns nothing.
+
+## Logging
+
+A library does not write to stdout. `levy._logging` provides a logger with a
+`NullHandler`; use it. The only `print()` in the package is in the `levy-tables`
+command, which is a CLI and is supposed to print.
+
+## Validation and the hot loop
+
+Pydantic validates **once, at the API boundary**, and never inside a likelihood
+evaluation. A fit runs thousands of density evaluations; a model construction in
+that loop would make the package slow in the one place it exists to be fast.
+
+`tests/test_hot_loop.py` counts `StableParams` constructions during a fit and
+fails if the count grows with the sample size. If you add a code path, keep it
+outside the loop.
+
+## Optional dependencies
+
+`pandas` and `torch` are extras. Neither may be imported unless it is being
+used, and "is it available" is answered by looking in `sys.modules`
+(`levy._compat.loaded`) — not by a `try: import` in a hot path.
+
+`tests/test_no_pandas.py` and `tests/test_no_torch.py` run the whole API in a
+subprocess with each blocked at the import system. If you add a third optional
+dependency, add the matching pair of test files.
+
+When an optional dependency really is required for something, raise through
+`levy._compat.require`, which names the extra: `pip install "pylevy[torch]"`,
+not an `ImportError` from three frames down.
+
+## Types
+
+`levy/api.py`, `levy/_typing.py`, `levy/_compat.py` and `levy/_pandas.py` are
+checked with `mypy --strict` and shipped with `py.typed`. The numerical core is
+not annotated and is deliberately excluded — it is checked by tests instead.
+
+If you add to the typed surface, keep it strict. If you need a value from the
+untyped core, narrow it with a checked `isinstance` (see `api._narrow`) rather
+than a bare `cast`.
+
+Annotations must work on Python 3.9: PEP 585 builtin generics (`list[str]`) are
+fine, `X | Y` unions are not.
+
+## Deprecations
+
+The 1.x names resolve through a PEP 562 module `__getattr__` and warn **on
+access, not on import**. `import levy` under `-W error::DeprecationWarning` must
+keep succeeding; there is a test for it.
+
+A deprecation message says three things: that the name is deprecated and since
+when, when it goes away, and what to use instead.
+
+Nothing is a wrapper — a deprecated name resolves to the same object, so numbers
+cannot drift between the old spelling and the new one.
+
+## Tests
+
+- Name them after the claim: `test_random_ignores_loc_scale_at_alpha_2`, not
+  `test_random_3`.
+- A bug fix comes with a regression test that fails before it.
+- State tolerances as constants with a reason. Do not tighten one to the last
+  digit you happened to observe on your machine — `libm` differs across
+  platforms, and CI will find out before you do.
+- Tests may use the 1.x names; that is how the goldens prove the shims return
+  identical numbers.
+
+## Commits and pull requests
+
+One purpose per pull request. The body says what changed, what it was verified
+against, and whether the goldens moved. Include the numbers — a table of
+measured deviations is what makes a numerical change reviewable at all.
+
+If you tried something, measured it, and it was worse, say so and say by how
+much. Two changes in this package's history were reverted on measurement, and
+recording that is more useful than quietly dropping them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,18 @@ public name still works and still returns the same floats, bit for bit.
 - A characterization test suite: 251 golden records, stored as exact hex floats,
   covering `levy`, `neglog_levy`, `random` and `fit_levy` in all five
   parametrizations. Every change since is measured against it.
-- CI on Linux × Python 3.9–3.13, plus a NumPy 1.x leg, a table-generation leg, a
-  golden-reproducibility leg, a lint/docstring leg and a doctest leg.
+- CI on Linux × Python 3.9–3.13 plus macOS and Windows at both ends of the
+  range, pinned NumPy 1.x and 2.x legs, and separate legs for table generation,
+  golden reproducibility, lint and docstrings, doctests, the optional extras,
+  and the documentation build.
+- Project documentation and automation: `CONTRIBUTING.md`, `AGENTS.md`,
+  `CODE_OF_CONDUCT.md`, `CITATION.cff`, issue and pull-request templates,
+  Dependabot for pip and GitHub Actions, and `.pre-commit-config.yaml`.
+- A release workflow: a `vX.Y.Z` tag is refused unless it matches
+  `levy.__version__`, the built wheel is smoke-tested in a clean environment
+  before anything is published, publishing goes through PyPI Trusted Publishing
+  (OIDC, no stored secret), and the lookup tables plus their manifest are
+  attached to the GitHub release as a download fallback for `levy-tables`.
 - `levy-tables`, a console script that regenerates the lookup tables into a user
   cache directory, with a `manifest.json` recording grid size, library versions
   and per-array SHA256.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,19 @@ number, a NaN, or an error -- it returns the same floats, bit for bit.
 - A characterization test suite: 251 golden records, stored as exact hex floats,
   covering `levy`, `neglog_levy`, `random` and `fit_levy` in all five
   parametrizations. Every change since is measured against it.
-- CI on Linux × Python 3.9–3.13, plus a NumPy 1.x leg, a table-generation leg, a
-  golden-reproducibility leg, a lint/docstring leg and a doctest leg.
+- CI on Linux × Python 3.9–3.13 plus macOS and Windows at both ends of the
+  range, pinned NumPy 1.x and 2.x legs, and separate legs for table generation,
+  golden reproducibility, lint and docstrings, doctests, the optional extras,
+  and the documentation build.
+- Project documentation and automation: `CONTRIBUTING.md`, `AGENTS.md`,
+  `CODE_OF_CONDUCT.md`, `CITATION.cff`, issue and pull-request templates,
+  Dependabot for pip and GitHub Actions, and `.pre-commit-config.yaml`.
+- A release workflow: a `vX.Y.Z` tag is refused unless it matches
+  `levy.__version__`, the built wheel is smoke-tested in a clean environment
+  before anything is published, publishing goes through PyPI Trusted Publishing
+  (OIDC, no stored secret), and the lookup tables plus their manifest are
+  attached to the GitHub release, for use through `$LEVY_DATA_DIR` or for
+  checking a local build against their checksums.
 - `levy-tables`, a console script that regenerates the lookup tables into a user
   cache directory, with a `manifest.json` recording grid size, library versions
   and per-array SHA256.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,48 @@
+cff-version: 1.2.0
+title: pylevy
+message: If you use this software, please cite it as below.
+type: software
+authors:
+  - family-names: Harrison
+    given-names: Paul
+  - family-names: Miotto
+    given-names: José María
+    email: josemiotto@gmail.com
+  - family-names: Carisimo
+    given-names: Esteban
+abstract: >-
+  Calculation and maximum-likelihood fitting of Levy alpha-stable
+  distributions, by interpolation of a precomputed lookup table.
+keywords:
+  - levy
+  - alpha-stable
+  - stable distribution
+  - heavy tails
+  - maximum likelihood
+license: GPL-3.0-or-later
+repository-code: https://github.com/josemiotto/pylevy
+version: 2.0.0
+references:
+  - type: book
+    title: Univariate Stable Distributions
+    authors:
+      - family-names: Nolan
+        given-names: John P.
+    publisher:
+      name: Springer
+    year: 2020
+  - type: article
+    title: A Method for Simulating Stable Random Variables
+    authors:
+      - family-names: Chambers
+        given-names: John M.
+      - family-names: Mallows
+        given-names: Colin L.
+      - family-names: Stuck
+        given-names: B. W.
+    journal: Journal of the American Statistical Association
+    volume: 71
+    issue: 354
+    start: 340
+    end: 344
+    year: 1976

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Code of Conduct
+
+## Our pledge
+
+We pledge to make participation in this project a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability,
+ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our mistakes
+- Focusing on what is best for the community
+
+Examples of unacceptable behaviour:
+
+- Sexualised language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported to the project maintainers. All complaints will be reviewed and
+investigated promptly and fairly, and the privacy and security of the reporter
+will be respected.
+
+Maintainers who do not follow or enforce this Code of Conduct in good faith may
+face temporary or permanent repercussions as determined by other members of the
+project's leadership.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Code of Conduct
+
+## Our pledge
+
+We pledge to make participation in this project a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability,
+ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our mistakes
+- Focusing on what is best for the community
+
+Examples of unacceptable behaviour:
+
+- Sexualised language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported privately to the maintainer, José María Miotto, at
+<josemiotto@gmail.com> -- the address listed under `maintainers` in
+`pyproject.toml` -- or through GitHub's
+[private reporting](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam)
+if the complaint concerns a maintainer. All complaints will be reviewed and
+investigated promptly and fairly, and the privacy and security of the reporter
+will be respected.
+
+Maintainers who do not follow or enforce this Code of Conduct in good faith may
+face temporary or permanent repercussions as determined by other members of the
+project's leadership.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing
+
+Thanks for looking. This is a small numerical package, and the thing that makes
+it maintainable is that every change can be checked. Most of what follows is
+about how to check yours.
+
+## Getting set up
+
+[uv](https://docs.astral.sh/uv/) is the recommended toolchain — it resolves and
+installs in seconds, which matters when the optional extras include torch:
+
+```console
+uv venv
+uv pip install -e ".[dev,lint,docs]"
+uv run pytest
+```
+
+Plain pip works identically:
+
+```console
+python -m venv .venv && . .venv/bin/activate
+pip install -e ".[dev,lint,docs]"
+pytest
+```
+
+There is deliberately **no `uv.lock` in the repository**. This is a library, not
+an application: its dependencies are declared as floors (`numpy>=1.20`) rather
+than pins, and the useful thing to test is that it works across that range —
+which the CI matrix does — not that it works against one frozen resolution. A
+lock file would add churn and hide exactly the breakage it looks like it
+prevents.
+
+## Running the checks
+
+```console
+pytest                          # the suite, minus the slow table build
+pytest -m build                 # regenerates tiny tables by quadrature, ~70s
+pytest --doctest-modules src/levy
+ruff check .
+mypy
+numpydoc lint src/levy/*.py src/levy/_build/*.py src/levy/backends/*.py
+sphinx-build -b html -W docs/source docs/_build/html
+```
+
+`.pre-commit-config.yaml` runs the fast ones on commit:
+
+```console
+pre-commit install
+```
+
+## The golden file
+
+`tests/golden/golden_v1.jsonl` holds 251 records pinning the numerical output of
+`levy`, `neglog_levy`, `random` and `fit_levy`, stored as exact hex floats so
+that a change to them shows up as a readable diff rather than a binary blob.
+
+**It is the centre of everything.** Every pull request either leaves it
+untouched, or changes it deliberately and says why.
+
+If your change moves a golden record, the pull request has to answer three
+questions in its body:
+
+1. **Which records moved, and by how much?** A per-case maximum relative change.
+2. **Why is the new value better?** Not "the test now passes" — a comparison
+   against `levy._build.calculate_levy`, the quadrature ground truth, showing
+   the new values are closer to it.
+3. **Was the move intended?** If the answer is "no, but the new values look
+   fine", stop and find out what actually changed.
+
+Regenerate with:
+
+```console
+python tests/golden/generate.py          # rewrite
+python tests/golden/generate.py --check  # verify without writing
+```
+
+A pull request that regenerates the goldens without that justification should be
+rejected, however green CI is. That discipline is the only thing standing
+between this package and a silent numerical regression — which is precisely what
+happened before: the last substantive commit of the 1.x line changed the
+numerics and regenerated both lookup tables with nothing protecting it.
+
+## Proving a refactor changed nothing
+
+For changes that move code without intending to move numbers:
+
+```console
+python scripts/compare_installs.py /path/to/venv-before/bin/python \
+                                  /path/to/venv-after/bin/python
+```
+
+It builds the same 99,312 values in both interpreters and diffs them as exact
+hex floats. "All values match bit for bit" is a much stronger claim than a green
+test suite, and it is cheap to produce.
+
+## Coding guidelines
+
+See [AGENTS.md](AGENTS.md). Briefly:
+
+- NumPy-style docstrings, enforced by `ruff` and `numpydoc`.
+- No `print()` in library code. The package has a logger.
+- Pydantic validates at the API boundary and never inside a likelihood
+  evaluation. `tests/test_hot_loop.py` enforces this by counting.
+- Optional dependencies are never imported unless they are used.
+- A comment explaining *why* is worth more than one explaining *what*. Several
+  of the constants in this package look arbitrary and are not; where that is
+  true, the reasoning is written down next to them.
+
+## Pull requests
+
+Small and single-purpose, please. The 2.0 work was delivered as a stack of
+focused pull requests rather than one large one, and that is the shape that gets
+reviewed.
+
+A good pull request body says what changed, what it was verified against, and
+whether the goldens moved. If it fixes a bug, it comes with a regression test
+that fails before and passes after.
+
+## Reporting a bug
+
+Numerical bugs need a reproducer with concrete numbers: the parameters, the
+input, what came out, and what you expected. `levy._build.calculate_levy` is the
+ground truth if you need something to compare against — slow, but independent of
+the interpolation tables.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing
+
+Thanks for looking. This is a small numerical package, and the thing that makes
+it maintainable is that every change can be checked. Most of what follows is
+about how to check yours.
+
+## Getting set up
+
+[uv](https://docs.astral.sh/uv/) is the recommended toolchain — it resolves and
+installs in seconds, which matters when the optional extras include torch:
+
+```console
+uv venv
+uv pip install -e ".[dev,lint,docs]"
+uv run pytest
+```
+
+Plain pip works identically:
+
+```console
+python -m venv .venv && . .venv/bin/activate
+pip install -e ".[dev,lint,docs]"
+pytest
+```
+
+There is deliberately **no `uv.lock` in the repository**. This is a library, not
+an application: its dependencies are declared as floors (`numpy>=1.20`) rather
+than pins, and the useful thing to test is that it works across that range —
+which the CI matrix does — not that it works against one frozen resolution. A
+lock file would add churn and hide exactly the breakage it looks like it
+prevents.
+
+## Running the checks
+
+```console
+pytest -m "not build"           # the suite, minus the slow table build
+pytest -m build                 # regenerates tiny tables by quadrature, ~70s
+pytest --doctest-modules src/levy
+ruff check .
+mypy
+numpydoc lint src/levy/*.py src/levy/_build/*.py src/levy/backends/*.py
+sphinx-build -b html -W docs/source docs/_build/html
+```
+
+`.pre-commit-config.yaml` runs the fast ones on commit. `pre-commit` itself
+is not one of the package's extras -- it is a developer tool, not something CI
+or a user needs -- so install it on its own:
+
+```console
+pip install pre-commit
+pre-commit install
+```
+
+## The golden file
+
+`tests/golden/golden_v1.jsonl` holds 251 records pinning the numerical output of
+`levy`, `neglog_levy`, `random` and `fit_levy`, stored as exact hex floats so
+that a change to them shows up as a readable diff rather than a binary blob.
+
+**It is the centre of everything.** Every pull request either leaves it
+untouched, or changes it deliberately and says why.
+
+If your change moves a golden record, the pull request has to answer three
+questions in its body:
+
+1. **Which records moved, and by how much?** A per-case maximum relative change.
+2. **Why is the new value better?** Not "the test now passes" — a comparison
+   against `levy._build.calculate_levy`, the quadrature ground truth, showing
+   the new values are closer to it.
+3. **Was the move intended?** If the answer is "no, but the new values look
+   fine", stop and find out what actually changed.
+
+Regenerate with:
+
+```console
+python tests/golden/generate.py          # rewrite
+python tests/golden/generate.py --check  # verify without writing
+```
+
+A pull request that regenerates the goldens without that justification should be
+rejected, however green CI is. That discipline is the only thing standing
+between this package and a silent numerical regression — which is precisely what
+happened before: the last substantive commit of the 1.x line changed the
+numerics and regenerated both lookup tables with nothing protecting it.
+
+## Proving a refactor changed nothing
+
+For changes that move code without intending to move numbers:
+
+```console
+python scripts/compare_installs.py /path/to/venv-before/bin/python \
+                                  /path/to/venv-after/bin/python
+```
+
+It builds the same 99,312 values in both interpreters and diffs them as exact
+hex floats. "All values match bit for bit" is a much stronger claim than a green
+test suite, and it is cheap to produce.
+
+## Coding guidelines
+
+See [AGENTS.md](AGENTS.md). Briefly:
+
+- NumPy-style docstrings, enforced by `ruff` and `numpydoc`.
+- No `print()` in library code. The package has a logger.
+- Pydantic validates at the API boundary and never inside a likelihood
+  evaluation. `tests/test_hot_loop.py` enforces this by counting.
+- Optional dependencies are never imported unless they are used.
+- A comment explaining *why* is worth more than one explaining *what*. Several
+  of the constants in this package look arbitrary and are not; where that is
+  true, the reasoning is written down next to them.
+
+## Pull requests
+
+Small and single-purpose, please. The 2.0 work was delivered as a stack of
+focused pull requests rather than one large one, and that is the shape that gets
+reviewed.
+
+A good pull request body says what changed, what it was verified against, and
+whether the goldens moved. If it fixes a bug, it comes with a regression test
+that fails before and passes after.
+
+## Reporting a bug
+
+Numerical bugs need a reproducer with concrete numbers: the parameters, the
+input, what came out, and what you expected. `levy._build.calculate_levy` is the
+ground truth if you need something to compare against — slow, but independent of
+the interpolation tables.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ fixes.
 [How it works](docs/source/how_it_works.md) explains the interpolation scheme
 and where the accuracy comes from.
 
+## Contributing
+
+[CONTRIBUTING.md](CONTRIBUTING.md) has the setup, the checks, and the rule that
+matters: the golden file pins this package's numerical output, and a change that
+moves it needs evidence, not a regeneration. [AGENTS.md](AGENTS.md) has the
+coding conventions.
+
 ## License
 
 GPL-3.0-or-later; see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ fixes.
 [How it works](https://github.com/josemiotto/pylevy/blob/master/docs/source/how_it_works.md)
 explains the interpolation scheme and where the accuracy comes from.
 
+## Contributing
+
+[CONTRIBUTING.md](https://github.com/josemiotto/pylevy/blob/master/CONTRIBUTING.md) has the setup, the checks, and the rule that
+matters: the golden file pins this package's numerical output, and a change that
+moves it needs evidence, not a regeneration. [AGENTS.md](https://github.com/josemiotto/pylevy/blob/master/AGENTS.md) has the
+coding conventions.
+
 ## License
 
 GPL-3.0-or-later; see [LICENSE](https://github.com/josemiotto/pylevy/blob/master/LICENSE).

--- a/docs/proposals/pypi-name.md
+++ b/docs/proposals/pypi-name.md
@@ -1,0 +1,74 @@
+# Which name to publish under
+
+## The situation
+
+**This package has never been published to PyPI.** `setup.py` declared
+`name='PyLevy'`, and `pyproject.toml` still does, but no release was ever
+uploaded.
+
+The `pylevy` slot on PyPI is taken. It belongs to Paul Harrison's original 2005
+package — version 0.3, maintainer `pfh` — which is the ancestor this repository
+was forked from, and which Harrison is still credited as an author of here.
+
+So `pip install pylevy` today installs twenty-year-old code, and there is
+currently no way to install this repository except from source. That is worth
+stating plainly, because it is the single largest reason the package has no
+traction: there is nothing to install.
+
+## Two paths
+
+### (a) Take over the `pylevy` name
+
+Strong case, and it costs one email:
+
+- Same lineage. This *is* the continuation of that package.
+- Paul Harrison is credited as an author here, so there is no dispute about
+  provenance.
+- The PyPI project has been dormant for twenty years.
+- The name is what people already type.
+
+Two routes, in order of preference:
+
+1. **Ask.** Email `pfh` and ask to be added as an owner of the PyPI project.
+   Twenty years dormant, same lineage, friendly request — this usually just
+   works, and it is far faster than the alternative.
+2. **PEP 541.** If there is no reply after a reasonable interval, file a
+   [PEP 541 name-transfer request](https://peps.python.org/pep-0541/) at
+   `pypi/support`. The criteria — abandoned project, requester is continuing the
+   same work — are met about as clearly as they ever are.
+
+### (b) Publish as `levy-stable`
+
+Verified free at the time of writing, as are `pylevy2` and `pylevy-ng`.
+
+`levy-stable` is the better fallback: it says what the package computes, it is
+what someone searching for this would plausibly type, and it does not read as a
+fork-of-a-fork the way `pylevy2` does.
+
+The cost is real, though: the import name would stay `levy` while the
+distribution name is `levy-stable`, which is a small permanent papercut for
+users, and search traffic for "pylevy" would keep landing on the 2005 package.
+
+## Recommendation
+
+Pursue (a) first, fall back to (b). Start with the email, not the PEP 541
+request.
+
+## This does not block anything
+
+The release workflow reads the distribution name from `pyproject.toml`, so the
+decision can be made at merge time — or after — by editing one line:
+
+```toml
+[project]
+name = "PyLevy"        # or "levy-stable"
+```
+
+Nothing else in the repository refers to the distribution name. The import name
+is `levy` either way.
+
+## While it is unresolved
+
+The README should not tell people to `pip install pylevy`, because that installs
+the 2005 package. It currently says `pip install .`, which is correct for a
+source checkout and should stay that way until the name is settled.

--- a/docs/proposals/pypi-name.md
+++ b/docs/proposals/pypi-name.md
@@ -1,0 +1,84 @@
+# Which name to publish under
+
+## The situation
+
+**This package has never been published to PyPI.** `setup.py` declared
+`name='PyLevy'`, and `pyproject.toml` still does, but no release was ever
+uploaded.
+
+The `pylevy` slot on PyPI is taken. It belongs to Paul Harrison's original 2005
+package — version 0.3, maintainer `pfh` — which is the ancestor this repository
+was forked from, and which Harrison is still credited as an author of here.
+
+So `pip install pylevy` today installs twenty-year-old code, and there is
+currently no way to install this repository except from source. That is worth
+stating plainly, because it is the single largest reason the package has no
+traction: there is nothing to install.
+
+## Two paths
+
+### (a) Take over the `pylevy` name
+
+Strong case, and it costs one email:
+
+- Same lineage. This *is* the continuation of that package.
+- Paul Harrison is credited as an author here, so there is no dispute about
+  provenance.
+- The PyPI project has been dormant for twenty years.
+- The name is what people already type.
+
+Two routes, in order of preference:
+
+1. **Ask.** Email `pfh` and ask to be added as an owner of the PyPI project.
+   Twenty years dormant, same lineage, friendly request — this usually just
+   works, and it is far faster than the alternative.
+2. **PEP 541.** If there is no reply after a reasonable interval, file a
+   [PEP 541 name-transfer request](https://peps.python.org/pep-0541/) at
+   `pypi/support`. The criteria — abandoned project, requester is continuing the
+   same work — are met about as clearly as they ever are.
+
+### (b) Publish as `levy-stable`
+
+Verified free at the time of writing, as are `pylevy2` and `pylevy-ng`.
+
+`levy-stable` is the better fallback: it says what the package computes, it is
+what someone searching for this would plausibly type, and it does not read as a
+fork-of-a-fork the way `pylevy2` does.
+
+The cost is real, though: the import name would stay `levy` while the
+distribution name is `levy-stable`, which is a small permanent papercut for
+users, and search traffic for "pylevy" would keep landing on the 2005 package.
+
+## Recommendation
+
+Pursue (a) first, fall back to (b). Start with the email, not the PEP 541
+request.
+
+## This does not block anything
+
+The release workflow reads the distribution name from `pyproject.toml`, so the
+decision can be made at merge time — or after — by editing one line:
+
+```toml
+[project]
+name = "PyLevy"        # or "levy-stable"
+```
+
+The import name is `levy` either way. A few other places spell the
+distribution name and would need the same one-word edit, all findable with
+`grep -rn 'pylevy\['`:
+
+- `src/levy/_compat.py`: the install hint in the missing-extra error,
+  `pip install "pylevy[torch]"`, and the two tests that assert its wording
+  (`tests/test_no_pandas.py`, `tests/test_no_torch.py`);
+- the same hint quoted in `AGENTS.md`, `docs/source/index.rst`,
+  `docs/source/how_it_works.md` and `docs/source/migration.md`.
+
+None of them affects what gets built or uploaded; the release workflow reads
+the name from `pyproject.toml` and links to the matching PyPI page.
+
+## While it is unresolved
+
+The README should not tell people to `pip install pylevy`, because that installs
+the 2005 package. It currently says `pip install .`, which is correct for a
+source checkout and should stay that way until the name is settled.

--- a/docs/proposals/repo-governance.md
+++ b/docs/proposals/repo-governance.md
@@ -1,0 +1,115 @@
+# Repository governance: a checklist for the owner
+
+Everything in this file needs permissions a pull request does not have. It is
+written down here so that the work is visible and can be done in one sitting,
+rather than discovered piecemeal.
+
+Nothing here changes any code. All of it makes the repository harder to break by
+accident.
+
+## 1. Protect `master`
+
+Settings → Branches → Add branch protection rule, pattern `master`:
+
+- [ ] Require a pull request before merging
+- [ ] Require status checks to pass, and mark these as required:
+      `py3.9`, `py3.13`, `numpy 1.x`, `lint and docstrings`, `doctests`,
+      `golden file is reproducible`, `optional extras`
+- [ ] Require branches to be up to date before merging
+- [ ] Do not allow force pushes
+- [ ] Do not allow deletions
+
+The `golden file is reproducible` check is the important one. It regenerates all
+251 golden records from scratch and compares them against the committed file, so
+a pull request cannot quietly edit the thing that pins the package's numerical
+behaviour.
+
+## 2. `CODEOWNERS`
+
+A `CODEOWNERS` file does nothing without branch protection, which is why it is
+proposed here rather than added by a pull request. Once the rule above exists,
+add `.github/CODEOWNERS`:
+
+```
+# Everything, by default.
+*                       @josemiotto
+
+# The numerical core and the file that pins its output. A change here is a
+# change to the package's results.
+/src/levy/distribution.py    @josemiotto
+/src/levy/interpolation.py   @josemiotto
+/src/levy/sampling.py        @josemiotto
+/tests/golden/               @josemiotto
+
+# Release and publishing.
+/.github/workflows/release.yml  @josemiotto
+```
+
+Then tick **Require review from Code Owners** in the branch rule.
+
+## 3. Reviewing policy
+
+Proposed, to go in `CONTRIBUTING.md` once agreed:
+
+- One approving review to merge; two for anything that moves a golden record.
+- The reviewer's job on a numerical change is to check the *evidence*, not to
+  re-derive the mathematics: which records moved, by how much, and the
+  comparison against `calculate_levy` ground truth.
+- CI being green is necessary and not sufficient. A pull request that
+  regenerates the goldens without justification is rejected however green it is.
+- Anything that changes the public API needs a changelog entry in the same pull
+  request.
+
+## 4. Trusted Publishing on PyPI
+
+`.github/workflows/release.yml` publishes via OIDC, which needs one
+configuration on PyPI and no stored secret:
+
+- [ ] On PyPI, project → Publishing → Add a new pending publisher
+      - Owner: `josemiotto`, repository: `pylevy`
+      - Workflow: `release.yml`, environment: `pypi`
+- [ ] In GitHub: Settings → Environments → New environment `pypi`, and add
+      yourself as a required reviewer so a publish cannot happen unattended
+
+See [pypi-name.md](pypi-name.md) for which project name this applies to.
+
+## 5. GitHub Pages
+
+`.github/workflows/docs.yml` publishes there:
+
+- [ ] Settings → Pages → Source: **GitHub Actions**
+
+## 6. Fix the repository "About"
+
+The sidebar currently has no description, no topics and no website, so the
+repository is effectively unfindable by search. Suggested:
+
+- **Description:** *Levy alpha-stable distributions for Python: density,
+  distribution function, sampling, and maximum-likelihood fitting by
+  interpolation.*
+- **Website:** the GitHub Pages URL, once §5 is done
+- **Topics:** `python`, `statistics`, `probability-distributions`,
+  `levy-distribution`, `alpha-stable`, `heavy-tails`, `maximum-likelihood`,
+  `scipy`, `numpy`
+- [ ] Tick "Releases" and "Packages" in the sidebar
+
+## 7. Stale branches
+
+- [ ] **`dev` (7 commits) — close with credit, do not merge.** It regresses
+      three things: it moves the `.npz` files to the repository root, outside
+      the installed package, which breaks `package_data` entirely; it deletes
+      all of `docs/`; and it flattens `levy/` to a single `levy.py`, the
+      opposite of the module split. It also rewrote both 12 MB tables, which is
+      part of why `.git` is 55 MB. Its one good idea — merging the two limit
+      tables into one archive — was salvaged and credited in the float32 pull
+      request.
+- [ ] **`dependabot/pip/numpy-1.22.0` — close, superseded.** Targets
+      `requirements.txt`, which no longer exists.
+- [ ] **`dependabot/pip/scipy-1.10.0` — close, superseded.** Same reason.
+
+## 8. Issue labels
+
+The defaults are fine except that a numerical package wants one more:
+
+- [ ] `numerics` — for anything where the disagreement is about a value rather
+      than about behaviour. These need a different kind of review.

--- a/docs/proposals/repo-governance.md
+++ b/docs/proposals/repo-governance.md
@@ -1,0 +1,138 @@
+# Repository governance: a checklist for the owner
+
+Everything in this file needs permissions a pull request does not have. It is
+written down here so that the work is visible and can be done in one sitting,
+rather than discovered piecemeal.
+
+Nothing here changes any code. All of it makes the repository harder to break by
+accident.
+
+## 1. Protect `master`
+
+Settings → Branches → Add branch protection rule, pattern `master`:
+
+- [ ] Require a pull request before merging
+- [ ] Require status checks to pass, and mark these as required:
+      every `test` leg -- `py3.9` through `py3.13`, `macos py3.10`,
+      `macos py3.13`, `windows py3.9`, `windows py3.13` -- plus `numpy 1.x`,
+      `numpy 2.x (pinned)`, `lint and docstrings`, `doctests`,
+      `golden file is reproducible`, `package builds`, `optional extras`,
+      `table generation`, and the docs workflow's `build` (the Sphinx build
+      with `-W`; its `links` job is informational and stays optional).
+      Everything that gates, in other words: a check that is not required is
+      one a platform-specific or documentation failure can slip past.
+- [ ] Require branches to be up to date before merging
+- [ ] Do not allow force pushes
+- [ ] Do not allow deletions
+
+And a second ruleset for tags, pattern `v*`, so that a release tag cannot be
+moved or removed once it exists:
+
+- [ ] Restrict creations to maintainers
+- [ ] Do not allow updates (no force-moving a tag)
+- [ ] Do not allow deletions
+
+The release workflow checks on its own that a tag is a tag and that the
+tagged commit is on `master`, and builds every job from that one commit; the
+tag ruleset closes what a workflow cannot, which is the tag being moved after
+the fact.
+
+The `golden file is reproducible` check is the important one. It regenerates all
+251 golden records from scratch and compares them against the committed file, so
+a pull request cannot quietly edit the thing that pins the package's numerical
+behaviour.
+
+## 2. `CODEOWNERS`
+
+A `CODEOWNERS` file does nothing without branch protection, which is why it is
+proposed here rather than added by a pull request. Once the rule above exists,
+add `.github/CODEOWNERS`:
+
+```
+# Everything, by default.
+*                       @josemiotto
+
+# The numerical core and the file that pins its output. A change here is a
+# change to the package's results.
+/src/levy/distribution.py    @josemiotto
+/src/levy/interpolation.py   @josemiotto
+/src/levy/sampling.py        @josemiotto
+/tests/golden/               @josemiotto
+
+# Release and publishing.
+/.github/workflows/release.yml  @josemiotto
+```
+
+Then tick **Require review from Code Owners** in the branch rule.
+
+## 3. Reviewing policy
+
+Proposed, to go in `CONTRIBUTING.md` once agreed:
+
+- One approving review to merge; two for anything that moves a golden record.
+- The reviewer's job on a numerical change is to check the *evidence*, not to
+  re-derive the mathematics: which records moved, by how much, and the
+  comparison against `calculate_levy` ground truth.
+- CI being green is necessary and not sufficient. A pull request that
+  regenerates the goldens without justification is rejected however green it is.
+- Anything that changes the public API needs a changelog entry in the same pull
+  request.
+
+## 4. Trusted Publishing on PyPI
+
+`.github/workflows/release.yml` publishes via OIDC, which needs one
+configuration on PyPI and no stored secret:
+
+- [ ] On PyPI, project → Publishing → Add a new pending publisher
+      - Owner: `josemiotto`, repository: `pylevy`
+      - Workflow: `release.yml`, environment: `pypi`
+- [ ] In GitHub: Settings → Environments → New environment `pypi`, and add
+      yourself as a required reviewer so a publish cannot happen unattended
+- [ ] In the same environment, set deployment branches and tags to
+      **selected**: `master` and `v*`. The workflow refuses a manual run
+      started anywhere but `master` and a tag whose commit is not on
+      `master`; this setting makes the platform refuse them too, so the OIDC
+      credential is never issued to a run that started from a branch.
+
+See [pypi-name.md](pypi-name.md) for which project name this applies to.
+
+## 5. GitHub Pages
+
+`.github/workflows/docs.yml` publishes there:
+
+- [ ] Settings → Pages → Source: **GitHub Actions**
+
+## 6. Fix the repository "About"
+
+The sidebar currently has no description, no topics and no website, so the
+repository is effectively unfindable by search. Suggested:
+
+- **Description:** *Levy alpha-stable distributions for Python: density,
+  distribution function, sampling, and maximum-likelihood fitting by
+  interpolation.*
+- **Website:** the GitHub Pages URL, once §5 is done
+- **Topics:** `python`, `statistics`, `probability-distributions`,
+  `levy-distribution`, `alpha-stable`, `heavy-tails`, `maximum-likelihood`,
+  `scipy`, `numpy`
+- [ ] Tick "Releases" and "Packages" in the sidebar
+
+## 7. Stale branches
+
+- [ ] **`dev` (7 commits) — close with credit, do not merge.** It regresses
+      three things: it moves the `.npz` files to the repository root, outside
+      the installed package, which breaks `package_data` entirely; it deletes
+      all of `docs/`; and it flattens `levy/` to a single `levy.py`, the
+      opposite of the module split. It also rewrote both 12 MB tables, which is
+      part of why `.git` is 55 MB. Its one good idea — merging the two limit
+      tables into one archive — was salvaged and credited in the float32 pull
+      request.
+- [ ] **`dependabot/pip/numpy-1.22.0` — close, superseded.** Targets
+      `requirements.txt`, which no longer exists.
+- [ ] **`dependabot/pip/scipy-1.10.0` — close, superseded.** Same reason.
+
+## 8. Issue labels
+
+The defaults are fine except that a numerical package wants one more:
+
+- [ ] `numerics` — for anything where the disagreement is about a value rather
+      than about behaviour. These need a different kind of review.


### PR DESCRIPTION
> Part 18 of a 20-commit stack. Stacked on #39 — review that first; the diff here against its base is a single commit.

The last piece: the things that keep a repository maintainable when its
maintainer is busy.

Release automation. A `vX.Y.Z` tag triggers a workflow that first refuses to
publish unless the tag equals `v{levy.__version__}`, read statically from the
AST. That guard is not hypothetical -- the tag `1.2` was cut from a tree whose
__version__ still read "1.1", so a release under those rules would have shipped
a wheel disagreeing with its own metadata. The built wheel is then installed
into a clean venv and asked to compute a known CDF value before anything goes
anywhere public.

Publishing goes through PyPI Trusted Publishing (OIDC). That choice matters
specifically here: an API token has to be minted by the account owner, stored as
a repository secret, and rotated -- three steps a dormant maintainer will not
do. Trusted Publishing needs one configuration on PyPI and then nothing ever
again. The lookup tables and their manifest are attached to the GitHub release,
which gives `levy-tables` a download fallback.

CI matrix. Linux x 3.9-3.13 as before, plus macOS and Windows at both ends of
the range, plus pinned NumPy 1.x *and* 2.x legs so the supported range is a
stated fact rather than whatever pip resolved this morning. Nine matrix legs
rather than the full fifteen: what differs across operating systems here is
libm and path handling, neither of which depends on the Python minor version.
Windows is not decorative -- `user_cache_dir()` has a LOCALAPPDATA branch that
had never been executed anywhere.

CONTRIBUTING.md and AGENTS.md. Both are organised around the one rule that
actually protects this package: numbers do not move by accident. A pull request
either leaves the golden file untouched or changes it deliberately and shows
that the new values are closer to `calculate_levy` ground truth -- and one that
regenerates the goldens without that evidence should be rejected however green
CI is. That is not a stylistic preference: the last substantive commit of the
1.x line changed the numerics and regenerated both lookup tables with nothing
protecting it, and nobody found out for five years.

CONTRIBUTING also documents uv as the local toolchain, and says why there is
deliberately no uv.lock: this is a library with dependency floors, and the
useful thing to test is the range, which the matrix does, not one frozen
resolution.

Also: CODE_OF_CONDUCT.md, CITATION.cff, issue forms that ask a numerical bug
report for a reproducer and an expected value, a pull-request template whose
central question is whether the goldens moved, Dependabot for pip *and* GitHub
Actions (the ecosystem that actually accrues security debt here), and
.pre-commit-config.yaml -- with the golden .jsonl excluded from whitespace
fixers, and a large-file guard set just above the table size, since an
accidental second copy of a 12 MB table is how .git reached 55 MB.

Two proposals for the owner, in docs/proposals/, covering what a pull request
cannot do:

* repo-governance.md -- branch protection with the golden-reproducibility check
  marked required, a CODEOWNERS to add once that rule exists, the reviewing
  policy, Trusted Publishing setup, enabling Pages, a description and topics for
  the empty "About" sidebar, and disposition of the three stale branches.
* pypi-name.md -- the package has never been published, and `pip install pylevy`
  installs Paul Harrison's 2005 original, the ancestor this was forked from.
  Ask `pfh` for co-ownership first, PEP 541 second, `levy-stable` as the
  fallback. The workflow reads the distribution name from pyproject.toml, so the
  decision does not block anything.

No source changes. Goldens unchanged; 871 tests pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

