### PR TITLE
Remove the Pages deploy from the docs workflow until an admin enables Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,19 +1,30 @@
 name: Docs
 
-# Builds the documentation on every pull request, and publishes it to GitHub
-# Pages from the default branch.
+# Builds the documentation on every pull request and on master, with -W, and
+# runs the doctest and linkcheck builders. It does not publish anywhere.
 #
-# Why Pages rather than only Read the Docs: this workflow needs no third-party
-# account and no maintainer credential, and it builds on every PR, so a broken
-# docs build is caught by the person who broke it. RTD PR previews need
-# configuration that cannot be done from a fork. .readthedocs.yaml is committed
-# too, so the existing readthedocs.io URL keeps working either way.
+# Publishing to GitHub Pages was removed on 2026-09-11: Pages is not enabled
+# on this repository, enabling it takes a repository admin (Settings -> Pages
+# -> Source: GitHub Actions), and actions/deploy-pages fails until it is, so
+# a publish job turned every push to master red for a reason nobody with
+# write access could fix. The built site is uploaded as a workflow artifact
+# instead, so a reviewer can still download and read it.
 #
-# One-time setup, needing repository admin: Settings -> Pages -> Source must
-# be set to "GitHub Actions". actions/deploy-pages cannot enable Pages itself,
-# so until that is done the `publish to Pages` job fails on every push to
-# master while the `build` job -- the one that gates pull requests -- is
-# unaffected.
+# To publish once Pages is enabled, add back a job after `build`:
+#
+#   publish:
+#     needs: build
+#     if: github.ref == 'refs/heads/master'
+#     runs-on: ubuntu-latest
+#     permissions: {pages: write, id-token: write}
+#     environment: {name: github-pages, url: ${{ steps.deployment.outputs.page_url }}}
+#     steps:
+#       - id: deployment
+#         uses: actions/deploy-pages@v4
+#
+# and switch the artifact step below to actions/upload-pages-artifact.
+# docs/proposals/repo-governance.md lists the admin setting with the others.
+# .readthedocs.yaml is committed too, so the readthedocs.io URL keeps working.
 
 on:
   push:
@@ -62,10 +73,14 @@ jobs:
       - name: Doctest the documentation
         run: python -m sphinx -b doctest docs/source docs/_build/doctest
 
-      - uses: actions/upload-pages-artifact@v3
-        if: github.ref == 'refs/heads/master'
+      # A plain artifact, not a Pages artifact: there is no Pages site to
+      # deploy to yet (see the header). Uploaded on every run, so a reviewer
+      # can download the rendered site for a pull request.
+      - uses: actions/upload-artifact@v4
         with:
+          name: docs-html
           path: docs/_build/html
+          retention-days: 14
 
   linkcheck:
     name: links
@@ -87,18 +102,3 @@ jobs:
 
       - name: linkcheck
         run: python -m sphinx -b linkcheck docs/source docs/_build/linkcheck
-
-  publish:
-    name: publish to Pages
-    needs: build
-    if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ number, a NaN, or an error -- it returns the same floats, bit for bit.
   did: for a package, `-m` requires `__main__.py`.
 - NumPy-style docstrings throughout, enforced by `ruff` (pydocstyle, numpy
   convention) and `numpydoc`, both gated in CI.
-- Documentation that builds from a checkout, published to GitHub Pages and
-  built on every pull request with `-W`, so a docstring that does not parse,
+- Documentation that builds from a checkout, built on every pull request
+  with `-W` and uploaded as an artifact, so a docstring that does not parse,
   a page missing from the toctree or an unreachable intersphinx inventory
   fails where it was introduced; the examples on the front and migration
   pages are executed by the doctest builder. New narrative pages: **How it works** (the tan-space

--- a/docs/proposals/repo-governance.md
+++ b/docs/proposals/repo-governance.md
@@ -98,9 +98,15 @@ See [pypi-name.md](pypi-name.md) for which project name this applies to.
 
 ## 5. GitHub Pages
 
-`.github/workflows/docs.yml` publishes there:
+`.github/workflows/docs.yml` builds the site on every pull request and
+uploads it as an artifact, but does not publish it: the publish job was
+removed on 2026-09-11 because Pages is not enabled and only an admin can
+enable it, so the job failed on every push to `master`. Two steps, in order:
 
 - [ ] Settings → Pages → Source: **GitHub Actions**
+- [ ] Put the `publish` job back in `docs.yml` -- the workflow header holds
+      the job, ready to paste -- and switch the artifact step to
+      `actions/upload-pages-artifact`.
 
 ## 6. Fix the repository "About"
 


### PR DESCRIPTION
Every push to `master` turns the Docs workflow red at `publish to Pages`, because GitHub Pages is not enabled on this repository (the Pages API answers 404), enabling it is an admin-only setting -- Settings → Pages → Source: **GitHub Actions** -- and `actions/deploy-pages` fails until it is made.

This removes the publish job rather than guarding it: a workflow that is red for an external reason trains people to ignore red. The `build` job (the one gating pull requests, with `-W`), the doctest run and linkcheck are unchanged, and the rendered site is now uploaded as an ordinary artifact on **every** run, so a reviewer can download it for a pull request.

The workflow header carries the removed job verbatim plus the two steps that bring publishing back once Pages is enabled; `docs/proposals/repo-governance.md` §5 lists them with the other admin-only settings; the changelog no longer says the docs are published.

Supersedes the earlier version of this PR, which skipped the deploy with a notice instead. Note for the queue: #48 (Dependabot, `deploy-pages` bump) becomes moot once this merges and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
