### PR TITLE
Tolerate a conversion that overshoots the domain by 44 ULP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,14 +135,26 @@ you want the old behaviour and no deprecation noise.
 - `levy.size` was hardcoded into the index arithmetic, so tables at any other
   resolution raised `IndexError` — which defeated the point of `--size`.
 - The doctests: 4 of the 21 had been failing, and CI now runs them as a gate.
+- `fit_levy(x, par='B')` aborted with `ValueError: beta must be in [-1.0, 1.0],
+  got 1.0000000000000004` on 9 of 36 measured samples. Converting Zolotarev's
+  B into parametrization 0 evaluates two tangents whose rounding does not
+  cancel, so `beta_0` can land up to 44 ULP outside `[-1, 1]`. The domain check
+  added earlier in this release was exact, and turned that rounding into a lost
+  fit. Values within 1e-12 of an endpoint are now snapped to it; anything
+  further out is still rejected.
 
 ### Known issues
 
 - The CDF is discontinuous at the tail crossover, stepping down by up to
   2.6e-03. Fixing it means regenerating the crossover limits or reconciling the
   interpolated and asymptotic branches; tracked separately.
-- `par_bounds` uses parametrization-0 semantics for all five parametrizations,
-  so a fit in `'B'` searches the wrong feasible region. Tracked separately.
+- Maximum likelihood for stable distributions is not convex, and L-BFGS-B can
+  settle on a local optimum. Measured over 36 samples fitted in all five
+  parametrizations, the fit reached a worse optimum than the best of the five
+  in 1/36 cases for `'0'`, 0/36 for `'M'`, 2/36 for `'B'`, 4/36 for `'1'` and
+  7/36 for `'A'`, with gaps up to 29 log-likelihood units. Fitting in more than
+  one parametrization and keeping the best is a sound workaround. A
+  multi-start or a smarter initial guess would be the real fix.
 
 ## Versioning
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,14 +139,26 @@ you want the old behaviour and no deprecation noise.
 - `levy.size` was hardcoded into the index arithmetic, so tables at any other
   resolution raised `IndexError` — which defeated the point of `--size`.
 - The doctests: 4 of the 21 had been failing, and CI now runs them as a gate.
+- `fit_levy(x, par='B')` aborted with `ValueError: beta must be in [-1.0, 1.0],
+  got 1.0000000000000004` on 9 of 36 measured samples. Converting Zolotarev's
+  B into parametrization 0 evaluates two tangents whose rounding does not
+  cancel, so `beta_0` can land up to 44 ULP outside `[-1, 1]`. The domain check
+  added earlier in this release was exact, and turned that rounding into a lost
+  fit. Values within 1e-12 of an endpoint are now snapped to it; anything
+  further out is still rejected.
 
 ### Known issues
 
 - The CDF is discontinuous at the tail crossover, stepping down by up to
   2.6e-03. Fixing it means regenerating the crossover limits or reconciling the
   interpolated and asymptotic branches; tracked separately.
-- `par_bounds` uses parametrization-0 semantics for all five parametrizations,
-  so a fit in `'B'` searches the wrong feasible region. Tracked separately.
+- Maximum likelihood for stable distributions is not convex, and L-BFGS-B can
+  settle on a local optimum. Measured over 36 samples fitted in all five
+  parametrizations, the fit reached a worse optimum than the best of the five
+  in 1/36 cases for `'0'`, 0/36 for `'M'`, 2/36 for `'B'`, 4/36 for `'1'` and
+  7/36 for `'A'`, with gaps up to 29 log-likelihood units. Fitting in more than
+  one parametrization and keeping the best is a sound workaround. A
+  multi-start or a smarter initial guess would be the real fix.
 
 ## Versioning
 

--- a/src/levy/api.py
+++ b/src/levy/api.py
@@ -71,7 +71,9 @@ from levy._typing import (
     Seed,
     Size,
 )
+from levy.constants import _lower, _upper
 from levy.distribution import levy as _levy
+from levy.distribution import snap_into_domain
 from levy.fitting import fit_levy as _fit_levy
 from levy.parametrization import Parameters
 from levy.sampling import random as _random
@@ -162,9 +164,15 @@ class StableParams(BaseModel):
         values = np.asarray([alpha, beta, loc, scale], dtype='d')
         if par != '0':
             values = Parameters.convert(values, par, '0')
+        # Snap first, validate second. Converting from B evaluates two tangents
+        # whose rounding does not cancel, so a perfectly legal beta_B can land
+        # a few tens of ULP outside [-1, 1]; validating that literally would
+        # reject a parameter set that is in range. Only the rounding is
+        # absorbed -- anything further out passes through untouched and is
+        # rejected below with a ValidationError naming the field.
         return cls(
-            alpha=float(values[0]),
-            beta=float(values[1]),
+            alpha=snap_into_domain(float(values[0]), _lower[1], _upper[1]),
+            beta=snap_into_domain(float(values[1]), _lower[2], _upper[2]),
             mu=float(values[2]),
             sigma=float(values[3]),
         )
