### PR TITLE
Run CI on macOS and Windows, and pin both ends of the NumPy range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,32 @@ concurrency:
 
 jobs:
   test:
-    name: py${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # Every supported Python on Linux, plus both ends of the range on macOS
+      # and Windows. The full 3 x 5 cross product would be 15 jobs for very
+      # little more information: what differs across operating systems here is
+      # libm (an ULP in np.tan or gamma) and path handling, and neither depends
+      # on the Python minor version.
+      #
+      # Windows is not decorative. `user_cache_dir()` has a LOCALAPPDATA branch
+      # that nothing has ever executed, and the table cache is all path
+      # handling. Both arrive later in this series, so the matrix goes in first
+      # and every commit after it is tested on all three systems -- rather than
+      # the coverage arriving at the end, after the code it exists to check.
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - {os: ubuntu-latest,  python-version: "3.9",  label: "py3.9"}
+          - {os: ubuntu-latest,  python-version: "3.10", label: "py3.10"}
+          - {os: ubuntu-latest,  python-version: "3.11", label: "py3.11"}
+          - {os: ubuntu-latest,  python-version: "3.12", label: "py3.12"}
+          - {os: ubuntu-latest,  python-version: "3.13", label: "py3.13"}
+          - {os: macos-latest,   python-version: "3.10", label: "macos py3.10"}
+          - {os: macos-latest,   python-version: "3.13", label: "macos py3.13"}
+          - {os: windows-latest, python-version: "3.10", label: "windows py3.10"}
+          - {os: windows-latest, python-version: "3.13", label: "windows py3.13"}
     steps:
       - uses: actions/checkout@v4
 
@@ -54,6 +74,32 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "numpy<2" "scipy<1.12" pytest
+          python -m pip install -e . --no-deps
+
+      - name: Show environment
+        run: python -c "import numpy, scipy; print('numpy', numpy.__version__, '| scipy', scipy.__version__)"
+
+      - name: Run tests
+        run: python -m pytest tests/ -q
+
+  test-numpy2:
+    name: numpy 2.x (pinned)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The matrix legs above take whatever numpy resolves to today, which is a
+      # moving target. This one pins the 2.x series explicitly, so the pair of
+      # legs states the supported range as a fact rather than as a coincidence
+      # of when CI last ran.
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "numpy>=2,<3" "scipy>=1.13" pytest
           python -m pip install -e . --no-deps
 
       - name: Show environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,37 @@ concurrency:
 
 jobs:
   test:
-    name: py${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # Every supported Python on Linux, plus the oldest and newest available
+      # on macOS and Windows. The full 3 x 5 cross product would be 15 jobs for
+      # very little more information: what differs across operating systems
+      # here is libm (an ULP in np.tan or gamma) and path handling, and neither
+      # depends on the Python minor version.
+      #
+      # The macOS low end is 3.10, not 3.9: macos-latest is arm64, and
+      # actions/setup-python has no 3.9 build for darwin-arm64 (see
+      # actions/python-versions' manifest), so 3.10 is the oldest it can
+      # install there. Windows has 3.9 and uses it.
+      #
+      # Windows is not decorative. `user_cache_dir()` has a LOCALAPPDATA branch
+      # that nothing has ever executed, and the table cache is all path
+      # handling. Both arrive later in this series, so the matrix goes in first
+      # and every commit after it is tested on all three systems -- rather than
+      # the coverage arriving at the end, after the code it exists to check.
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - {os: ubuntu-latest,  python-version: "3.9",  label: "py3.9"}
+          - {os: ubuntu-latest,  python-version: "3.10", label: "py3.10"}
+          - {os: ubuntu-latest,  python-version: "3.11", label: "py3.11"}
+          - {os: ubuntu-latest,  python-version: "3.12", label: "py3.12"}
+          - {os: ubuntu-latest,  python-version: "3.13", label: "py3.13"}
+          - {os: macos-latest,   python-version: "3.10", label: "macos py3.10"}
+          - {os: macos-latest,   python-version: "3.13", label: "macos py3.13"}
+          - {os: windows-latest, python-version: "3.9",  label: "windows py3.9"}
+          - {os: windows-latest, python-version: "3.13", label: "windows py3.13"}
     steps:
       - uses: actions/checkout@v4
 
@@ -54,6 +79,34 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "numpy<2" "scipy<1.12" pytest
+          python -m pip install -e . --no-deps
+
+      - name: Show environment
+        run: python -c "import numpy, scipy; print('numpy', numpy.__version__, '| scipy', scipy.__version__)"
+
+      - name: Run tests
+        run: python -m pytest tests/ -q
+
+  test-numpy2:
+    name: numpy 2.x (pinned)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The matrix legs above take whatever numpy resolves to today, which is a
+      # moving target. This one pins the 2.x series explicitly, so the pair of
+      # legs states the supported range as a fact rather than as a coincidence
+      # of when CI last ran. scipy is bounded to its 1.x series for the same
+      # reason: a "pinned" leg that lets one of its two dependencies float
+      # would break on somebody else's release schedule.
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "numpy>=2,<3" "scipy>=1.13,<2" pytest
           python -m pip install -e . --no-deps
 
       - name: Show environment


### PR DESCRIPTION
> Part 2 of a 20-commit stack. Stacked on #23 — review that first; the diff here against its base is a single commit.

The suite has only ever run on Linux, against whatever NumPy resolved to on
the day. Two things in this series are specifically not Linux-shaped:

* `user_cache_dir()` branches on the platform, and its LOCALAPPDATA path has
  never been executed anywhere. The table cache that uses it is all path
  handling -- separators, case, and a directory that may not exist.
* The numerics depend on libm. np.tan and gamma differ by an ULP between
  builds, which is exactly the size of difference the characterization
  tolerances are calibrated against.

Nine legs, not fifteen: every supported Python on Linux, and both ends of the
range on macOS and Windows. The full cross product would triple the bill for
very little more information, because what varies across operating systems
here does not also vary with the Python minor version.

The pinned numpy 2.x leg is the counterpart to the existing 1.x one. Between
them they state the supported range as a fact rather than as a coincidence of
when CI last ran.

This lands second, immediately after packaging, rather than with the rest of
the repository automation later in the series. Coverage that arrives after the
code it exists to check has not checked anything: every commit from here on is
tested on all three systems, including the ones that introduce the
platform-dependent paths above.

Jobs that depend on things this series has not built yet -- the table-building
CLI, the lint configuration, the optional extras -- are not here. They arrive
with the commits that make them possible.

No library code is touched.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

