### PR TITLE
Write everything in American English, and say so in AGENTS.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
       # this workflow -- see docs/proposals/pypi-name.md: the `pylevy` versus
       # `levy-stable` decision is made by editing one line of pyproject.toml,
       # and the environment URL below has to follow it rather than go stale.
-      # Normalised as PyPI does (PEP 503), so `PyLevy` links to /project/pylevy/.
+      # Normalized as PyPI does (PEP 503), so `PyLevy` links to /project/pylevy/.
       - name: Read the distribution name
         id: name
         run: |
@@ -117,10 +117,10 @@ jobs:
           import os, re, tomllib
           with open("pyproject.toml", "rb") as handle:
               name = tomllib.load(handle)["project"]["name"]
-          normalised = re.sub(r"[-_.]+", "-", name).lower()
+          normalized = re.sub(r"[-_.]+", "-", name).lower()
           with open(os.environ["GITHUB_OUTPUT"], "a") as out:
-              out.write(f"name={normalised}\n")
-          print(f"distribution name: {name} -> {normalised}")
+              out.write(f"name={normalized}\n")
+          print(f"distribution name: {name} -> {normalized}")
           PY
 
   build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ any of them, either it was not supposed to and you have a bug, or it was and you
 owe the reviewer evidence. For the density, distribution and sampling records
 that is a comparison against `levy._build.calculate_levy` showing the new
 values are closer to the truth. For the `fit_levy` records the truth is the
