### PR TITLE
Add a security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Contributions are welcome. [CONTRIBUTING.md](https://github.com/josemiotto/pylev
 | [CHANGELOG.md](https://github.com/josemiotto/pylevy/blob/master/CHANGELOG.md) | What 2.0 changed, fixed and added |
 | [AGENTS.md](https://github.com/josemiotto/pylevy/blob/master/AGENTS.md) | Coding conventions, for humans and coding agents alike |
 | [CODE_OF_CONDUCT.md](https://github.com/josemiotto/pylevy/blob/master/CODE_OF_CONDUCT.md) | Community standards |
+| [SECURITY.md](https://github.com/josemiotto/pylevy/blob/master/SECURITY.md) | Supported versions, how to report a vulnerability, and what the package does with its inputs |
 | [docs/source/how_it_works.md](https://github.com/josemiotto/pylevy/blob/master/docs/source/how_it_works.md) | The grid, the interpolation, the tails, and the measured accuracy |
 | [docs/source/migration.md](https://github.com/josemiotto/pylevy/blob/master/docs/source/migration.md) | Moving from 1.x |
 | [docs/proposals/](https://github.com/josemiotto/pylevy/tree/master/docs/proposals) | Repository governance, the PyPI name, and the state of every upstream issue |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+| ------- | --------- |
+| 2.x     | Yes |
+| 1.x     | No. 1.x was never published to PyPI; move to 2.0, where every 1.x name still works |
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for a security problem.
+
+Report it privately by email to the maintainer listed under `maintainers` in
+`pyproject.toml` (José María Miotto, <josemiotto@gmail.com>). Include the
+version, what the problem is, and a minimal reproduction if you have one. You
+will get an acknowledgement within a week. A fix is released as a patch version
+and recorded in `CHANGELOG.md`.
+
+Once GitHub's private vulnerability reporting is enabled for this repository
+(an administrator setting, listed in `docs/proposals/repo-governance.md`),
+reports can also go through
+<https://github.com/josemiotto/pylevy/security/advisories/new>.
+
+## What this package does and does not do
+
+pylevy is a numerical library. It reads no network, runs no service, and
+executes no code from its inputs. The only files it reads are the lookup tables
+(`.npz` archives) and a `manifest.json`, from the installed package or from a
+directory the user chooses (`$LEVY_DATA_DIR` or the user cache); they are loaded
+with `numpy.load` **without** `allow_pickle`, so an archive cannot execute code,
+and an archive that does not parse is reported as an error naming the file.
+
+The `levy-tables` command writes tables to the user cache directory, never into
+the installation.
+
+The main risk areas are therefore malformed table files and the optional
+dependencies (pandas, torch, pydantic, NumPy, SciPy), whose own advisories are
+tracked by Dependabot.

--- a/docs/proposals/repo-governance.md
+++ b/docs/proposals/repo-governance.md
@@ -108,6 +108,14 @@ enable it, so the job failed on every push to `master`. Two steps, in order:
       the job, ready to paste -- and switch the artifact step to
       `actions/upload-pages-artifact`.
 
+## 5b. Private vulnerability reporting
+
+`SECURITY.md` routes reports to the maintainer's email until this is on:
+
+- [ ] Settings → Code security → **Private vulnerability reporting: Enable**.
+      Reports then go through the repository's Security Advisories page,
+      which `SECURITY.md` already links to.
+
 ## 6. Fix the repository "About"
 
 The sidebar currently has no description, no topics and no website, so the


### PR DESCRIPTION
Adds `SECURITY.md`: supported versions, where to report a vulnerability privately, and what the package does with its inputs -- no network, no service, no code from data; the lookup tables are loaded with `numpy.load` without `allow_pickle`, so a crafted archive cannot execute anything.

Reports go to the maintainer's published address for now: GitHub's private vulnerability reporting is an admin setting and is **off** for this repository. The policy links the advisories page for when it is enabled, and `docs/proposals/repo-governance.md` gains that setting (§5b) next to the other admin-only ones. The README's document table links the policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)