@@ -806,6 +814,11 @@ def fit(
 
     parameters, nll = _fit_levy(as_sample(x), par=par, **fixed)
     alpha, beta, mu, sigma = (float(v) for v in parameters.get('0'))
+    # A fit in B can report a beta_0 a few ULP outside [-1, 1] for the same
+    # rounding reason as from_par. Without this, fit() raised a ValidationError
+    # on the result it had just successfully computed.
+    alpha = snap_into_domain(alpha, _lower[1], _upper[1])
+    beta = snap_into_domain(beta, _lower[2], _upper[2])
     return FitResult(
         params=StableParams(alpha=alpha, beta=beta, mu=mu, sigma=sigma),
         negative_log_likelihood=float(nll),

--- a/src/levy/api.py
+++ b/src/levy/api.py
@@ -72,8 +72,9 @@ from levy._typing import (
     Seed,
     Size,
 )
-from levy.constants import par_names
+from levy.constants import _lower, _upper, par_names
 from levy.distribution import levy as _levy
+from levy.distribution import snap_into_domain
 from levy.fitting import fit_levy as _fit_levy
 from levy.parametrization import Parameters
 from levy.sampling import random as _random
@@ -187,9 +188,15 @@ class StableParams(BaseModel):
         values = np.asarray([alpha, beta, loc, scale], dtype='d')
         if par != '0':
             values = Parameters.convert(values, par, '0')
+        # Snap first, validate second. Converting from B evaluates two tangents
+        # whose rounding does not cancel, so a perfectly legal beta_B can land
+        # a few tens of ULP outside [-1, 1]; validating that literally would
+        # reject a parameter set that is in range. Only the rounding is
+        # absorbed -- anything further out passes through untouched and is
+        # rejected below with a ValidationError naming the field.
         return cls(
-            alpha=float(values[0]),
-            beta=float(values[1]),
+            alpha=snap_into_domain(float(values[0]), _lower[1], _upper[1]),
+            beta=snap_into_domain(float(values[1]), _lower[2], _upper[2]),
             mu=float(values[2]),
             sigma=float(values[3]),
         )
@@ -954,6 +961,11 @@ def fit(
 
     parameters, nll = _fit_levy(as_sample(x), par=par, **pinned)
     alpha, beta, mu, sigma = (float(v) for v in parameters.get('0'))
+    # A fit in B can report a beta_0 a few ULP outside [-1, 1] for the same
+    # rounding reason as from_par. Without this, fit() raised a ValidationError
+    # on the result it had just successfully computed.
+    alpha = snap_into_domain(alpha, _lower[1], _upper[1])
+    beta = snap_into_domain(beta, _lower[2], _upper[2])
     return FitResult(
         params=StableParams(alpha=alpha, beta=beta, mu=mu, sigma=sigma),
         negative_log_likelihood=float(nll),

--- a/src/levy/backends/_torch.py
+++ b/src/levy/backends/_torch.py
@@ -263,7 +263,7 @@ def _evaluate(x, alpha, beta, mu, sigma, cdf):
         else float(alpha_t.detach())
     beta_value = float(beta_t.detach().reshape(-1)[0]) if beta_t.dim() \
         else float(beta_t.detach())
-    _check_alpha_beta(alpha_value, beta_value)
+    alpha_value, beta_value = _check_alpha_beta(alpha_value, beta_value)
 
     table = _table('cdf' if cdf else 'pdf', x)
     lower_limit = _table('lower_limit', x)

--- a/src/levy/backends/_torch.py
+++ b/src/levy/backends/_torch.py
@@ -276,7 +276,7 @@ def _evaluate(x, alpha, beta, mu, sigma, cdf):
         else float(alpha_t.detach())
     beta_value = float(beta_t.detach().reshape(-1)[0]) if beta_t.dim() \
         else float(beta_t.detach())
-    _check_alpha_beta(alpha_value, beta_value)
+    alpha_value, beta_value = _check_alpha_beta(alpha_value, beta_value)
 
     table = _table('cdf' if cdf else 'pdf', x)
     lower_limit = _table('lower_limit', x)

--- a/src/levy/distribution.py
+++ b/src/levy/distribution.py
@@ -22,11 +22,29 @@ from levy.constants import _lower, _upper
 from levy.interpolation import _interpolate
 from levy.tables import _read_from_cache
 
-__all__ = ['levy', 'neglog_levy']
+__all__ = ['levy', 'neglog_levy', 'snap_into_domain']
+
+
+# A parameter this far outside the tabulated range is a conversion that
+# overshot the endpoint, not a caller asking for something unsupported.
+#
+# Only parametrization B overshoots at all: `beta_0 = tan(beta_B * psi(alpha)) /
+# tan(alpha * pi / 2)` is exactly +-1 at beta_B = +-1 in exact arithmetic, but
+# the two tangents are evaluated separately and their rounding does not cancel.
+# Swept over a 601 x 601 grid of (alpha, beta_B) covering the whole box, 76 of
+# 361,201 points land outside [-1, 1], by at most 9.77e-15 -- 44 ULP. The other
+# four parametrizations are exact everywhere on the same sweep.
+#
+# 1e-12 is ~4500 ULP: two orders of magnitude of headroom over what was
+# measured, and still eleven orders below the smallest mistake a caller could
+# plausibly make (alpha=0.4 misses by 0.1). Values inside the tolerance are
+# snapped to the endpoint rather than merely accepted, so nothing downstream
+# has to think about it again.
+_DOMAIN_TOLERANCE = 1e-12
 
 
 def _check_alpha_beta(alpha, beta):
-    """Reject parameters the lookup tables do not cover.
+    """Reject parameters the lookup tables do not cover, and snap the endpoints.
 
     Parameters
     ----------
@@ -35,29 +53,103 @@ def _check_alpha_beta(alpha, beta):
     beta : float
         Skewness, must lie in ``[-1, 1]``.
 
+    Returns
+    -------
+    alpha : float
+        `alpha`, clamped to the tabulated range if it was within
+        ``_DOMAIN_TOLERANCE`` of an endpoint.
+    beta : float
+        `beta`, clamped the same way.
+
     Raises
     ------
     ValueError
-        If either parameter falls outside the tabulated range.
+        If either parameter falls outside the tabulated range by more than the
+        tolerance.
 
     Notes
     -----
-    Without this, `alpha` below 0.5 produced a *negative* grid index, which is
-    a perfectly valid Python index: ``alpha=0.4`` gave -4 and silently returned
-    the limits for ``alpha ~ 1.94``. The old ``except IndexError`` guard only
-    fired for positive overflow, so under-range values failed silently while
-    over-range values raised.
+    Without the check, `alpha` below 0.5 produced a *negative* grid index, which
+    is a perfectly valid Python index: ``alpha=0.4`` gave -4 and silently
+    returned the limits for ``alpha ~ 1.94``. The old ``except IndexError``
+    guard only fired for positive overflow, so under-range values failed
+    silently while over-range values raised.
+
+    The tolerance exists because checking exactly was too strict to be correct.
+    Converting parameters from Zolotarev's B into 0 can overshoot ``beta = 1``
+    by a few tens of ULP, and an exact check turned that rounding into a
+    ``ValueError`` that aborted an entire ``fit_levy(x, par='B')``. See the
+    comment on ``_DOMAIN_TOLERANCE``.
     """
-    if not (_lower[1] <= alpha <= _upper[1]):
-        raise ValueError(
-            f'alpha must be in [{_lower[1]}, {_upper[1]}], got {alpha!r}. pylevy '
-            'interpolates from a lookup table that does not cover values '
-            'outside that range.'
-        )
-    if not (_lower[2] <= beta <= _upper[2]):
-        raise ValueError(
-            f'beta must be in [{_lower[2]}, {_upper[2]}], got {beta!r}.'
-        )
+    alpha = _snap(alpha, _lower[1], _upper[1], 'alpha')
+    beta = _snap(beta, _lower[2], _upper[2], 'beta')
+    return alpha, beta
+
+
+def snap_into_domain(value, low, high):
+    """Clamp a value that is within tolerance of its range, and nothing else.
+
+    Parameters
+    ----------
+    value : float
+        The parameter.
+    low : float
+        Lower end of the tabulated range, inclusive.
+    high : float
+        Upper end of the tabulated range, inclusive.
+
+    Returns
+    -------
+    float
+        The endpoint, if `value` was within ``_DOMAIN_TOLERANCE`` of it;
+        otherwise `value` unchanged. Never raises -- a value further out is
+        left alone for the caller to reject in whatever way suits it.
+
+    Notes
+    -----
+    Separate from :func:`_check_alpha_beta` so that :mod:`levy.api` can snap
+    without inheriting the ``ValueError``: everything that fails validation
+    there should surface as a pydantic ``ValidationError``, naming the field.
+    """
+    if low <= value <= high:
+        return value
+    if low - _DOMAIN_TOLERANCE <= value <= high + _DOMAIN_TOLERANCE:
+        return min(high, max(low, value))
+    return value
+
+
+def _snap(value, low, high, name):
+    """Clamp a value that is within tolerance of its range, or reject it.
+
+    Parameters
+    ----------
+    value : float
+        The parameter.
+    low : float
+        Lower end of the tabulated range, inclusive.
+    high : float
+        Upper end of the tabulated range, inclusive.
+    name : str
+        Parameter name, for the error message.
+
+    Returns
+    -------
+    float
+        `value`, or the endpoint it was within ``_DOMAIN_TOLERANCE`` of.
+
+    Raises
+    ------
+    ValueError
+        If `value` is outside the range by more than the tolerance.
+    """
+    snapped = snap_into_domain(value, low, high)
+    if low <= snapped <= high:
+        return snapped
+    raise ValueError(
+        f'{name} must be in [{low}, {high}], got {value!r}. pylevy '
+        'interpolates from a lookup table that does not cover values '
+        'outside that range.'
+    )
 
 
 def _grid_shape():
@@ -215,7 +307,7 @@ def levy(x, alpha, beta, mu=0.0, sigma=1.0, cdf=False):
     >>> np.round(levy(x, 1.5, 0.0), 6)
     array([0.202038, 0.084539, 0.031509])
     """
-    _check_alpha_beta(alpha, beta)
+    alpha, beta = _check_alpha_beta(alpha, beta)
 
     loc = mu
 

--- a/tests/test_domain_tolerance.py
+++ b/tests/test_domain_tolerance.py
@@ -1,0 +1,222 @@
+"""A conversion that overshoots an endpoint by 44 ULP is not a domain error.
+
+Validating alpha and beta against the tabulated range was the right fix for a
+real bug -- alpha below 0.5 used to produce a negative grid index and silently
+return values for alpha ~ 1.94. But checking the range *exactly* was too strict
+to be correct, and it broke a whole parametrization.
+
+`beta_0 = tan(beta_B * psi(alpha)) / tan(alpha * pi / 2)` is exactly +-1 at
+beta_B = +-1 in exact arithmetic. The two tangents are evaluated separately and
+their rounding does not cancel, so the quotient can land a few tens of ULP
+outside [-1, 1]. An exact check turned that into a ValueError that aborted the
+entire fit.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+import levy
+from levy.distribution import _DOMAIN_TOLERANCE, _check_alpha_beta
+from levy.distribution import levy as levy_pdf
+from levy.fitting import fit_levy
+from levy.parametrization import convert_to_par0
+from levy.sampling import random
+
+PARS = ["0", "1", "M", "A", "B"]
+
+
+# --------------------------------------------------------------------------
+# the regression: a fit in B used to abort
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("alpha", "beta"), [
+    (1.7, 0.95),
+    (1.9, 1.0),
+    (1.95, -1.0),
+    (1.99, 0.99),
+])
+@pytest.mark.parametrize("par", PARS)
+def test_fitting_near_the_skewness_boundary_completes(par, alpha, beta):
+    # Before the tolerance, par='B' raised
+    #   ValueError: beta must be in [-1.0, 1.0], got 1.0000000000000004
+    # partway through the optimisation, losing the whole fit.
+    np.random.seed(7)
+    sample = random(alpha, beta, 0.0, 1.0, shape=(600,))
+    parameters, nll = fit_levy(sample, par=par)
+    assert np.isfinite(nll)
+
+    # The contract that matters is not that the reported parameters sit inside
+    # [-1, 1] to the last bit -- a fit in B can report beta_0 a few ULP outside
+    # it, for the same rounding reason -- but that whatever comes out can be
+    # fed straight back in.
+    fitted = parameters.get("0")
+    density = levy_pdf(np.array([0.0, 1.0]), fitted[0], fitted[1])
+    assert np.all(np.isfinite(density))
+
+
+def test_all_five_parametrizations_reach_the_same_optimum_there():
+    np.random.seed(7)
+    sample = random(1.7, 0.95, 0.0, 1.0, shape=(1500,))
+    likelihoods = {par: fit_levy(sample, par=par)[1] for par in PARS}
+    best = min(likelihoods.values())
+    for par, nll in likelihoods.items():
+        assert nll - best < 1e-6, f"par={par} reached {nll}, best was {best}"
+
+
+# --------------------------------------------------------------------------
+# the overshoot itself, measured
+# --------------------------------------------------------------------------
+
+def test_only_parametrization_b_overshoots_and_only_by_a_few_ulp():
+    # The numbers in the comment on _DOMAIN_TOLERANCE, kept honest. A coarser
+    # sweep than the one quoted there, so the test stays quick.
+    alphas = np.linspace(0.5, 2.0, 151)
+    betas = np.linspace(-1.0, 1.0, 151)
+
+    worst = {par: 0.0 for par in PARS}
+    for par in PARS:
+        for alpha in alphas:
+            for beta in betas:
+                converted = convert_to_par0[par](np.array([alpha, beta, 0.0, 1.0]))
+                value = converted[1]
+                if np.isfinite(value):
+                    worst[par] = max(worst[par], abs(value) - 1.0)
+
+    for par in ("0", "1", "M", "A"):
+        assert worst[par] <= 0.0, f"par={par} overshoots by {worst[par]:.3e}"
+
+    assert worst["B"] > 0.0, "B no longer overshoots; the tolerance may be dead code"
+    assert worst["B"] < _DOMAIN_TOLERANCE, (
+        f"B overshoots by {worst['B']:.3e}, which the {_DOMAIN_TOLERANCE:.0e} "
+        "tolerance no longer covers"
+    )
+
+
+def test_the_tolerance_has_orders_of_magnitude_of_headroom():
+    # Measured worst overshoot is 9.77e-15 on a 601x601 sweep. The tolerance
+    # should sit well above that and far below any real mistake.
+    assert _DOMAIN_TOLERANCE > 1e-13
+    assert _DOMAIN_TOLERANCE < 1e-9
+
+
+# --------------------------------------------------------------------------
+# what the tolerance must not let through
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("alpha", "beta"), [
+    (0.4, 0.0),        # the original bug: gave a negative grid index
+    (0.49999, 0.0),
+    (2.1, 0.0),
+    (2.000001, 0.0),
+    (1.5, -1.5),
+    (1.5, 1.000001),
+    (0.0, 0.0),
+    (-1.0, 0.0),
+])
+def test_genuinely_out_of_range_values_are_still_rejected(alpha, beta):
+    with pytest.raises(ValueError):
+        levy_pdf(np.array([1.0]), alpha, beta)
+
+
+def test_the_smallest_plausible_mistake_is_still_far_outside_the_tolerance():
+    # alpha=0.4 misses by 0.1, which is eleven orders of magnitude larger than
+    # the tolerance. There is no overlap between "rounding" and "wrong".
+    assert 0.1 / _DOMAIN_TOLERANCE > 1e10
+
+
+# --------------------------------------------------------------------------
+# snapping
+# --------------------------------------------------------------------------
+
+def test_values_inside_the_tolerance_are_snapped_to_the_endpoint():
+    alpha, beta = _check_alpha_beta(2.0 + 1e-15, 1.0 + 1e-15)
+    assert alpha == 2.0
+    assert beta == 1.0
+
+    alpha, beta = _check_alpha_beta(0.5 - 1e-15, -1.0 - 1e-15)
+    assert alpha == 0.5
+    assert beta == -1.0
+
+
+def test_values_inside_the_range_are_returned_untouched():
+    alpha, beta = _check_alpha_beta(1.3456789, -0.4321)
+    assert alpha == 1.3456789
+    assert beta == -0.4321
+
+
+def test_snapping_changes_the_result_by_nothing_measurable():
+    x = np.linspace(-6.0, 6.0, 121)
+    at_edge = levy_pdf(x, 2.0, 1.0)
+    just_over = levy_pdf(x, 2.0 + 1e-15, 1.0 + 1e-15)
+    assert np.array_equal(at_edge, just_over)
+
+
+# --------------------------------------------------------------------------
+# the deprecated surface behaves the same way
+# --------------------------------------------------------------------------
+
+def test_the_1x_function_is_fixed_too():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        np.random.seed(7)
+        sample = levy.random(1.7, 0.95, 0.0, 1.0, shape=(600,))
+        parameters, nll = levy.fit_levy(sample, par="B")
+    assert np.isfinite(nll)
+
+
+def test_the_typed_api_still_rejects_out_of_range_before_the_tables():
+    from pydantic import ValidationError
+
+    from levy import api
+
+    with pytest.raises(ValidationError):
+        api.pdf(np.array([1.0]), alpha=0.4, beta=0.0)
+
+
+# --------------------------------------------------------------------------
+# the typed API used to reject its own results
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("alpha", "beta"), [
+    (1.95, -1.0),
+    (1.9, 1.0),
+    (1.7, 0.95),
+])
+@pytest.mark.parametrize("par", PARS)
+def test_api_fit_accepts_the_result_it_just_computed(par, alpha, beta):
+    # StableParams bounds beta at -1, and a fit in B can produce
+    # -1.000000000000002, so api.fit raised a ValidationError on a fit that had
+    # completed perfectly well. Snapping happens before validation now.
+    from levy import api
+
+    np.random.seed(7)
+    sample = random(alpha, beta, 0.0, 1.0, shape=(600,))
+    result = api.fit(sample, par=par)
+    assert -1.0 <= result.params.beta <= 1.0
+    assert 0.5 <= result.params.alpha <= 2.0
+    assert np.isfinite(result.negative_log_likelihood)
+
+
+@pytest.mark.parametrize("par", PARS)
+def test_from_par_accepts_the_endpoints_of_its_own_parametrization(par):
+    from levy import api
+
+    for beta in (-1.0, 1.0):
+        for alpha in (0.5, 1.0, 1.5, 1.95, 2.0):
+            params = api.StableParams.from_par(alpha, beta, 0.0, 1.0, par=par)
+            assert -1.0 <= params.beta <= 1.0
+            assert 0.5 <= params.alpha <= 2.0
+
+
+def test_a_fit_result_round_trips_back_into_the_evaluator():
+    from levy import api
+
+    np.random.seed(7)
+    sample = random(1.95, -1.0, 0.0, 1.0, shape=(600,))
+    params = api.fit(sample, par="B").params
+    values = api.pdf(np.array([-1.0, 0.0, 1.0]), **params.as_kwargs())
+    assert np.all(np.isfinite(values))

--- a/tests/test_domain_tolerance.py
+++ b/tests/test_domain_tolerance.py
@@ -1,0 +1,238 @@
+"""A conversion that overshoots an endpoint by 44 ULP is not a domain error.
+
+Validating alpha and beta against the tabulated range was the right fix for a
+real bug -- alpha below 0.5 used to produce a negative grid index and silently
+return values for alpha ~ 1.94. But checking the range *exactly* was too strict
+to be correct, and it broke a whole parametrization.
+
+`beta_0 = tan(beta_B * psi(alpha)) / tan(alpha * pi / 2)` is exactly +-1 at
+beta_B = +-1 in exact arithmetic. The two tangents are evaluated separately and
+their rounding does not cancel, so the quotient can land a few tens of ULP
+outside [-1, 1]. An exact check turned that into a ValueError that aborted the
+entire fit.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+import levy
+from levy.distribution import _DOMAIN_TOLERANCE, _check_alpha_beta
+from levy.distribution import levy as levy_pdf
+from levy.fitting import fit_levy
+from levy.parametrization import convert_to_par0
+from levy.sampling import random
+
+PARS = ["0", "1", "M", "A", "B"]
+
+#: How far apart the five parametrizations' optima may lie, in negative log
+#: likelihood, and still count as the same optimum. L-BFGS-B stops when the
+#: relative decrease of the objective drops below its default ftol of 2.2e-9,
+#: which at an NLL of ~2900 is ~6e-6 absolute -- anything tighter than that
+#: compares optimizer noise, not optima. The measured spread on macOS/arm64 is
+#: 5.6e-9; 1e-3 leaves two orders of magnitude over ftol and five over the
+#: measurement, while the failure this guards against -- B aborting, or B
+#: landing +22 NLL away as it did on the issue-20 sample -- is far larger.
+SAME_OPTIMUM_NLL = 1e-3
+
+
+# --------------------------------------------------------------------------
+# the regression: a fit in B used to abort
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("alpha", "beta"), [
+    (1.7, 0.95),
+    (1.9, 1.0),
+    (1.95, -1.0),
+    (1.99, 0.99),
+])
+@pytest.mark.parametrize("par", PARS)
+def test_fitting_near_the_skewness_boundary_completes(par, alpha, beta):
+    # Before the tolerance, par='B' raised
+    #   ValueError: beta must be in [-1.0, 1.0], got 1.0000000000000004
+    # partway through the optimisation, losing the whole fit.
+    np.random.seed(7)
+    sample = random(alpha, beta, 0.0, 1.0, shape=(600,))
+    parameters, nll = fit_levy(sample, par=par)
+    assert np.isfinite(nll)
+
+    # The contract that matters is not that the reported parameters sit inside
+    # [-1, 1] to the last bit -- a fit in B can report beta_0 a few ULP outside
+    # it, for the same rounding reason -- but that whatever comes out can be
+    # fed straight back in.
+    fitted = parameters.get("0")
+    density = levy_pdf(np.array([0.0, 1.0]), fitted[0], fitted[1])
+    assert np.all(np.isfinite(density))
+
+
+def test_all_five_parametrizations_reach_the_same_optimum_there():
+    np.random.seed(7)
+    sample = random(1.7, 0.95, 0.0, 1.0, shape=(1500,))
+    likelihoods = {par: fit_levy(sample, par=par)[1] for par in PARS}
+    best = min(likelihoods.values())
+    for par, nll in likelihoods.items():
+        assert nll - best < SAME_OPTIMUM_NLL, f"par={par} reached {nll}, best was {best}"
+
+
+# --------------------------------------------------------------------------
+# the overshoot itself, measured
+# --------------------------------------------------------------------------
+
+def test_only_parametrization_b_overshoots_and_only_by_a_few_ulp():
+    # The numbers in the comment on _DOMAIN_TOLERANCE, kept honest. A coarser
+    # sweep than the one quoted there, so the test stays quick.
+    alphas = np.linspace(0.5, 2.0, 151)
+    betas = np.linspace(-1.0, 1.0, 151)
+
+    worst = {par: 0.0 for par in PARS}
+    for par in PARS:
+        for alpha in alphas:
+            for beta in betas:
+                converted = convert_to_par0[par](np.array([alpha, beta, 0.0, 1.0]))
+                value = converted[1]
+                if np.isfinite(value):
+                    worst[par] = max(worst[par], abs(value) - 1.0)
+
+    for par in ("0", "1", "M", "A"):
+        assert worst[par] <= 0.0, f"par={par} overshoots by {worst[par]:.3e}"
+
+    if worst["B"] <= 0.0:
+        # Whether B overshoots at all is a property of libm's tan; the
+        # tolerance is just as correct on a platform where it happens not
+        # to. It does on all three CI operating systems (2.4e-15 measured on
+        # macOS/arm64), so a platform where it does not is worth a skip
+        # message, not a red build.
+        pytest.skip("parametrization B does not overshoot on this platform's libm")
+    assert worst["B"] < _DOMAIN_TOLERANCE, (
+        f"B overshoots by {worst['B']:.3e}, which the {_DOMAIN_TOLERANCE:.0e} "
+        "tolerance no longer covers"
+    )
+
+
+def test_the_tolerance_has_orders_of_magnitude_of_headroom():
+    # Measured worst overshoot is 9.77e-15 on a 601x601 sweep. The tolerance
+    # should sit well above that and far below any real mistake.
+    assert _DOMAIN_TOLERANCE > 1e-13
+    assert _DOMAIN_TOLERANCE < 1e-9
+
+
+# --------------------------------------------------------------------------
+# what the tolerance must not let through
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("alpha", "beta"), [
+    (0.4, 0.0),        # the original bug: gave a negative grid index
+    (0.49999, 0.0),
+    (2.1, 0.0),
+    (2.000001, 0.0),
+    (1.5, -1.5),
+    (1.5, 1.000001),
+    (0.0, 0.0),
+    (-1.0, 0.0),
+])
+def test_genuinely_out_of_range_values_are_still_rejected(alpha, beta):
+    with pytest.raises(ValueError):
+        levy_pdf(np.array([1.0]), alpha, beta)
+
+
+def test_the_smallest_plausible_mistake_is_still_far_outside_the_tolerance():
+    # alpha=0.4 misses by 0.1, which is eleven orders of magnitude larger than
+    # the tolerance. There is no overlap between "rounding" and "wrong".
+    assert 0.1 / _DOMAIN_TOLERANCE > 1e10
+
+
+# --------------------------------------------------------------------------
+# snapping
+# --------------------------------------------------------------------------
+
+def test_values_inside_the_tolerance_are_snapped_to_the_endpoint():
+    alpha, beta = _check_alpha_beta(2.0 + 1e-15, 1.0 + 1e-15)
+    assert alpha == 2.0
+    assert beta == 1.0
+
+    alpha, beta = _check_alpha_beta(0.5 - 1e-15, -1.0 - 1e-15)
+    assert alpha == 0.5
+    assert beta == -1.0
+
+
+def test_values_inside_the_range_are_returned_untouched():
+    alpha, beta = _check_alpha_beta(1.3456789, -0.4321)
+    assert alpha == 1.3456789
+    assert beta == -0.4321
+
+
+def test_snapping_changes_the_result_by_nothing_measurable():
+    x = np.linspace(-6.0, 6.0, 121)
+    at_edge = levy_pdf(x, 2.0, 1.0)
+    just_over = levy_pdf(x, 2.0 + 1e-15, 1.0 + 1e-15)
+    assert np.array_equal(at_edge, just_over)
+
+
+# --------------------------------------------------------------------------
+# the deprecated surface behaves the same way
+# --------------------------------------------------------------------------
+
+def test_the_1x_function_is_fixed_too():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        np.random.seed(7)
+        sample = levy.random(1.7, 0.95, 0.0, 1.0, shape=(600,))
+        parameters, nll = levy.fit_levy(sample, par="B")
+    assert np.isfinite(nll)
+
+
+def test_the_typed_api_still_rejects_out_of_range_before_the_tables():
+    from pydantic import ValidationError
+
+    from levy import api
+
+    with pytest.raises(ValidationError):
+        api.pdf(np.array([1.0]), alpha=0.4, beta=0.0)
+
+
+# --------------------------------------------------------------------------
+# the typed API used to reject its own results
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(("alpha", "beta"), [
+    (1.95, -1.0),
+    (1.9, 1.0),
+    (1.7, 0.95),
+])
+@pytest.mark.parametrize("par", PARS)
+def test_api_fit_accepts_the_result_it_just_computed(par, alpha, beta):
+    # StableParams bounds beta at -1, and a fit in B can produce
+    # -1.000000000000002, so api.fit raised a ValidationError on a fit that had
+    # completed perfectly well. Snapping happens before validation now.
+    from levy import api
+
+    np.random.seed(7)
+    sample = random(alpha, beta, 0.0, 1.0, shape=(600,))
+    result = api.fit(sample, par=par)
+    assert -1.0 <= result.params.beta <= 1.0
+    assert 0.5 <= result.params.alpha <= 2.0
+    assert np.isfinite(result.negative_log_likelihood)
+
+
+@pytest.mark.parametrize("par", PARS)
+def test_from_par_accepts_the_endpoints_of_its_own_parametrization(par):
+    from levy import api
+
+    for beta in (-1.0, 1.0):
+        for alpha in (0.5, 1.0, 1.5, 1.95, 2.0):
+            params = api.StableParams.from_par(alpha, beta, 0.0, 1.0, par=par)
+            assert -1.0 <= params.beta <= 1.0
+            assert 0.5 <= params.alpha <= 2.0
+
+
+def test_a_fit_result_round_trips_back_into_the_evaluator():
+    from levy import api
+
+    np.random.seed(7)
+    sample = random(1.95, -1.0, 0.0, 1.0, shape=(600,))
+    params = api.fit(sample, par="B").params
+    values = api.pdf(np.array([-1.0, 0.0, 1.0]), **params.as_kwargs())
+    assert np.all(np.isfinite(values))


### PR DESCRIPTION
> Part 19 of a 20-commit stack. Stacked on #40 — review that first; the diff here against its base is a single commit.

`fit_levy(x, par='B')` aborted with

    ValueError: beta must be in [-1.0, 1.0], got 1.0000000000000004

on **9 of 36 measured samples**. Validating alpha and beta against the
tabulated range was the right fix for a real bug, but checking the range
exactly was too strict to be correct, and it broke a whole parametrization.

`beta_0 = tan(beta_B * psi(alpha)) / tan(alpha * pi / 2)` is exactly +-1 at
beta_B = +-1 in exact arithmetic. The two tangents are evaluated separately and
their rounding does not cancel, so the quotient can land just outside [-1, 1].
Swept over a 601 x 601 grid covering the whole box: **76 of 361,201 points
overshoot, by at most 9.77e-15 -- 44 ULP.** The other four parametrizations are
exact everywhere on the same sweep, which is why only B was affected.

Values within 1e-12 of an endpoint are now snapped to it. That is ~4500 ULP,
two orders of magnitude above what was measured, and still eleven orders below
the smallest mistake a caller could plausibly make: alpha=0.4 misses by 0.1.
There is no overlap between "rounding" and "wrong", and the original bug --
alpha below 0.5 giving a negative grid index and silently returning values for
alpha ~ 1.94 -- is still caught.

Before and after, 12 truths x 3 seeds x 5 parametrizations:

    par | crashes before | crashes after | worse than best | max gap
      0 |       0        |       0       |     1 / 36      |  0.0000
      1 |       0        |       0       |     4 / 36      | 18.7053
      M |       0        |       0       |     0 / 36      |  0.0000
      A |       0        |       0       |     7 / 36      | 29.2435
      B |       9        |       0       |     2 / 36      | 19.3552

Every column except `crashes` is identical before and after: this removes the
abort and changes nothing else. Install parity against the parent commit is
bit-exact over 99,312 values, and the goldens do not move.

A second bug, same root cause, found while testing the first: **`api.fit(x,
par='B')` raised a ValidationError on the fit it had just successfully
computed.** StableParams bounds beta at -1, and the fit reported
-1.000000000000002. `api.fit` and `StableParams.from_par` now snap before
validating. They use a non-raising helper rather than the domain check itself,
so a value genuinely out of range still surfaces as a pydantic
ValidationError naming the field, not a ValueError -- there is a test from the
typed-API PR that pins exactly that, and it caught my first attempt.

Also corrects a claim I put in the changelog. It said `par_bounds` applies
parametrization-0 semantics to all five, so a fit in 'B' searches the wrong
feasible region. That is **not what happens**: measured over the same 601 x 601
sweep, the beta_B box maps onto beta_0 with max |beta_0| of exactly 1.000000.
The real residual issue is that maximum likelihood for stable distributions is
not convex and L-BFGS-B can settle on a local optimum -- in *every*
parametrization, including 0 itself. The changelog now says that, with the
measured rates, instead of the wrong thing.

37 new tests (929 total).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