-maximum of the *interpolated* likelihood — that is what the fitter optimises —
+maximum of the *interpolated* likelihood — that is what the fitter optimizes —
 so the evidence is the negative log likelihood of the old and new optima on
 the same sample and the same tables, which must not get worse; a quadrature
 score is worth reporting alongside, but its per-point error (~1e-7 relative,
@@ -24,6 +24,19 @@ change makes, so it cannot adjudicate them on its own. See
 
 Never regenerate the golden file to make a test pass. That inverts the entire
 point of having it.
+
+## Language
+
+Everything is written in English, and the English is **American**: `behavior`,
+`center`, `normalize`, `labeled`, `analyze`, `artifact`, `judgment`, `gray`,
+`license` as both noun and verb. That covers identifiers, docstrings, comments,
+documentation, commit messages, pull request text, and replies to reviews. The
+prose was written in British English first and converted in one pass; do not
+reintroduce `-ise`, `-our`, `-re` or doubled `-ll-` spellings, and if you are
+unsure of a word, a dictionary's first spelling is the American one.
+
+Two things are not English and stay as they are: proper names (Lévy, Zolotarev,
+José María Miotto) and the parametrization letters, which are notation.
 
 ## Docstrings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,13 +110,13 @@ be removed in a future major release.
 | `levy.f_bounds` | `levy.constants.f_bounds` | |
 
 Each 1.x name also remains importable from its own module without a warning, if
-you want the old behaviour and no deprecation noise.
+you want the old behavior and no deprecation noise.
 
 ### Fixed
 
 - `random(alpha=2.0, mu=..., sigma=...)` ignored `mu` and `sigma`. The Gaussian
   branch returned before reaching the line that applied them, so
-  `random(2.0, 0.0, mu=100, sigma=5)` came back centred on zero.
+  `random(2.0, 0.0, mu=100, sigma=5)` came back centered on zero.
 - `random(1.0, ±1.0)` produced **NaN for about 0.9% of draws**, and the
   surviving samples were from the wrong distribution (Kolmogorov–Smirnov against
   this package's own CDF: p = 3e-07 over 200k draws). The α = 1 nudge sat 1e-15

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,17 +10,17 @@ race, religion, or sexual identity and orientation.
 
 ## Our standards
 
-Examples of behaviour that contributes to a positive environment:
+Examples of behavior that contributes to a positive environment:
 
 - Demonstrating empathy and kindness toward other people
 - Being respectful of differing opinions, viewpoints, and experiences
 - Giving and gracefully accepting constructive feedback
-- Accepting responsibility and apologising to those affected by our mistakes
+- Accepting responsibility and apologizing to those affected by our mistakes
 - Focusing on what is best for the community
 
-Examples of unacceptable behaviour:
+Examples of unacceptable behavior:
 
-- Sexualised language or imagery, and sexual attention or advances of any kind
+- Sexualized language or imagery, and sexual attention or advances of any kind
 - Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
 - Publishing others' private information without their explicit permission
@@ -29,7 +29,7 @@ Examples of unacceptable behaviour:
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported privately to the maintainer, José María Miotto, at
 <josemiotto@gmail.com> -- the address listed under `maintainers` in
 `pyproject.toml` -- or through GitHub's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ pre-commit install
 `levy`, `neglog_levy`, `random` and `fit_levy`, stored as exact hex floats so
 that a change to them shows up as a readable diff rather than a binary blob.
 
-**It is the centre of everything.** Every pull request either leaves it
+**It is the center of everything.** Every pull request either leaves it
 untouched, or changes it deliberately and says why.
 
 If your change moves a golden record, the pull request has to answer three
@@ -100,6 +100,7 @@ test suite, and it is cheap to produce.
 
 See [AGENTS.md](AGENTS.md). Briefly:
 
+- American English everywhere: code, comments, docs, commit messages.
 - NumPy-style docstrings, enforced by `ruff` and `numpydoc`.
 - No `print()` in library code. The package has a logger.
 - Pydantic validates at the API boundary and never inside a likelihood

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📈 pylevy
 
-Lévy alpha-stable distributions for Python: density, distribution function, sampling, and maximum-likelihood fitting. Stable distributions are the heavy-tailed generalisation of the normal, and computing their density directly means a slow numerical integration for every point. pylevy interpolates a precomputed table instead, which is what makes fitting them by maximum likelihood fast enough to be practical.
+Lévy alpha-stable distributions for Python: density, distribution function, sampling, and maximum-likelihood fitting. Stable distributions are the heavy-tailed generalization of the normal, and computing their density directly means a slow numerical integration for every point. pylevy interpolates a precomputed table instead, which is what makes fitting them by maximum likelihood fast enough to be practical.
 
 [![CI](https://github.com/josemiotto/pylevy/actions/workflows/ci.yml/badge.svg)](https://github.com/josemiotto/pylevy/actions/workflows/ci.yml)
 [![Docs](https://github.com/josemiotto/pylevy/actions/workflows/docs.yml/badge.svg)](https://github.com/josemiotto/pylevy/actions/workflows/docs.yml)
@@ -35,7 +35,7 @@ pip install .
 Optional extras:
 
 ```bash
-pip install ".[pandas]"          # labelled input and output
+pip install ".[pandas]"          # labeled input and output
 pip install ".[torch]"           # differentiable backend
 pip install ".[pandas,torch]"    # both
 ```
@@ -143,7 +143,7 @@ api.fit(returns).to_series()
 
 ### 🔥 torch
 
-Hand the functions tensors and the result carries gradients, so the log likelihood can be minimised by gradient descent inside a larger model:
+Hand the functions tensors and the result carries gradients, so the log likelihood can be minimized by gradient descent inside a larger model:
 
 ```python
 import torch

--- a/docs/proposals/repo-governance.md
+++ b/docs/proposals/repo-governance.md
@@ -40,7 +40,7 @@ the fact.
 The `golden file is reproducible` check is the important one. It regenerates all
 251 golden records from scratch and compares them against the committed file, so
 a pull request cannot quietly edit the thing that pins the package's numerical
-behaviour.
+behavior.
 
 ## 2. `CODEOWNERS`
 
@@ -149,4 +149,4 @@ repository is effectively unfindable by search. Suggested:
 The defaults are fine except that a numerical package wants one more:
 
 - [ ] `numerics` — for anything where the disagreement is about a value rather
-      than about behaviour. These need a different kind of review.
+      than about behavior. These need a different kind of review.

--- a/docs/proposals/upstream-issues.md
+++ b/docs/proposals/upstream-issues.md
@@ -42,7 +42,7 @@ o en algún bug del código"* — is correct.
 > (.5 o 2 (cuando alpha=2, beta es irrelevante por que es la gaussiana))
 
 The note about `beta` being irrelevant at `alpha=2` is what identifies the
-reported `beta=1.00` as an artefact rather than a second symptom.
+reported `beta=1.00` as an artifact rather than a second symptom.
 
 ### It is not a local optimum
 
@@ -191,7 +191,7 @@ What was measured here, for the record:
   the supported range, the largest far-left-tail CDF value is 0.068 at
   `alpha=0.5, beta=−1`. No CDF above 1 remains.
 
-**Position taken here:** the maintainer's judgement stands, and this stack does
+**Position taken here:** the maintainer's judgment stands, and this stack does
 not reopen it. His stated reason — *"I guess they are unavoidable"* — is a
 hypothesis rather than a demonstration, and ragibson's technical points about
 `_get_closest_approx` (the all-NaN `argmin` returning 0, discarding 95% of the
@@ -261,6 +261,6 @@ checks in #14 and #15, which were run against `origin/master` directly. The
 per-parametrization local-optimum rates quoted in `CHANGELOG.md` come from a
 separate sweep of 12 truths × 3 seeds × 5 parametrizations.
 
-Numbers that came from a single sample are labelled as such. Where a claim is
+Numbers that came from a single sample are labeled as such. Where a claim is
 weaker than it looks — the unreproduced `alpha=2.00` mode in #20 — that is said
 in the text rather than left for a reviewer to discover.

--- a/docs/source/how_it_works.md
+++ b/docs/source/how_it_works.md
@@ -46,7 +46,7 @@ Evaluation is a Catmull-Rom cubic interpolation in all three dimensions at once:
 a weighted sum over the 4×4×4 = 64 grid nodes surrounding the query point, with
 weights that are cubic polynomials in the fractional offsets.
 
-Catmull-Rom takes its tangents from centred differences. That makes it exact for
+Catmull-Rom takes its tangents from centered differences. That makes it exact for
 quadratics — measured at 1.3e-15 on a quadratic test grid — and it is C¹ across
 cell boundaries, which matters because the fit differentiates the likelihood
 numerically.
@@ -127,7 +127,7 @@ a known open defect, listed in the changelog.
 transform, which turns two uniforms directly into a stable variate — no table
 involved, so sampling accuracy does not depend on the grid at all. The one
 approximation is the `1e-8` nudge of `alpha` near 1 described next; away from
-that neighbourhood the transform is exact up to floating-point rounding.
+that neighborhood the transform is exact up to floating-point rounding.
 
 The transform divides by `tan(pi*alpha/2)`, which has a pole at `alpha = 1`, so
 `alpha` within 1e-8 of 1 is nudged aside. The nudge used to be 1e-15, close

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,7 @@ Install
 
    pip install pylevy
 
-Optional extras: ``pylevy[pandas]`` for labelled input and output,
+Optional extras: ``pylevy[pandas]`` for labeled input and output,
 ``pylevy[torch]`` for a differentiable backend. Neither is imported unless it
 is installed and used.
 

--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -11,7 +11,7 @@ What changed is that each 1.x name now emits a `DeprecationWarning` when reached
 through `levy.`, naming its replacement. They will be removed in a future major
 release.
 
-If you want to keep the 1.x behaviour and silence the warning, import from the
+If you want to keep the 1.x behavior and silence the warning, import from the
 module the function actually lives in — `levy.distribution.levy` rather than
 `levy.levy`. No warning, same function object.
 
@@ -75,7 +75,7 @@ levy.api.pdf(x, alpha=0.4, beta=0.0)   # 2.0: ValidationError, naming alpha
 ```
 
 Along the same lines, `api.fit` rejects a keyword that is not a parameter name.
-`fit_levy` took `**kwargs` and ignored anything it did not recognise, so
+`fit_levy` took `**kwargs` and ignored anything it did not recognize, so
 `fit_levy(x, beta_=0.0)` fitted `beta` freely and said nothing.
 
 ## Fits give you an object, not a tuple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,7 @@ files = ["src/levy/api.py", "src/levy/_typing.py", "src/levy/_compat.py",
 mypy_path = "src"
 strict = true
 
-# The core is not analysed at all: its symbols become `Any` here, which is
+# The core is not analyzed at all: its symbols become `Any` here, which is
 # honest -- it has no annotations to trust. api.py is still checked strictly,
 # and converts everything it gets back to a declared type at the boundary, so
 # nothing untyped escapes into a user's type checker.

--- a/src/levy/__init__.py
+++ b/src/levy/__init__.py
@@ -234,7 +234,7 @@ def __getattr__(name):
             f'levy.{name} is deprecated since 2.0 and will be removed in a future '
             f'major release; '
             f'use {replacement}. It still lives at {module_name}.{attribute} '
-            f'if you want the 1.x behaviour without the warning.',
+            f'if you want the 1.x behavior without the warning.',
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/levy/_compat.py
+++ b/src/levy/_compat.py
@@ -123,7 +123,7 @@ def require(name: str) -> ModuleType:
         return importlib.import_module(name)
     except ImportError as error:
         # find_spec itself can raise: a finder that refuses the name (as the
-        # no-pandas tests do) or a half-initialised module both count as
+        # no-pandas tests do) or a half-initialized module both count as
         # "not there".
         try:
             installed = importlib.util.find_spec(name) is not None

--- a/src/levy/_pandas.py
+++ b/src/levy/_pandas.py
@@ -17,7 +17,7 @@
 
 Everything here is boundary work. The numerical core never sees a ``Series`` or
 a ``DataFrame``: :mod:`levy.api` unwraps to a plain array, computes, and puts
-the labels back. A density evaluated at a labelled index should come back with
+the labels back. A density evaluated at a labeled index should come back with
 that index attached -- losing it silently is how a misaligned join happens.
 
 pandas is optional and is never imported on its behalf. Detection goes through

--- a/src/levy/api.py
+++ b/src/levy/api.py
@@ -450,7 +450,7 @@ def _dispatch(
     """
     module = backends.get(backend, x, alpha, beta, mu, sigma)
     if module.name != 'numpy' and labels_of(x):
-        # A labelled result would have to be a Series or DataFrame, and that
+        # A labeled result would have to be a Series or DataFrame, and that
         # cannot carry a tensor's gradient; converting silently would drop
         # the labels the caller passed in on purpose. Say so instead.
         raise ValueError(
@@ -488,8 +488,8 @@ def _from_backend(value: Any) -> ScalarOrArray:
     Returns
     -------
     float or ndarray
-        Declared, not checked. The same localised inaccuracy as
-        :func:`_labelled`, and for the same reason: torch is an optional extra
+        Declared, not checked. The same localized inaccuracy as
+        :func:`_labeled`, and for the same reason: torch is an optional extra
         and must not become a type-checking dependency. Every call a type
         checker will normally see uses the NumPy backend and really does return
         float or ndarray.
@@ -497,7 +497,7 @@ def _from_backend(value: Any) -> ScalarOrArray:
     return cast(ScalarOrArray, value)
 
 
-def _labelled(values: Any, labels: dict[str, Any]) -> ScalarOrArray:
+def _labeled(values: Any, labels: dict[str, Any]) -> ScalarOrArray:
     """Put pandas labels back on a result, and declare the type of the outcome.
 
     Parameters
@@ -510,7 +510,7 @@ def _labelled(values: Any, labels: dict[str, Any]) -> ScalarOrArray:
     Returns
     -------
     Series or DataFrame
-        Declared as ``ScalarOrArray``, which is a deliberate and localised
+        Declared as ``ScalarOrArray``, which is a deliberate and localized
         inaccuracy: what actually comes back is a pandas object. Expressing
         that in the annotation would make pandas a type-checking dependency of
         an *optional* extra. Every non-pandas call -- which is every call a
@@ -607,7 +607,7 @@ def pdf(
         argument is a ``torch.Tensor``, and NumPy otherwise. Tensor parameters
         carry gradients through the result. pandas input is NumPy-only: its
         labels cannot be put back on a tensor, so it is refused rather than
-        silently unlabelled.
+        silently unlabeled.
 
     Returns
     -------
@@ -638,7 +638,7 @@ def pdf(
     labels = labels_of(x)
     values = _levy(np.asarray(x, dtype='d') if labels else x,
                    p.alpha, p.beta, p.mu, p.sigma, cdf=False)
-    return _labelled(values, labels) if labels else _narrow(values)
+    return _labeled(values, labels) if labels else _narrow(values)
 
 
 def cdf(
@@ -673,7 +673,7 @@ def cdf(
         argument is a ``torch.Tensor``, and NumPy otherwise. Tensor parameters
         carry gradients through the result. pandas input is NumPy-only: its
         labels cannot be put back on a tensor, so it is refused rather than
-        silently unlabelled.
+        silently unlabeled.
 
     Returns
     -------
@@ -704,7 +704,7 @@ def cdf(
     labels = labels_of(x)
     values = _levy(np.asarray(x, dtype='d') if labels else x,
                    p.alpha, p.beta, p.mu, p.sigma, cdf=True)
-    return _labelled(values, labels) if labels else _narrow(values)
+    return _labeled(values, labels) if labels else _narrow(values)
 
 
 def logpdf(
@@ -739,7 +739,7 @@ def logpdf(
         argument is a ``torch.Tensor``, and NumPy otherwise. Tensor parameters
         carry gradients through the result. pandas input is NumPy-only: its
         labels cannot be put back on a tensor, so it is refused rather than
-        silently unlabelled.
+        silently unlabeled.
 
     Returns
     -------
@@ -775,7 +775,7 @@ def logpdf(
     values = np.log(np.maximum(1e-100, _levy(
         np.asarray(x, dtype='d') if labels else x,
         p.alpha, p.beta, p.mu, p.sigma, cdf=False)))
-    return _labelled(values, labels) if labels else _narrow(values)
+    return _labeled(values, labels) if labels else _narrow(values)
 
 
 def rvs(
@@ -827,7 +827,7 @@ def rvs(
     would mean reimplementing the sampler and changing every seeded number.
 
     For the same reason a seeded call saves the global stream's state, seeds,
-    draws and restores it. That sequence is not synchronised: two threads
+    draws and restores it. That sequence is not synchronized: two threads
     making seeded calls at once can restore each other's stale state, and
     the guarantee that the surrounding stream is left where it was then
     fails. Seeded calls are single-threaded by contract; unseeded ones are
@@ -938,7 +938,7 @@ def fit(
     # a location and is unbounded, the fourth is a scale in every
     # parametrization.
     names = par_names[par]
-    # Normalised once, and the normalised values are what the fitter gets:
+    # Normalized once, and the normalized values are what the fitter gets:
     # checking float(value) and then passing `value` through would let a
     # string or a 0-d array that happens to convert reach the optimizer as
     # it came.

--- a/src/levy/backends/_numpy.py
+++ b/src/levy/backends/_numpy.py
@@ -15,7 +15,7 @@
 
 """The default backend: the package's own NumPy implementation.
 
-Deliberately nothing but a re-export. The numerical core is not reorganised to
+Deliberately nothing but a re-export. The numerical core is not reorganized to
 accommodate a second backend, so adding torch cannot have moved a NumPy number
 -- there is no shared code to have changed.
 """

--- a/src/levy/backends/_torch.py
+++ b/src/levy/backends/_torch.py
@@ -201,7 +201,7 @@ def approximate(x, alpha, beta, cdf=False):
     Parameters
     ----------
     x : Tensor
-        Standardised values outside the crossover limits.
+        Standardized values outside the crossover limits.
     alpha : Tensor
         Index of stability.
     beta : Tensor

--- a/src/levy/distribution.py
+++ b/src/levy/distribution.py
@@ -193,7 +193,7 @@ def _grid_index(value, axis, length=None):
     -----
     This truncates rather than rounding to nearest, which is almost certainly
     unintentional -- but it is deliberately left alone here, because measuring
-    it showed that switching to nearest-neighbour does *not* improve accuracy.
+    it showed that switching to nearest-neighbor does *not* improve accuracy.
 
     Over 300 sampled points where the two strategies disagree, compared against
     :func:`levy._build.quadrature.calculate_levy` ground truth:
@@ -230,7 +230,7 @@ def _approximate(x, alpha, beta, cdf=False):
     Parameters
     ----------
     x : ndarray
-        Standardised values, outside the tabulated crossover limits.
+        Standardized values, outside the tabulated crossover limits.
     alpha : float
         Index of stability.
     beta : float

--- a/src/levy/fitting.py
+++ b/src/levy/fitting.py
@@ -135,8 +135,8 @@ def _data_scaled_start(x, par, fixed):
 
     lower, upper = np.percentile(finite, [25, 75])
     spread = float(upper - lower) / _IQR_OF_STANDARD_STABLE
-    centre = float(np.median(finite))
-    if not np.isfinite(spread) or spread <= 0 or not np.isfinite(centre):
+    center = float(np.median(finite))
+    if not np.isfinite(spread) or spread <= 0 or not np.isfinite(center):
         return None
 
     # Built in parametrization 0 -- the only one in which the third and fourth
@@ -162,7 +162,7 @@ def _data_scaled_start(x, par, fixed):
             # parametrization's own conversion; elsewhere this is the identity.
             beta_0 = Parameters.convert(
                 np.array([alpha_0, fixed[names[1]], 0.0, 1.0]), par, '0')[1]
-        start = Parameters.convert(np.array([alpha_0, beta_0, centre, spread]), '0', par)
+        start = Parameters.convert(np.array([alpha_0, beta_0, center, spread]), '0', par)
     if not np.all(np.isfinite(start)):
         return None
 
@@ -213,11 +213,11 @@ def fit_levy(x, par='0', **kwargs):
 
     See Also
     --------
-    levy.distribution.neglog_levy : The objective being minimised.
+    levy.distribution.neglog_levy : The objective being minimized.
 
     Notes
     -----
-    The objective is minimised with L-BFGS-B over the free parameters only, box
+    The objective is minimized with L-BFGS-B over the free parameters only, box
     constrained by ``par_bounds``. Since the likelihood is evaluated by
     interpolating a lookup table, the optimum's last digits are not portable
     across platforms; compare fitted parameters with a tolerance, never for
@@ -250,10 +250,10 @@ def fit_levy(x, par='0', **kwargs):
     >>> bool(np.allclose(symmetric.get('0'), [1.529, 0.0, 0.028, 0.988], atol=5e-3))
     True
 
-    Fit a symmetric distribution centred on zero:
+    Fit a symmetric distribution centered on zero:
 
-    >>> centred, _ = fit_levy(x, beta=0.0, mu=0.0)
-    >>> bool(np.allclose(centred.get('0'), [1.531, 0.0, 0.0, 0.990], atol=5e-3))
+    >>> centered, _ = fit_levy(x, beta=0.0, mu=0.0)
+    >>> bool(np.allclose(centered.get('0'), [1.531, 0.0, 0.0, 0.990], atol=5e-3))
     True
 
     Fit a Cauchy distribution:
@@ -279,7 +279,7 @@ def fit_levy(x, par='0', **kwargs):
         Returns
         -------
         float
-            The objective L-BFGS-B minimises.
+            The objective L-BFGS-B minimizes.
         """
         temp.x = param
         alpha, beta, mu, sigma = temp.get('0')

--- a/src/levy/interpolation.py
+++ b/src/levy/interpolation.py
@@ -107,7 +107,7 @@ def _interpolate(points, grid, lower, upper):
 
     Notes
     -----
-    Catmull-Rom takes its tangents from centred differences, which are exact
+    Catmull-Rom takes its tangents from centered differences, which are exact
     for a quadratic but not for a cubic; it therefore reproduces quadratics to
     machine precision. Indices are clamped at the edges, so points outside
     ``[lower, upper]`` are extrapolated from the boundary cell rather than

--- a/src/levy/sampling.py
+++ b/src/levy/sampling.py
@@ -103,7 +103,7 @@ def random(alpha, beta, mu=0.0, sigma=1.0, shape=()):
     if alpha == 2:
         # mu and sigma have to be applied here too. This branch used to return
         # before reaching the `return mu + sigma * k` at the end of the
-        # function, so random(2.0, 0.0, mu=100, sigma=5) came back centred on
+        # function, so random(2.0, 0.0, mu=100, sigma=5) came back centered on
         # zero with unit-ish scale.
         return mu + sigma * np.random.standard_normal(shape) * np.sqrt(2.0)
 
@@ -123,17 +123,17 @@ def random(alpha, beta, mu=0.0, sigma=1.0, shape=()):
     pi = np.pi
 
     one_minus_alpha = 1.0 - alpha                    # was a
-    centred_uniform = uniform_angle - 0.5            # was b, in [-1/2, 1/2)
-    angle = one_minus_alpha * centred_uniform * pi   # was c
+    centered_uniform = uniform_angle - 0.5            # was b, in [-1/2, 1/2)
+    angle = one_minus_alpha * centered_uniform * pi   # was c
     skew_term = _phi(alpha, beta)                    # was e; beta*tan(pi*alpha/2)
 
     # was f
     scale_factor = (
         -(np.cos(angle) + skew_term * np.sin(angle))
-        / (np.log(uniform_for_exponential) * np.cos(centred_uniform * pi))
+        / (np.log(uniform_for_exponential) * np.cos(centered_uniform * pi))
     ) ** (one_minus_alpha / alpha)
 
-    tan_half_turn = np.tan(pi * centred_uniform / 2.0)   # was g
+    tan_half_turn = np.tan(pi * centered_uniform / 2.0)   # was g
     tan_half_angle = np.tan(angle / 2.0)                 # was h
     one_minus_tan_squared = 1.0 - tan_half_turn ** 2.0   # was i
 

--- a/src/levy/tables.py
+++ b/src/levy/tables.py
@@ -166,9 +166,9 @@ def _repair_table(key, table):
     Notes
     -----
     CDF cells outside ``[0, 1]`` (or non-finite) are replaced by linear
-    interpolation along x, which is well justified here: the neighbours of the
+    interpolation along x, which is well justified here: the neighbors of the
     known-bad cells are smooth and about 0.0128 apart. A bad cell at either
-    end of the x range has a usable neighbour on one side only and is copied
+    end of the x range has a usable neighbor on one side only and is copied
     from it instead. A repair is logged once at ``WARNING``.
     """
     if key != 'cdf':
@@ -193,7 +193,7 @@ def _repair_table(key, table):
         left, right = low - 1, high + 1
         if left < 0 and right > x_size - 1:
             # Every cell in this column is unusable, so there is no good
-            # neighbour to interpolate or copy from -- and the copy below
+            # neighbor to interpolate or copy from -- and the copy below
             # would index one past the end. Nothing can be recovered here.
             clipped += 1
             # Once per column: an unusable column is unusable in every one
@@ -211,7 +211,7 @@ def _repair_table(key, table):
             # given a value explicitly: -inf becomes 0, +inf and NaN become
             # 1. No number is *right* for a column like this -- the point is
             # that the table comes back finite, as promised, so the
-            # interpolator cannot spread NaN into every neighbour it touches.
+            # interpolator cannot spread NaN into every neighbor it touches.
             value = table[x_index, alpha_index, beta_index]
             if not np.isfinite(value):
                 value = 0.0 if value < 0.0 else 1.0
@@ -238,18 +238,18 @@ def _repair_table(key, table):
             interpolated,
         )
     if copied:
-        # Not interpolated either: one usable neighbour is not enough to
-        # interpolate between, so the cell took that neighbour's value.
+        # Not interpolated either: one usable neighbor is not enough to
+        # interpolate between, so the cell took that neighbor's value.
         logger.warning(
             'A further %d cell(s) at an end of the x range had a usable '
-            'neighbour on one side only and were copied from it.',
+            'neighbor on one side only and were copied from it.',
             copied,
         )
     if clipped:
-        # Not interpolated: these had no usable neighbour to interpolate
+        # Not interpolated: these had no usable neighbor to interpolate
         # from, so the line above must not count them as if they had.
         logger.warning(
-            'A further %d cell(s) had no usable neighbour and were only '
+            'A further %d cell(s) had no usable neighbor and were only '
             'clipped into [0, 1]; those columns are not trustworthy.',
             clipped,
         )
@@ -334,11 +334,11 @@ def _load_table(directory, key):
     Returns
     -------
     ndarray
-        The materialised array.
+        The materialized array.
 
     Notes
     -----
-    ``np.load`` returns a lazy ``NpzFile``; the array is materialised and the
+    ``np.load`` returns a lazy ``NpzFile``; the array is materialized and the
     archive closed rather than leaking the handle until garbage collection.
     """
     if key in ('lower_limit', 'upper_limit'):
@@ -363,7 +363,7 @@ def _load_array(path, directory, name):
     Returns
     -------
     ndarray
-        The materialised array.
+        The materialized array.
 
     Raises
     ------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,10 +39,10 @@ def tiny_grid():
 
     Returns ``(grid, lower, upper, f)`` where ``f(x, y, z)`` is the closed-form
     function the grid samples. Shape is (20, 8, 11) -- three orders of magnitude
-    smaller than the shipped (200, 76, 101) tables, so interpolation behaviour
+    smaller than the shipped (200, 76, 101) tables, so interpolation behavior
     can be tested without loading 12 MB from disk.
 
-    ``f`` is quadratic on purpose. Catmull-Rom takes its tangents from centred
+    ``f`` is quadratic on purpose. Catmull-Rom takes its tangents from centered
     differences, which are exact for a quadratic but not for a cubic, so it
     reproduces quadratics to machine precision (measured 1.3e-15) while a cubic
     is off by ~8.8e-04. Only the quadratic is a true oracle.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -412,7 +412,7 @@ def test_rvs_rejects_a_non_integer_shape():
         api.rvs(alpha=1.5, beta=0.0, size=2.5)
 
 
-def test_fit_passes_the_normalised_pinned_values_to_the_fitter():
+def test_fit_passes_the_normalized_pinned_values_to_the_fitter():
     """The range checks converted each value with float() and then handed
     the original on, so a 0-d array or a numeric string reached the
     optimizer as it came. The fitter now receives plain floats.

--- a/tests/test_build_cli.py
+++ b/tests/test_build_cli.py
@@ -34,7 +34,7 @@ def test_data_dir_defaults_to_the_packaged_tables(monkeypatch, tmp_path):
     assert levy.data_dir() == levy.PACKAGED_DATA
 
 
-def test_data_dir_honours_the_environment_override(monkeypatch):
+def test_data_dir_honors_the_environment_override(monkeypatch):
     monkeypatch.setenv("LEVY_DATA_DIR", "/somewhere/else")
     assert levy.data_dir() == "/somewhere/else"
 

--- a/tests/test_domain_tolerance.py
+++ b/tests/test_domain_tolerance.py
@@ -53,7 +53,7 @@ SAME_OPTIMUM_NLL = 1e-3
 def test_fitting_near_the_skewness_boundary_completes(par, alpha, beta):
     # Before the tolerance, par='B' raised
     #   ValueError: beta must be in [-1.0, 1.0], got 1.0000000000000004
-    # partway through the optimisation, losing the whole fit.
+    # partway through the optimization, losing the whole fit.
     np.random.seed(7)
     sample = random(alpha, beta, 0.0, 1.0, shape=(600,))
     parameters, nll = fit_levy(sample, par=par)

--- a/tests/test_fit_starting_scale.py
+++ b/tests/test_fit_starting_scale.py
@@ -157,9 +157,9 @@ def test_the_scaled_start_round_trips_in_every_parametrization(par, pinned):
         assert start[0] == 1.7 and start[1] == 0.6
 
     back = Parameters.convert(start, par, "0")
-    centre = np.median(data)
+    center = np.median(data)
     spread = (np.percentile(data, 75) - np.percentile(data, 25)) / 2.0
-    np.testing.assert_allclose(back[2:], [centre, spread], rtol=1e-9)
+    np.testing.assert_allclose(back[2:], [center, spread], rtol=1e-9)
 
 
 def test_unit_scale_data_starts_essentially_where_it_used_to():

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -33,7 +33,7 @@ GRID = list(itertools.product(ALPHAS, BETAS))
 def test_location_scale_identity_is_exact(alpha, beta, mu, sigma):
     """pdf(x; mu, sigma) == pdf((x-mu)/sigma; 0, 1) / sigma, bit for bit.
 
-    ``levy()`` implements location/scale by standardising ``x`` up front, so
+    ``levy()`` implements location/scale by standardizing ``x`` up front, so
     this identity is exact rather than approximate. Any future rewrite of that
     code path has to preserve it.
     """
@@ -209,7 +209,7 @@ def test_interpolator_reproduces_a_quadratic(tiny_grid):
     This is a real oracle, not a smoke test, and it runs against a (20, 8, 11)
     synthetic array -- the shipped 12 MB tables are never touched.
 
-    Quadratic, not cubic: Catmull-Rom takes its tangents from centred
+    Quadratic, not cubic: Catmull-Rom takes its tangents from centered
     differences, which are exact for a quadratic but carry an O(h^2 f''')
     error for a cubic. Measured here: 1.3e-15 for a quadratic against 8.8e-04
     for a cubic.

--- a/tests/test_known_bugs.py
+++ b/tests/test_known_bugs.py
@@ -1,6 +1,6 @@
 """Executable bug reports.
 
-Every test here asserts the behaviour pylevy *should* have and is marked
+Every test here asserts the behavior pylevy *should* have and is marked
 ``xfail(strict=True)``, so each one fails today and the suite turns red the
 moment a bug is fixed without its report being updated. That makes this file
 the checklist for the fix PRs that follow. When a bug is fixed, its test
@@ -35,7 +35,7 @@ def test_tail_crossover_is_accurate_off_the_grid():
     ``_grid_index`` snaps (alpha, beta) to one cell of the 76x101 limit tables
     and uses that cell's crossover for every value in between. The consequence
     is large: at alpha=1.410182, beta=-0.5 the selected cell has an upper
-    crossover of 71.30 while the neighbouring cell has 499.80, so at x=285.55
+    crossover of 71.30 while the neighboring cell has 499.80, so at x=285.55
     the two disagree by 64% -- one takes the power-law branch, the other the
     interpolated branch.
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,7 +1,7 @@
-"""pandas objects in, labelled pandas objects out -- and nothing in the core.
+"""pandas objects in, labeled pandas objects out -- and nothing in the core.
 
 Two claims are tested here. The first is that labels survive: a density
-evaluated at a labelled index comes back with that index, because silently
+evaluated at a labeled index comes back with that index, because silently
 dropping it is how a misaligned join happens later. The second is that the
 numbers are the same ones the array path produces, bit for bit -- the pandas
 layer converts, it does not compute.
@@ -93,9 +93,9 @@ def test_frame_values_are_bit_identical_column_by_column(frame):
 
 def test_fit_on_a_series_matches_fit_on_its_values():
     sample = api.rvs(alpha=1.5, beta=0.0, size=500, random_state=3)
-    labelled = pd.Series(sample, index=pd.date_range("2021-01-01", periods=500))
+    labeled = pd.Series(sample, index=pd.date_range("2021-01-01", periods=500))
 
-    from_series = api.fit(labelled)
+    from_series = api.fit(labeled)
     from_array = api.fit(sample)
 
     assert from_series.params == from_array.params

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -347,7 +347,7 @@ def test_alpha_1_nudge_is_well_conditioned():
     assert swing < 1e-6, f"one ULP in alpha moves _phi by {swing:.2%}"
 
 
-def test_alpha_1_is_continuous_with_its_neighbourhood():
+def test_alpha_1_is_continuous_with_its_neighborhood():
     """alpha exactly 1 must not be an outlier against alpha just either side."""
     stats = pytest.importorskip("scipy.stats")
     samples = {}
@@ -424,7 +424,7 @@ def test_repaired_column_is_monotone():
 
 
 def test_repair_survives_a_column_with_no_usable_cell():
-    """Whole column bad -> left is -1 and right is x_size, and the neighbour
+    """Whole column bad -> left is -1 and right is x_size, and the neighbor
     copy used to index one past the end of the table.
     """
     table = np.zeros((4, 2, 2), dtype="float64")
@@ -447,14 +447,14 @@ def test_repair_leaves_no_nan_in_a_column_with_no_usable_cell():
 
 
 def test_edge_cells_are_reported_as_copied_not_interpolated(caplog):
-    """A bad cell at the end of the x range has one usable neighbour, so it
+    """A bad cell at the end of the x range has one usable neighbor, so it
     is copied, not interpolated -- but it used to be counted and reported
     as interpolated along x.
     """
     import logging
 
     table = np.full((4, 2, 2), 0.5, dtype="float64")
-    table[0, 0, 0] = np.nan            # first x cell: neighbour on the right only
+    table[0, 0, 0] = np.nan            # first x cell: neighbor on the right only
     with caplog.at_level(logging.WARNING, logger="levy"):
         repaired = levy._repair_table("cdf", table)
     assert repaired[0, 0, 0] == 0.5

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -9,7 +9,7 @@ shown to agree with NumPy rather than assumed to. It is checked here at
 Gradients: ``torch.autograd.gradcheck`` compares the analytic gradient against
 finite differences in float64, for all four parameters, for pdf, cdf and the
 negative log density. Passing that is what makes "differentiable" a fact rather
-than a claim -- and the optimisation test below shows it is *useful*: gradient
+than a claim -- and the optimization test below shows it is *useful*: gradient
 descent lands on the same optimum this package's own L-BFGS-B finds.
 
 `tests/test_no_torch.py` covers the other half: an install without torch never
@@ -78,7 +78,7 @@ def test_agreement_is_far_tighter_than_the_contract(alpha, beta, mu, sigma):
     #
     # The bound is 1e-10 rather than the ~1e-16 a single operation would give:
     # the interpolation is a 64-term weighted sum, and torch and NumPy do not
-    # order or vectorise it identically. Measured worst case is 2.6e-16 on
+    # order or vectorize it identically. Measured worst case is 2.6e-16 on
     # macOS/x86 and 1.4e-12 on the Linux CI runner -- a libm difference, not a
     # divergence. 1e-10 keeps two orders of magnitude of headroom over the
     # worse of those while staying four below the contract.


### PR DESCRIPTION
The prose was written in British English -- `behaviour`, `centre`, `normalised`, `labelled`, `artefact`, `judgement` and the rest. One pass converts all of it to American English, identifiers included: the private helper `_labelled` becomes `_labeled`, the sampler's `centred_uniform` becomes `centered_uniform`, and three tests are renamed. 96 replacements across 33 files, plus `afterwards` → `afterward`.

No behavior changes. The golden check, the doctests, the Sphinx doctests and the full suite pass unchanged; ruff, numpydoc and mypy are green.

`AGENTS.md` gains a **Language** section: American English for everything written -- code, comments, docstrings, docs, commit messages, pull request text -- with the common traps listed and the two things that stay as they are (proper names, the parametrization letters). `CONTRIBUTING.md` carries the one-line version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)